### PR TITLE
download ambari 2.1 images only

### DIFF
--- a/user-data-script.sh
+++ b/user-data-script.sh
@@ -4,7 +4,7 @@
 
 [[ "$TRACE" ]] && set -x
 
-: ${IMAGES:=sequenceiq/ambari:2.0.0-consul sequenceiq/ambari-warmup:2.0.0-consul sequenceiq/ambari:2.1.0-consul sequenceiq/consul:v0.5.0-v5 postgres:9.4.1 sequenceiq/docker-consul-watch-plugn:2.0.0-consul swarm:0.3.0 sequenceiq/munchausen:0.5.3 gliderlabs/alpine:3.1 sequenceiq/registrator:v5.2 sequenceiq/cb-gateway-nginx:0.2 sequenceiq/baywatch:v0.5.3 sequenceiq/baywatch-client:v0.5.3 sequenceiq/logrotate:v0.5.1 ehazlett/cert-tool:0.0.3}
+: ${IMAGES:=sequenceiq/ambari:2.1.0-consul sequenceiq/ambari-warmup:2.1.0-consul sequenceiq/consul:v0.5.0-v5 postgres:9.4.1 sequenceiq/docker-consul-watch-plugn:2.0.0-consul swarm:0.3.0 sequenceiq/munchausen:0.5.3 gliderlabs/alpine:3.1 sequenceiq/registrator:v5.2 sequenceiq/cb-gateway-nginx:0.2 sequenceiq/baywatch:v0.5.3 sequenceiq/baywatch-client:v0.5.3 sequenceiq/logrotate:v0.5.1 ehazlett/cert-tool:0.0.3}
 : ${DEBUG:=1}
 
 debug() {
@@ -77,8 +77,6 @@ pull_images() {
   for i in ${IMAGES}; do
     docker pull ${i}
   done
-  # Until the HDP is not released does not makes sense to Warmup
-  docker tag sequenceiq/ambari:2.1.0-consul sequenceiq/ambari-warmup:2.1.0-consul
 }
 
 install_scripts() {


### PR DESCRIPTION
the warmup image is not really warmed up as it does not contain any pre-downloaded package, but needed because of zeppelin, so it's size is about ~100 mb bigger than the base

![](http://i.imgur.com/3EwbtrB.gif)
