### PR TITLE
Update metering package to use binary package (instead of install python pip deps)

### DIFF
--- a/saltstack/hortonworks/salt/metering/init.sls
+++ b/saltstack/hortonworks/salt/metering/init.sls
@@ -1,6 +1,6 @@
 {% set os = salt['environ.get']('OS') %}
 {% set metering_rmp_repo_url = 'https://cloudera-service-delivery-cache.s3-us-west-2.amazonaws.com/metering/heartbeat_producer/'%}
-{% set metering_rpm_location = metering_rmp_repo_url + 'metering-heartbeat-application-0.1-SNAPSHOT_191281a19a4ca403a93294514da847cdb160549d.x86_64.rpm' %}
+{% set metering_rpm_location = metering_rmp_repo_url + 'metering-heartbeat-application-0.1-SNAPSHOT_652d2a8abc3132092b718c5f0cd24ef235f10910.x86_64.rpm' %}
 
 {% if grains['init'] == 'systemd' %}
   {% if os.startswith("centos") or os.startswith("redhat") or os == "amazonlinux2" %}


### PR DESCRIPTION
With a newer version of the metering application, the rpm will install only a binary and won't depend on any python/pip libs