### PR TITLE
Manage unbound with resolvconf on Debian/Ubuntu

### DIFF
--- a/saltstack/base/salt/resolvconf/etc/resolvconf/update.d/unbound
+++ b/saltstack/base/salt/resolvconf/etc/resolvconf/update.d/unbound
@@ -1,0 +1,35 @@
+#!/bin/sh -e
+
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+if [ ! -x /usr/sbin/unbound ]; then
+    exit 0
+fi
+
+if [ ! -x /lib/resolvconf/list-records ]; then
+    exit 1
+fi
+
+RESOLVCONF_FILES="$(/lib/resolvconf/list-records)"
+
+if [ -n "$RESOLVCONF_FILES" ]; then
+    NS_IPS="$(sed -rne 's/^[[:space:]]*nameserver[[:space:]]+//p' $RESOLVCONF_FILES \
+        | egrep -v '^(127\.|::1)' | sort -u)"
+else
+    NS_IPS=""
+fi
+
+if [ -n "$NS_IPS" ]; then
+    :> /etc/unbound/conf.d/99-resolvconf.conf
+    for zone in . in-addr.arpa.; do
+        echo "forward-zone:"     >>/etc/unbound/conf.d/99-resolvconf.conf
+        echo "  name: \"$zone\"" >>/etc/unbound/conf.d/99-resolvconf.conf
+        for nameserver in $NS_IPS; do
+            echo "  forward-addr: ${nameserver}" >>/etc/unbound/conf.d/99-resolvconf.conf
+        done
+    done
+else
+    rm -f /etc/unbound/conf.d/99-resolvconf.conf 1>/dev/null 2>&1 || true
+fi
+
+pkill -SIGHUP unbound

--- a/saltstack/base/salt/resolvconf/etc/systemd/system/resolvconf.service
+++ b/saltstack/base/salt/resolvconf/etc/systemd/system/resolvconf.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Nameserver information manager
+Documentation=man:resolvconf(8)
+DefaultDependencies=no
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+RemainAfterExit=yes
+ExecStartPre=/bin/mkdir -p /run/resolvconf/interface
+ExecStartPre=/bin/sh -c 'echo "nameserver 127.0.0.1" > /run/resolvconf/interface/lo.unbound'
+ExecStartPre=/bin/touch /run/resolvconf/postponed-update
+ExecStart=/sbin/resolvconf --enable-updates
+ExecStop=/sbin/resolvconf --disable-updates
+
+[Install]
+WantedBy=sysinit.target

--- a/saltstack/base/salt/resolvconf/init.sls
+++ b/saltstack/base/salt/resolvconf/init.sls
@@ -1,0 +1,20 @@
+{% if grains['os'] == 'Debian' %}
+install_resolvconf_package:
+  pkg.installed:
+    - pkgs:
+      - resolvconf
+{% endif %}
+
+{% if grains['init'] == 'systemd' %}
+set_resolvconf_unbound:
+  file.managed:
+    - name: /etc/resolvconf/update.d/unbound
+    - source: salt://{{ slspath }}/etc/resolvconf/update.d/unbound
+    - skip_verify: True
+    - mode: 755
+
+resolvconf_service:
+  file.managed:
+    - name: /etc/systemd/system/resolvconf.service
+    - source: salt://{{ slspath }}/etc/systemd/system/resolvconf.service
+{% endif %}

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -11,6 +11,10 @@ base:
     - postgresql
     - unbound
     - monitoring
+{% if grains['os_family'] == 'Debian' %}
+    - resolvconf
+{% else %}
     - dhcp
+{% endif %}
     - performance
     - custom


### PR DESCRIPTION
On Ubuntu16 resolvconf package manages /etc/resolv.conf, therefore dhcp-client generated unbound configuration is not accessible. Ambari-agent connects ambari-server by domain name which fails since name resolution is misconfigured.