### PR TITLE
fix {image_name}.json generation for base images (no pre-warm parcels)

### DIFF
--- a/scripts/pp_json.sh
+++ b/scripts/pp_json.sh
@@ -15,6 +15,9 @@ fi
 
 echo "pre_warm_parcels: ${pre_warm_parcels}"
 
+pre_warm_parcels=${pre_warm_parcels:-\"\"}
+pre_warm_csd=${pre_warm_csd:-\"\"}
+
 cat  > ${image_name}.json <<EOF
 {
 "created_at": ${created_at},


### PR DESCRIPTION
Testing: I am not yet familiar with the image building process, so I only tested it by executing pp_images.json.

It should now create a valid json with the parcels missing.

