### PR TITLE
cloud-init not needed on azure

### DIFF
--- a/shared/usr/bin/user-data-helper.sh
+++ b/shared/usr/bin/user-data-helper.sh
@@ -38,10 +38,10 @@ extend_rootfs() {
 }
 
 relocate_docker() {
-  if [[ $CLOUD_PLATFORM == AZURE* ]] && [ -n "$(mount | grep ' /mnt ')" ]; then
+  if [[ $CLOUD_PLATFORM == AZURE* ]] && [ -n "$(mount | grep ' /mnt/resource ')" ]; then
       touch /var/docker-relocate
-      mv /var/lib/docker /mnt/docker
-      ln -s /mnt/docker /var/lib/docker
+      mv /var/lib/docker /mnt/resource/docker
+      ln -s /mnt/resource/docker /var/lib/docker
   fi
 }
 

--- a/user-data-script.sh
+++ b/user-data-script.sh
@@ -46,6 +46,8 @@ modify_waagent() {
   if [ -f /etc/waagent.conf ]; then
     cp /etc/waagent.conf /etc/waagent.conf.bak
     sed -i 's/Provisioning.SshHostKeyPairType.*/Provisioning.SshHostKeyPairType=ecdsa/' /etc/waagent.conf
+    sed -i 's/Provisioning.DecodeCustomData.*/Provisioning.DecodeCustomData=y/' /etc/waagent.conf
+    sed -i 's/Provisioning.ExecuteCustomData.*/Provisioning.ExecuteCustomData=y/' /etc/waagent.conf
     diff /etc/waagent.conf /etc/waagent.conf.bak || :
   fi
 }
@@ -64,7 +66,7 @@ install_utils() {
 
   yum -y install unzip curl git wget bind-utils ntp tmux bash-completion
 
-  if [ "azure" == $provider ] || [ "ec2" == $provider ]; then
+  if [ "ec2" == $provider ]; then
     yum install -y cloud-init
 fi
 


### PR DESCRIPTION
@keyki 
- cloud-init is not needed on Azure, waagent is capable of running the provisioning script, so cloud-init and waagent won't interfere with each other
- local SSD is mounted on /mnt/resource instead of /mnt on the new image (needs testing with multiple vm types)
