### PR TITLE
CLOUD-57217 fix for incorrect log dir

### DIFF
--- a/shared/pre/etc/systemd/system/salt-bootstrap
+++ b/shared/pre/etc/systemd/system/salt-bootstrap
@@ -39,7 +39,7 @@ EOF
 fi
 
 NAME=`basename $0`
-LOG_DIR="/var/log/saltboot.log"
+LOG_DIR="/var/log"
 SALTBOOT_PORT=7070
 
 get_pid() {


### PR DESCRIPTION
@keyki this is why /var/log/saltboot.log is a directory on AMZ
