### PR TITLE
CB-4366 Nginx should allow underscores in header names

### DIFF
--- a/saltstack/base/salt/nginx/etc/nginx/nginx.conf
+++ b/saltstack/base/salt/nginx/etc/nginx/nginx.conf
@@ -18,6 +18,8 @@ http {
     keepalive_timeout  30;
     keepalive_requests 100;
 
+    underscores_in_headers on;
+
     proxy_buffering  off;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Scheme $scheme;


### PR DESCRIPTION
Nginx by default prevents underscores in header names.
The HTTP spec allows underscores in headers. This change
configures Nginx to allow underscores in headers. It needs
to be configured at the top level since there are multiple
Nginx server config blocks.

http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers

Some additional background on underscores in headers can
be found here:

https://stackoverflow.com/questions/22856136/why-http-servers-forbid-underscores-in-http-header-names

Signed-off-by: Kevin Risden <krisden@apache.org>