### PR TITLE
CLOUD-44982 Replace cloud-init dependency to cloud-final

### DIFF
--- a/shared/docker/docker.service
+++ b/shared/docker/docker.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network.target docker.socket cloud-init.service
+After=network.target docker.socket cloud-final.service
 Requires=docker.socket
-Wants=cloud-init.service
+Wants=cloud-final.service
 
 [Service]
 ExecStart=/usr/bin/docker -d -H fd:// -H tcp://0.0.0.0:2376 --selinux-enabled=false --storage-driver=devicemapper --storage-opt=dm.basesize=30G


### PR DESCRIPTION
@akanto last test result was:
# systemctl status cloud-final

   Active: active (exited) since Fri 2015-09-25 06:57:35 UTC; 2min 5s ago
# systemctl status docker

   Active: active (running) since Fri 2015-09-25 06:57:35 UTC; 2min 8s ago
