### PR TITLE
Upgrade pip to overcome zipp issue

### DIFF
--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -6,6 +6,7 @@
 set -e -o pipefail -o errexit
 
 function install_salt_with_pip() {
+  pip install --upgrade pip
   pip install virtualenv
   mkdir ${SALT_PATH}
   virtualenv ${SALT_PATH}


### PR DESCRIPTION
failed: http://build.eng.hortonworks.com:8080/job/cloudbreak-multi-packer-image-builder-salt-v3/365/console
working build started with the feature branch of this PR: http://build.eng.hortonworks.com:8080/job/cloudbreak-multi-packer-image-builder-salt-v3/366/console