### PR TITLE
BUG-115846 - Generalize the install of MPacks

### DIFF
--- a/saltstack/hortonworks/salt/pre-warm/tmp/install_hdp.sh
+++ b/saltstack/hortonworks/salt/pre-warm/tmp/install_hdp.sh
@@ -200,9 +200,7 @@ main() {
       download_vdf
     fi
     install_hdp_without_ambari
-    if [[ "$STACK_TYPE" == "HDF" ]]; then
-      install_mpacks
-    fi
+    install_mpacks
   fi
 #  set +x
 }


### PR DESCRIPTION
This is needed to be able to install MPacks like DAS on demand.