### PR TITLE
CB-6032 add jinja2 package to global python rather than virtualenv

### DIFF
--- a/saltstack/base/salt/prerequisites/init.sls
+++ b/saltstack/base/salt/prerequisites/init.sls
@@ -14,6 +14,7 @@ include:
   - {{ slspath }}.user
   - {{ slspath }}.firewall
   - {{ slspath }}.umask
+  - {{ slspath }}.jinja
 {% if  pillar['OS'].startswith('ubuntu') %}
   - {{ slspath }}.disable-unattended-upgrades
  {% endif %}

--- a/saltstack/base/salt/prerequisites/jinja.sls
+++ b/saltstack/base/salt/prerequisites/jinja.sls
@@ -1,0 +1,3 @@
+install_jinja2:
+  cmd.run:
+    - name: /usr/bin/pip install jinja2


### PR DESCRIPTION
I tried pip.installed, but I couldn't make it work when virtualenv is used. You can specify bin_env, but didn't work either. 