### PR TITLE
Fix how to locate postgres.conf on docker containers

### DIFF
--- a/saltstack/base/salt/postgresql/scripts/conf_pgsql_listen_address.sh
+++ b/saltstack/base/salt/postgresql/scripts/conf_pgsql_listen_address.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-CONFIG_FILE=$(psql -c "show config_file;" -t | xargs)
-echo "Config file: $CONFIG_FILE"
+if grep -q :/docker/ /proc/1/cgroup; then
+    # inside docker container
+    CONFIG_FILE=$(find /etc/postgresql /var/lib/pgsql -type f -name postgresql.conf 2>/dev/null | head -1)
+else
+    CONFIG_FILE=$(psql -c "show config_file;" -t | xargs)
+    echo "Config file: $CONFIG_FILE"
+fi
 
 set -e
 if grep -qR "^listen_addresses =" $CONFIG_FILE; then


### PR DESCRIPTION
During 'docker build' a fake systemd exists and services are not started.
That is why we are not able to query postgresql to the location of its
configuration file.