### PR TITLE
Fix docker build for debian9 and ubuntu16

### DIFF
--- a/docker/common/start-systemd.sh
+++ b/docker/common/start-systemd.sh
@@ -56,10 +56,4 @@ if [ -f "/etc/cloudbreak-config.props" ]; then
     /usr/bin/cb-init.sh
 fi
 
-###
-# Fix ssh login problem.
-# "System is booting up. See pam_nologin(8)"
-###
-sed -i '/pam_nologin/s/\(.*\)/#\1/g' /etc/pam.d/sshd
-
 exec /bin/systemd --system

--- a/docker/common/start-systemd.sh
+++ b/docker/common/start-systemd.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+###
+# CloudBreak uses unbound as a caching name server. Docker bind-mounts
+# /etc/resolv.conf file that is why resolvconf package cannot be used
+# as it tries to replace it with a symlink. A workaround is to tranform
+# resolv.conf into unbound configuration and set unbound as a nameserver.
+###
+echo 'forward-zone:' >/etc/unbound/conf.d/99-default.conf
+echo '  name: "."' >>/etc/unbound/conf.d/99-default.conf
+for nameserver in $(awk '/^nameserver/{print $2}' /etc/resolv.conf); do
+  echo "  forward-addr: ${nameserver}" >>/etc/unbound/conf.d/99-default.conf
+done
+
+echo 'forward-zone:' >>/etc/unbound/conf.d/99-default.conf
+echo '  name: "in-addr.arpa."' >>/etc/unbound/conf.d/99-default.conf
+for nameserver in $(awk '/^nameserver/{print $2}' /etc/resolv.conf); do
+  echo "  forward-addr: ${nameserver}" >>/etc/unbound/conf.d/99-default.conf
+done
+
+echo "nameserver 127.0.0.1" >/etc/resolv.conf
+
+###
+# Set container limits for Ambari
+###
+if [ -f container_limits ]; then
+    cpu=$(awk -F= '/vcores=/{print $2}' container_limits)
+    memory=$(awk -F= '/memory=/{print $2*1024}' container_limits)
+    mkdir -p /etc/resource_overrides
+    cat >/etc/resource_overrides/ycloud.json <<EOF
+{
+    "processorcount": "$cpu",
+    "physicalprocessorcount": "$cpu",
+    "memorysize": "$memory",
+    "memoryfree": "$memory",
+    "memorytotal": "$memory"
+}
+EOF
+fi
+
+###
+# CloudBreak provides a configuration file called cloudbreak-config.props
+# when starting a deployment on Yarn. This is the method how it emulates
+# user-data functionality of cloud-init.
+###
+if [ -f "/etc/cloudbreak-config.props" ]; then
+    . /etc/cloudbreak-config.props
+
+    mkdir -p /home/${sshUser}/.ssh
+    chmod 700 /home/${sshUser}/.ssh
+    echo "${sshPubKey}" >>/home/${sshUser}/.ssh/authorized_keys
+    chown -R ${sshUser}:${sshUser} /home/${sshUser}
+
+    echo "${userData}" | base64 -d >/usr/bin/cb-init.sh
+    chmod +x /usr/bin/cb-init.sh
+    /usr/bin/cb-init.sh
+fi
+
+###
+# Fix ssh login problem.
+# "System is booting up. See pam_nologin(8)"
+###
+sed -i '/pam_nologin/s/\(.*\)/#\1/g' /etc/pam.d/sshd
+
+exec /bin/systemd --system

--- a/docker/common/systemd-fix.service
+++ b/docker/common/systemd-fix.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Workaround startup issue if systemd started as non pid-1
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mkdir -p /run/systemd/system/
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docker/debian9/Dockerfile
+++ b/docker/debian9/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 COPY /docker/common/src /src
 
-RUN gcc -Wall -DCOMMAND='"/bin/systemd"' -o /systemd-wrapper /src/start-setuid.c
+RUN gcc -Wall -DCOMMAND='"/bootstrap/start-systemd.sh"' -o /systemd-wrapper /src/start-setuid.c
 
 #####
 
@@ -23,6 +23,7 @@ ENV PS1 "[\u@cloudbreak \W]\$ "
 # Set default shell to bash
 SHELL ["/bin/bash", "-c"]
 
+# Install packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -56,12 +57,19 @@ RUN dpkg-divert --add --rename /bin/systemctl && \
 COPY /saltstack/ /tmp/saltstack/
 COPY /repos/     /tmp/repos/
 COPY /scripts/   /tmp/scripts/
-
 COPY docker/common/_grains/ /tmp/saltstack/base/salt/_grains/
 COPY docker/common/_grains/ /tmp/saltstack/hortonworks/salt/_grains/
 RUN printf '\n\nproviders:\n  service: systemd\n' >>/tmp/saltstack/config/minion
-RUN /tmp/scripts/salt-install.sh ubuntu salt-repo-ubuntu16.list
+RUN /tmp/scripts/salt-install.sh debian salt-repo-debian9.list
 RUN /tmp/scripts/salt-setup.sh hortonworks
+
+# Fix SaltStack init autodiscovery
+RUN printf '\n\nproviders:\n  service: systemd\n' >>/etc/salt/minion
+COPY docker/common/_grains/ /srv/salt/_grains/
+
+# Fix startup problems for Type=notify systemd services
+COPY docker/common/systemd-fix.service /etc/systemd/system/
+RUN systemctl enable systemd-fix
 
 # Undo systemctl replacement
 RUN rm /bin/systemctl && \
@@ -71,12 +79,14 @@ RUN rm /bin/systemctl && \
 RUN groupmod -g 99 nogroup && \
     usermod -u 99 -g nogroup nobody
 
-COPY --from=builder /systemd-wrapper /systemd-wrapper
-RUN chown root:nogroup /systemd-wrapper && \
-    chmod 4750 /systemd-wrapper
+# CloudBreak expects /bootstrap/start-systemd as an entrypoint
+COPY docker/common/start-systemd.sh /bootstrap/start-systemd.sh
+COPY --from=builder /systemd-wrapper /bootstrap/start-systemd
+RUN chown root:nogroup /bootstrap/start-systemd && \
+    chmod 4750 /bootstrap/start-systemd
 
 RUN systemctl enable ssh cron
 
 EXPOSE 22
 
-CMD ["/systemd-wrapper", "--system"]
+CMD ["/bootstrap/start-systemd"]

--- a/docker/debian9/Dockerfile
+++ b/docker/debian9/Dockerfile
@@ -75,6 +75,10 @@ RUN systemctl enable systemd-fix
 RUN rm /bin/systemctl && \
     dpkg-divert --remove --rename /bin/systemctl
 
+# Fix ssh login and salt-api auth problems
+RUN sed -i '/pam_nologin/s/\(.*\)/#\1/g' /etc/pam.d/sshd
+RUN sed -i '/pam_nologin/s/\(.*\)/#\1/g' /etc/pam.d/login
+
 # Ycloud integration
 RUN groupmod -g 99 nogroup && \
     usermod -u 99 -g nogroup nobody

--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -75,6 +75,10 @@ RUN systemctl enable systemd-fix
 RUN rm /bin/systemctl && \
     dpkg-divert --remove --rename /bin/systemctl
 
+# Fix ssh login and salt-api auth problems
+RUN sed -i '/pam_nologin/s/\(.*\)/#\1/g' /etc/pam.d/sshd
+RUN sed -i '/pam_nologin/s/\(.*\)/#\1/g' /etc/pam.d/login
+
 # Ycloud integration
 RUN groupmod -g 99 nogroup && \
     usermod -u 99 -g nogroup nobody

--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 COPY /docker/common/src /src
 
-RUN gcc -Wall -DCOMMAND='"/bin/systemd"' -o /systemd-wrapper /src/start-setuid.c
+RUN gcc -Wall -DCOMMAND='"/bootstrap/start-systemd.sh"' -o /systemd-wrapper /src/start-setuid.c
 
 #####
 
@@ -23,6 +23,7 @@ ENV PS1 "[\u@cloudbreak \W]\$ "
 # Set default shell to bash
 SHELL ["/bin/bash", "-c"]
 
+# Install packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -56,12 +57,19 @@ RUN dpkg-divert --add --rename /bin/systemctl && \
 COPY /saltstack/ /tmp/saltstack/
 COPY /repos/     /tmp/repos/
 COPY /scripts/   /tmp/scripts/
-
 COPY docker/common/_grains/ /tmp/saltstack/base/salt/_grains/
 COPY docker/common/_grains/ /tmp/saltstack/hortonworks/salt/_grains/
 RUN printf '\n\nproviders:\n  service: systemd\n' >>/tmp/saltstack/config/minion
 RUN /tmp/scripts/salt-install.sh ubuntu salt-repo-ubuntu16.list
 RUN /tmp/scripts/salt-setup.sh hortonworks
+
+# Fix SaltStack init autodiscovery
+RUN printf '\n\nproviders:\n  service: systemd\n' >>/etc/salt/minion
+COPY docker/common/_grains/ /srv/salt/_grains/
+
+# Fix startup problems for Type=notify systemd services
+COPY docker/common/systemd-fix.service /etc/systemd/system/
+RUN systemctl enable systemd-fix
 
 # Undo systemctl replacement
 RUN rm /bin/systemctl && \
@@ -71,12 +79,14 @@ RUN rm /bin/systemctl && \
 RUN groupmod -g 99 nogroup && \
     usermod -u 99 -g nogroup nobody
 
-COPY --from=builder /systemd-wrapper /systemd-wrapper
-RUN chown root:nogroup /systemd-wrapper && \
-    chmod 4750 /systemd-wrapper
+# CloudBreak expects /bootstrap/start-systemd as an entrypoint
+COPY docker/common/start-systemd.sh /bootstrap/start-systemd.sh
+COPY --from=builder /systemd-wrapper /bootstrap/start-systemd
+RUN chown root:nogroup /bootstrap/start-systemd && \
+    chmod 4750 /bootstrap/start-systemd
 
 RUN systemctl enable ssh cron
 
 EXPOSE 22
 
-CMD ["/systemd-wrapper", "--system"]
+CMD ["/bootstrap/start-systemd"]

--- a/saltstack/base/salt/cloud-init/init.sls
+++ b/saltstack/base/salt/cloud-init/init.sls
@@ -2,7 +2,7 @@ install_cloud-init_packages:
   pkg.installed:
     - pkgs:
       - cloud-init
-    {% if grains['os_family'] == 'Debian' and  grains['osmajorrelease'] | int == 7 %}
+    {% if grains['os'] == 'Debian' and  grains['osmajorrelease'] | int == 7 %}
     - fromrepo: wheezy-backports
     {% endif %}
 

--- a/saltstack/base/salt/prerequisites/repository.sls
+++ b/saltstack/base/salt/prerequisites/repository.sls
@@ -13,7 +13,7 @@
         - epel-release
 
   {% endif %}
-{% elif grains['os_family'] == 'Debian' and grains['osmajorrelease'] | int == 7 %}
+{% elif grains['os'] == 'Debian' and grains['osmajorrelease'] | int == 7 %}
 
 install_wheezy_backports_repository:
   pkgrepo.managed:

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -9,12 +9,13 @@ base:
     - salt-bootstrap
     - salt
     - postgresql
-    - unbound
     - monitoring
+{% if pillar['subtype'] != 'Docker' %}
 {% if grains['os_family'] == 'Debian' %}
     - resolvconf
 {% else %}
     - dhcp
+{% endif %}
 {% endif %}
     - performance
     - custom

--- a/saltstack/base/salt/unbound/init.sls
+++ b/saltstack/base/salt/unbound/init.sls
@@ -29,7 +29,7 @@ install_unbound_server:
   pkg.installed:
     {% if grains['os'] == 'Amazon' %}
     - fromrepo: centos-os
-    {% elif grains['os_family'] == 'Debian' and  grains['osmajorrelease'] | int == 7 %}
+    {% elif grains['os'] == 'Debian' and  grains['osmajorrelease'] | int == 7 %}
     - fromrepo: wheezy-backports
     {% endif %}
     {% if grains['os_family'] == 'Suse' %}

--- a/saltstack/final/salt/cleanup/salt.sls
+++ b/saltstack/final/salt/cleanup/salt.sls
@@ -12,3 +12,6 @@
 
 /srv/pillar:
   file.absent
+
+/var/cache/salt/minion:
+  file.absent


### PR DESCRIPTION
* Redirect all name resolution requests to locally configured unbound
  daemon and set up nameservers in its configuration
* SSH login problem fix for "System is booting up. See pam_nologin(8)"
  messages
* Parameter handling (user-data) through /etc/cloudbreak-config.props
* Mofidy CMD to /bootstrap/start-systemd as it is hardwired into
  CloudBreak
* Create /run/systemd/system directory runtime because Type=notify
  services did not work when it was missing
* Clear /var/cache/salt/minion directory at the end of image creation
* Fix salt-api authentication problem when running in a container

Closes-Bug: SUST-618, SUST-619