### PR TITLE
update to Ambari 2.1.2

### DIFF
--- a/packer-azure.json
+++ b/packer-azure.json
@@ -18,7 +18,7 @@
 			"os_image_label"		: "OpenLogic 7.1",
 			"location"			: "West Europe",
 			"instance_size"			: "Large",
-			"user_image_label"		: "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+			"user_image_label"		: "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
 		}
 	],
   "provisioners": [{

--- a/packer-ec2.json
+++ b/packer-ec2.json
@@ -44,7 +44,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   },
   {
     "name": "ap-northeast-1",
@@ -73,7 +73,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   },
   {
     "name": "eu-west-1",
@@ -102,7 +102,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   },
   {
     "name": "eu-central-1",
@@ -131,7 +131,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   },
   {
     "name": "us-east-1",
@@ -160,7 +160,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   },
   {
     "name": "us-west-1",
@@ -189,7 +189,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   },
   {
     "name": "us-west-2",
@@ -218,7 +218,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   },
   {
     "name": "ap-southeast-2",
@@ -247,7 +247,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   },
   {
     "name": "ap-southeast-1",
@@ -276,7 +276,7 @@
       "version": "{{user `version`}}"
     },
     "ami_groups" :"all",
-    "ami_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
+    "ami_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{user `namesuffix`}}"
   }],
   "provisioners": [{
     "type": "file",

--- a/packer-gce.json
+++ b/packer-gce.json
@@ -3,7 +3,7 @@
     "namesuffix": "{{env `IMAGE_NAME_SUFFIX`}}",
     "version": "0.9",
     "account_file": "{{env `GCE_ACCOUNT_FILE`}}",
-    "image_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}{{env `IMAGE_NAME_SUFFIX`}}"
+    "image_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}{{env `IMAGE_NAME_SUFFIX`}}"
   },
   "builders":[{
     "disk_size": "40",

--- a/packer-openstack.json
+++ b/packer-openstack.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "os_auth_url": "",
-    "os_image_name": "cb-centos71-amb210-{{ isotime \"2006-01-02\" }}",
+    "os_image_name": "cb-centos71-amb212-{{ isotime \"2006-01-02\" }}",
     "os_username": "",
     "os_password": "",
     "os_tenant_name": ""

--- a/user-data-script.sh
+++ b/user-data-script.sh
@@ -4,7 +4,7 @@
 
 [[ "$TRACE" ]] && set -x
 
-: ${IMAGES:=sequenceiq/ambari:2.1.0-consul sequenceiq/ambari-warmup:2.1.0-consul sequenceiq/consul:v0.5.0-v5 postgres:9.4.1 sequenceiq/docker-consul-watch-plugn:2.0.2-consul swarm:0.4.0 sequenceiq/munchausen:0.5.5 gliderlabs/alpine:3.1 sequenceiq/registrator:v5.2 sequenceiq/cb-gateway-nginx:0.3 sequenceiq/baywatch:v0.5.3 sequenceiq/baywatch-client:v1.0.0 sequenceiq/logrotate:v0.5.1 sequenceiq/kerberos:2.1.0-consul ehazlett/cert-tool:0.0.3}
+: ${IMAGES:=sequenceiq/ambari:2.1.2-v1 sequenceiq/consul:v0.5.0-v5 postgres:9.4.1 sequenceiq/docker-consul-watch-plugn:2.0.2-consul swarm:0.4.0 sequenceiq/munchausen:0.5.5 gliderlabs/alpine:3.1 sequenceiq/registrator:v5.2 sequenceiq/cb-gateway-nginx:0.3 sequenceiq/baywatch:v0.5.3 sequenceiq/baywatch-client:v1.0.0 sequenceiq/logrotate:v0.5.1 sequenceiq/kerberos:2.1.0-consul ehazlett/cert-tool:0.0.3}
 : ${DEBUG:=1}
 
 debug() {


### PR DESCRIPTION
@akanto 
- Update to 2.1.2
- Ambari warmup image removed
- Increased PermGen space for Ambari
- Replaced ambari-view JAR to support WASB
