### PR TITLE
CB-5138 image burning fails while it tries to download jmx_javaagent

### DIFF
--- a/saltstack/base/salt/monitoring/jmx-exporter.sls
+++ b/saltstack/base/salt/monitoring/jmx-exporter.sls
@@ -1,6 +1,6 @@
 /opt/jmx_javaagent.jar:
   file.managed:
-    - source: http://central.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.2.0/jmx_prometheus_javaagent-0.2.0.jar
+    - source: https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.2.0/jmx_prometheus_javaagent-0.2.0.jar
     - source_hash: md5=5aed7dd0f6ed8bdf62a303db5d18410d
     - user: root
     - group: root

--- a/saltstack/base/salt/monitoring/prometheus.sls
+++ b/saltstack/base/salt/monitoring/prometheus.sls
@@ -11,7 +11,7 @@ install_prometheus:
 install_jmx_javaagent_exporter:
   file.managed:
     - name: /opt/jmx_javaagent.jar
-    - source: http://central.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.2.0/jmx_prometheus_javaagent-0.2.0.jar
+    - source: https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.2.0/jmx_prometheus_javaagent-0.2.0.jar
     - source_hash: md5=5aed7dd0f6ed8bdf62a303db5d18410d
     - if_missing: /opt/jmx_javaagent.jar
 


### PR DESCRIPTION
tested with `build-aws-centos7` make target (base image):
╭─ahorvath~
╰─$ docker logs e963e533cdbd | grep "ID: /opt/jmx_javaagent.jar" -A 12
    aws-centos7:           ID: /opt/jmx_javaagent.jar
    aws-centos7:     Function: file.managed
    aws-centos7:       Result: True
    aws-centos7:      Comment: File /opt/jmx_javaagent.jar updated
    aws-centos7:      Started: 08:49:07.378811
    aws-centos7:     Duration: 34.247 ms
    aws-centos7:      Changes:
    aws-centos7:               ----------
    aws-centos7:               diff:
    aws-centos7:                   New file
    aws-centos7:               mode:
    aws-centos7:                   0644
    aws-centos7: ----------
╭─ahorvath~
╰─$ docker logs e963e533cdbd | grep "ID: install_jmx_javaagent_exporter" -A 8
    aws-centos7:           ID: install_jmx_javaagent_exporter
    aws-centos7:     Function: file.managed
    aws-centos7:         Name: /opt/jmx_javaagent.jar
    aws-centos7:       Result: True
    aws-centos7:      Comment: File /opt/jmx_javaagent.jar is in the correct state
    aws-centos7:      Started: 08:49:12.824951
    aws-centos7:     Duration: 3.182 ms
    aws-centos7:      Changes:
    aws-centos7: ----------