### PR TITLE
CB-5334 Changes for FreeIPA backup

### DIFF
--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -56,6 +56,28 @@ packages_install:
       - ipa-client
       - openldap
       - openldap-clients
+      - awscli
+
+download_azcopy:
+  archive.extracted:
+    - name: /tmp/azcopy
+    - source:  https://aka.ms/downloadazcopy-v10-linux
+    - archive_format: tar
+    - skip_verify: true
+    - options: "--strip 1"
+    - enforce_toplevel: false
+
+/usr/local/bin/azcopy:
+  file.managed:
+    - source: /tmp/azcopy/azcopy
+    - user: root
+    - group: root
+    - mode: 755
+
+remove_azcopy_extract:
+  file.directory:
+    - name: /tmp/azcopy
+    - clean: True
 
 {% if grains['os_family'] == 'Suse' %}
 remove_snappy:

--- a/saltstack/freeipa/salt/freeipa/init.sls
+++ b/saltstack/freeipa/salt/freeipa/init.sls
@@ -4,6 +4,14 @@
       + 'cdp-hashed-pwd-' + freeipa_plugin_version
       + '.x86_64.rpm' %}
 
+disable_postfix:
+  service.disabled:
+    - name: postfix
+
+disable_postgres:
+  service.disabled:
+    - name: postgresql
+
 freeipa-install:
   pkg.installed:
     - pkgs:


### PR DESCRIPTION
This is adding the AWS CLI tools and AZCopy to the FreeIPA image creation in order to support automatic backups of the FreeIPA service to cloud-based object stores.  It was not added to the general image due to the specific nature of adding the AZcopy binary and wanting to limit the impact of the AWS CLI on other images builds.

Closes #CB-5338
Closes #CB-5337