### PR TITLE
Ansible Playbooks & Puppet Modules Integration

### DIFF
--- a/saltstack/base/salt/custom/usr/local/bin/custom-ansible.sh
+++ b/saltstack/base/salt/custom/usr/local/bin/custom-ansible.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Install Ansible and execute Ansible Playbooks on local machine using RHEL 7.x
+# Note: Process runs as root user
+
+# Install Ansible to allow access to "ansible-playbook" command
+yum -y install ansible
+
+# Pull Ansible Playbooks from Git
+mkdir /tmp/ansible-playbooks
+git clone https://github.com/gitowner/ansible-playbooks.git /tmp/ansible-playbooks
+
+# Create Ansible Inventory file that evaluates all in Playbook to localhost.
+# Note: Any variables needed by script go on end of line.
+cat <<EOF > /tmp/ansible-local-inventory
+  localhost ansible_connection=local var1="Value1"
+EOF
+
+# Execute Ansible Playbook
+ansible-playbook --inventory-file=/tmp/ansible-local-inventory /tmp/ansible-playbooks/whoami/site.yml
+
+# Cleanup
+rm -rf /tmp/ansible-playbooks
+rm -rf /tmp/ansible-local-inventory
+

--- a/saltstack/base/salt/custom/usr/local/bin/custom-puppet.sh
+++ b/saltstack/base/salt/custom/usr/local/bin/custom-puppet.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Install Puppet Agent and execute Puppet modules on local machine running RHEL 7.x
+# Note: Process runs as root user
+
+# Install the Puppet 6.x Repository on RHEL
+rpm -Uvh https://yum.puppet.com/puppet6/puppet6-release-el-7.noarch.rpm
+# Install the Puppet 5.x Repository on RHEL
+# rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm
+
+# Install the Puppet Agent to allow access to "puppet apply" command 
+yum install -y puppet-agent
+
+# Pull Puppet modules from Git
+# Note: It would be preferrable to use Puppetlabs r10k but baseline does not include required Ruby version
+mkdir /tmp/puppet-examples
+git clone https://github.com/gitowner/puppet-examples.git /tmp/puppet-examples
+
+cd /tmp/puppet-examples/variables
+
+# Execute the Puppet Module in the current directory (explicit path necessary)
+/opt/puppetlabs/bin/puppet apply --modulepath=. -e "include modulename"
+
+# Cleanup
+rm -rf /tmp/puppet-examples


### PR DESCRIPTION
Attached examples show integration of both Ansible Playbooks and Puppet during custom AMI generation process.  Just rename the file custom.sh and adjust Git to run external OS hardening processes.