### PR TITLE
CLOUD-2066. Add CCM client to CB images.

### DIFF
--- a/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel-values.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel-values.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ux
+
+TUNNEL_INITIATOR_ID= #ID of the tunnel initator. This is what will be used to query this endpoint.
+ROLE= #This is what we will be using to query.
+HOST_PORT= # Which port to do you want to tunnel onto?
+CCM_SSH_PORT=8990 # The mina port. This is the default port number. No need to change this.
+ENCIPHERED_PRIVATE_KEY=/tmp/enc.key # Put key here. Need not be encrypted for testing purposes.
+HOST= # Destination of the mina service.
+PUBLIC_KEY= # Path to the public key file of the mina service.

--- a/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ux
+
+SCRIPT=`basename "$0"`
+ROLE=$1
+
+. /cdp/bin/reverse-tunnel-values-${ROLE}.sh
+
+# Setting gate time to 0 to retry on SSH failures due to connectivity issues on first try
+export AUTOSSH_GATETIME=0
+export AUTOSSH_LOGLEVEL=7
+export AUTOSSH_LOGFILE="/var/log/autossh-${ROLE}.log"
+# Set max backoff interval in case of recurring connection failures.
+export AUTOSSH_POLL=30
+
+PRIVATE_KEY=/tmp/pk.key
+
+if grep -q "BEGIN" ${ENCIPHERED_PRIVATE_KEY}; then
+    cat ${ENCIPHERED_PRIVATE_KEY} > ${PRIVATE_KEY}
+else
+    IV=436c6f7564657261436c6f7564657261
+    cat ${ENCIPHERED_PRIVATE_KEY} | openssl enc -aes-128-cbc -d -A -a \
+        -K $(xxd -pu <<< $(echo ${TUNNEL_INITIATOR_ID} | cut -c1-16) | cut -c1-32) \
+        -iv ${IV} > ${PRIVATE_KEY}
+fi
+
+chmod 400 ${PRIVATE_KEY}
+
+if [[ ${ROLE} == "SSH" ]]; then
+    LOCAL_IP=127.0.0.1
+    USER=${TUNNEL_INITIATOR_ID}_${ROLE}
+else
+    LOCAL_IP=0.0.0.0
+    USER=${TUNNEL_INITIATOR_ID}_${ROLE}
+fi
+
+exec autossh -M 0 -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" \
+-o UserKnownHostsFile=${PUBLIC_KEY} -N -T -R ${LOCAL_IP}:0:localhost:${HOST_PORT} \
+-i ${PRIVATE_KEY} -p ${CCM_SSH_PORT} ${USER}@${HOST} -vvv

--- a/saltstack/base/salt/ccm-client/cdp/bin/update-reverse-tunnel-values.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/update-reverse-tunnel-values.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ux
+
+ROLE=$1
+HOST_PORT=$2
+cat > /cdp/bin/reverse-tunnel-values-${ROLE}.sh <<EOF
+CCM_SSH_PORT=${CCM_SSH_PORT}
+HOST_PORT=${HOST_PORT}
+ROLE=${ROLE}
+HOST=${HOST}
+TUNNEL_INITIATOR_ID=${TUNNEL_INITIATOR_ID}
+ENCIPHERED_PRIVATE_KEY=${ENCIPHERED_PRIVATE_KEY}
+CLOUD_PROVIDER=${CLOUD_PROVIDER}
+PUBLIC_KEY=${PUBLIC_KEY}
+EOF
+systemctl enable tunnel@{ROLE}.service
+systemctl start tunnel@${ROLE}.service

--- a/saltstack/base/salt/ccm-client/init.sls
+++ b/saltstack/base/salt/ccm-client/init.sls
@@ -1,0 +1,19 @@
+/cdp/bin/reverse-tunnel.sh:
+  file.managed:
+    - name: /cdp/bin/reverse-tunnel.sh
+    - source: salt://{{ slspath }}/cdp/bin/reverse-tunnel.sh
+
+/cdp/bin/reverse-tunnel-values.sh:
+  file.managed:
+    - name: /cdp/bin/reverse-tunnel-values.sh
+    - source: salt://{{ slspath }}/cdp/bin/reverse-tunnel-values.sh
+
+/cdp/bin/update-reverse-tunnel-values.sh:
+  file.managed:
+    - name: /cdp/bin/update-reverse-tunnel-values.sh
+    - source: salt://{{ slspath }}/cdp/bin/updatereverse-tunnel-values.sh
+
+/systemd/tunnel@.service:
+  file.managed:
+    - name: /systemd/tunnel@.service
+    - source: salt://{{ slspath }}/systemd/tunnel@.service

--- a/saltstack/base/salt/ccm-client/systemd/tunnel@.service
+++ b/saltstack/base/salt/ccm-client/systemd/tunnel@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=AutoSSH tunnel service for user %i
+ConditionPathExists=/cdp/bin/reverse-tunnel-values-%i.sh
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/cdp/bin/reverse-tunnel.sh %i
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -43,6 +43,9 @@ packages_install:
   {% endif %}
       - deltarpm
       - nvme-cli
+      - autossh
+      - openssl
+      - vim-common
 
 {% if grains['os_family'] == 'Suse' %}
 remove_snappy:

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -10,4 +10,5 @@ base:
     - postgresql
     - monitoring
     - performance
+    - ccm-client
     - custom


### PR DESCRIPTION
With these changes, the CCM client infrastructure and prerequisites
have been added to the Salt configuration for CB images.