### PR TITLE
Fix requests module import problems on centos6

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         :box => "centos/6",
         :ram => 1536,
         :cpu => 2,
-        :salt_repo => "salt-repo-2016.11-6.el.repo",
+        :salt_repo => "salt-repo-2017.7.el.repo",
         :optional_states => "oracle-java",
         :oracle_jdk8_url_rpm => "http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/jdk-8u151-linux-x64.rpm"
 =begin

--- a/repos/salt-repo-2016.11-6.el.repo
+++ b/repos/salt-repo-2016.11-6.el.repo
@@ -1,8 +1,0 @@
-[saltstack-repo]
-name=SaltStack 2016.11.6 Release Channel for RHEL/CentOS $releasever
-baseurl=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/archive/2016.11.6
-failovermethod=priority
-priority=10
-enabled=1
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/saltstack-gpg-key.pub

--- a/repos/salt-repo-2017.7.el.repo
+++ b/repos/salt-repo-2017.7.el.repo
@@ -1,0 +1,8 @@
+[saltstack-repo]
+name=SaltStack 2017.7 Release Channel for RHEL/CentOS $releasever
+baseurl=https://repo.saltstack.com/yum/redhat/$releasever/$basearch/2017.7/
+failovermethod=priority
+priority=10
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/saltstack-gpg-key.pub

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -16,4 +16,4 @@ base:
     - monitoring
     - dhcp
     - performance
-{   - custom
+    - custom


### PR DESCRIPTION
New repo contains newer python urllib3 which contains the backported ssl_match_hostname module.