### PR TITLE
CB-2140. Use cloudera public gem repo for install fluent-plugin-databus.

### DIFF
--- a/saltstack/hortonworks/salt/fluent/init.sls
+++ b/saltstack/hortonworks/salt/fluent/init.sls
@@ -1,4 +1,5 @@
 {% set os = salt['environ.get']('OS') %}
+{% set cloudera_public_gem_repo = 'https://repository.cloudera.com/cloudera/api/gems/cloudera-gems/' %}
 
 {% if os.startswith("centos") or os.startswith("redhat") %}
 install_fluentd_yum:
@@ -57,8 +58,6 @@ warning_fluentd_os:
 install_fluentd_plugins:
   cmd.run:
     - names:
-      - /opt/td-agent/embedded/bin/fluent-gem install fluent-plugin-cloudwatch-logs
-      - curl -k -o /tmp/fluent-plugin-databus-1.0.0.gem https://cloudera-service-delivery-cache.s3-us-west-2.amazonaws.com/fluent-plugin-databus-1.0.0.gem
-      - /opt/td-agent/embedded/bin/fluent-gem install /tmp/fluent-plugin-databus-1.0.0.gem
-      - rm -r /tmp/fluent-plugin-databus-1.0.0.gem
+      - /opt/td-agent/embedded/bin/fluent-gem source -a {{ cloudera_public_gem_repo }}
+      - /opt/td-agent/embedded/bin/fluent-gem install fluent-plugin-databus fluent-plugin-cloudwatch-logs
     - onlyif: test -d /opt/td-agent/embedded/bin/


### PR DESCRIPTION
use cldr public gem repo, as fluent-plugin-databus is available there, the repo is not configurable yet so it's passed as a constant
similar as: https://github.com/hortonworks/cloudbreak/pull/5478

i did not test this code, only the change on the PR above, but that is exactly the same 