### PR TITLE
Revert "Disable THP in centos images"

### DIFF
--- a/user-data-script.sh
+++ b/user-data-script.sh
@@ -97,38 +97,7 @@ fix_hostname() {
 }
 
 fix_fstab() {
-    sed -i "/dev\/xvdb/ d" /etc/fstab
-}
-
-disable_thp() {
-    local scriptname=/etc/profile.d/thp-disable.sh
-    cat > $scriptname << "EOF"
-    # only root can issue these commands
-    if [ "$(id -u)" == "0" ]; then
-      # remount /sys for writing in case it's read-only
-      # we will revert to read-only if it were the original case
-      sysRO="false"
-      if grep sysfs /proc/mounts | grep -q 'ro,'; then
-        sysRO="true"
-        mount -o rw,remount /sys
-      fi
-
-      if test -f /sys/kernel/mm/transparent_hugepage/enabled; then
-        echo never > /sys/kernel/mm/transparent_hugepage/enabled
-      fi
-      if test -f /sys/kernel/mm/transparent_hugepage/defrag; then
-        echo never > /sys/kernel/mm/transparent_hugepage/defrag
-      fi
-
-      if [ $sysRO == "true" ]; then
-        mount -o ro,remount /sys
-      fi
-
-    fi
-EOF
-
-    # apply to a current session too
-    source $scriptname
+	sed -i "/dev\/xvdb/ d" /etc/fstab
 }
 
 get_provider_from_packer() {
@@ -172,7 +141,6 @@ main() {
     pull_images
     fix_hostname
     fix_fstab
-    disable_thp
     touch /tmp/ready
     sync
 }


### PR DESCRIPTION
Reverts sequenceiq/cloudbreak-images#14

Please do not put it under /etc/profile.d. If you put it under profile.d then it becomes interactive and we would like to avoid remounting of sys/proc fs when root starts a bash shell and we also would like to avoid setting these parameters when root starts a shell.

I think the proper solution would be if the script is part on SysV init.
