### PR TITLE
CB-2654. Additional script improvements.

### DIFF
--- a/saltstack/base/salt/ccm-client/cdp/bin/update-reverse-tunnel-values.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/update-reverse-tunnel-values.sh
@@ -11,5 +11,6 @@ CCM_ENCIPHERED_PRIVATE_KEY_FILE=${CCM_ENCIPHERED_PRIVATE_KEY_FILE}
 CCM_TUNNEL_ROLE=${CCM_TUNNEL_ROLE}
 CCM_TUNNEL_SERVICE_PORT=${CCM_TUNNEL_SERVICE_PORT}
 EOF
+chmod 744 /cdp/bin/reverse-tunnel-values-${CCM_TUNNEL_ROLE}.sh
 systemctl enable ccm-tunnel@${CCM_TUNNEL_ROLE}.service
 systemctl start ccm-tunnel@${CCM_TUNNEL_ROLE}.service


### PR DESCRIPTION
With these changes, the CCM variables are correctly passed through
to the update script, and the provider-specific instance ID is used
as the default CCM tunnel initiator ID.