### PR TITLE
Pkgversionfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SLES_REGISTRATION_CODE ?= ""
 # DO NOT EDIT BELOW THIS LINE #
 ###############################
 
-PACKAGE_VERSIONS ?= "python"
+PACKAGE_VERSIONS ?= ""
 HDP_VERSION_SHORT=hdp-$(shell echo $(HDP_VERSION) | tr -d . | cut -c1-2 )
 IMAGE_NAME ?= $(BASE_NAME)-$(HDP_VERSION_SHORT)-$(shell date +%y%m%d%H%M)$(IMAGE_NAME_SUFFIX)
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SLES_REGISTRATION_CODE ?= ""
 # DO NOT EDIT BELOW THIS LINE #
 ###############################
 
-PACKAGE_VERSIONS ?= "salt python kernel"
+PACKAGE_VERSIONS ?= "python"
 HDP_VERSION_SHORT=hdp-$(shell echo $(HDP_VERSION) | tr -d . | cut -c1-2 )
 IMAGE_NAME ?= $(BASE_NAME)-$(HDP_VERSION_SHORT)-$(shell date +%y%m%d%H%M)$(IMAGE_NAME_SUFFIX)
 

--- a/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-#Determine salt-bootstrap version
+set -x
+
 SALT_BOOTSTRAP_VERSION=$(salt-bootstrap --version | awk '{print $2}')
+KERNEL_VERSION=$(salt-call --local grains.get kernelrelease --out json | jq -r .local)
+SALT_VERSION=$(salt-call --local grains.get saltversion --out json | jq -r .local)
 
 #Determine other package versions
 cat  > /tmp/package-versions.json <<EOF
@@ -10,7 +13,9 @@ $(for package in "$@"
 do
     echo "  \"$package\" : \"$(salt-call --local pkg.version $package --out json | jq -r .local)\"",
 done)
-  "salt-bootstrap" : "$SALT_BOOTSTRAP_VERSION"
+  "salt-bootstrap" : "$SALT_BOOTSTRAP_VERSION",
+  "kernel" : "$KERNEL_VERSION",
+  "salt" : "$SALT_VERSION"
 }
 EOF
 chmod 744 /tmp/package-versions.json


### PR DESCRIPTION
For now I have hard coded salt-bootstrap and salt version to be part of the json and removed python and kernel since it does not work on some distributions. Package names are varying on distros
python -> python27
kernel -> linux-images etc..
For now we're not including this information in the catalog
Also changed the json construction to be done with jq