### PR TITLE
Use latest amz-linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,9 @@ build-in-docker:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /usr/local/bin/docker:/usr/local/bin/docker \
 		images:build make build-aws
+
+list-amz-linux-amis:
+	aws ec2 describe-images --filter Name=owner-alias,Values=amazon --query 'reverse(sort_by(Images[?contains(ImageLocation,`amazon/amzn-ami-hvm`) && ends_with(ImageLocation, `gp2`)].{loc:ImageLocation,id:ImageId}, &loc))' --out table --region us-west-2
+
+latest-amz-linux-ami:
+	aws ec2 describe-images --filter Name=owner-alias,Values=amazon --query 'reverse(sort_by(Images[?contains(ImageLocation,`amazon/amzn-ami-hvm`) && ends_with(ImageLocation, `gp2`)].{loc:ImageLocation,id:ImageId}, &loc))[0].id' --out text --region us-west-2

--- a/packer.json
+++ b/packer.json
@@ -24,7 +24,7 @@
     "image_name": "cb-{{ isotime \"2006-01-02-03-04\" }}{{env `IMAGE_NAME_SUFFIX`}}",
 
     "instance_type": "m3.medium",
-    "ami-us-west-2": "ami-c229c0a2"
+    "ami-us-west-2": "ami-d0f506b0"
   },
   "builders":[
   {


### PR DESCRIPTION
Helper make tags are added to check latest ami:

show latest HVM/gp2 amazon linux ami:

```
make latest-amz-linux-ami 
```

for reference you can list all by:

```
make list-amz-linux-amis
```
