### PR TITLE
wip: [build-gov-aws-amazonlinux] change path to pip

### DIFF
--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -6,9 +6,12 @@
 set -e -o pipefail -o errexit
 
 function install_salt_with_pip() {
-  pip install --upgrade pip
-  pip install virtualenv
+  # Upgrading pip replaces the system pip, removing /usr/bin/pip and installing
+  # /usr/local/bin/pip in its stead
+  pip install -v --upgrade pip
+  /usr/local/bin/pip install virtualenv
   mkdir ${SALT_PATH}
+  # But virtualenv is installed globally it seems
   virtualenv ${SALT_PATH}
   source ${SALT_PATH}/bin/activate
   pip install -r /tmp/salt_requirements.txt


### PR DESCRIPTION
In #383, the yum-managed pip is upgraded with pip. As part of that
upgrade pip removes /usr/bin/pip and install /usr/local/bin/pip. This
will likely break behavior of any root processes trying to use pip or
even yum updates of the pip package. That being said, we update our prep
script to resolve the new location so that it can get salt ready to go.