### PR TITLE
update to saltstack 2017.7.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_REPO_PASSWORD ?= ""
 ## https://github.com/hashicorp/packer/issues/6536
 AWS_MAX_ATTEMPTS ?= 300
 PACKAGE_VERSIONS ?= ""
-SALT_VERSION ?= 2017.7.5
+SALT_VERSION ?= 2017.7.7
 SALT_PATH ?= /opt/salt_$(SALT_VERSION)
 PYZMQ_VERSION ?= 14.5.0
 PYTHON_APT_VERSION ?= 1.1.0_beta1ubuntu0.16.04.1

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -3,7 +3,7 @@
 : ${DEBUG:=1}
 : ${DRY_RUN:-1}
 
-set -e -o pipefail -o errexit
+set -ex -o pipefail -o errexit
 
 function install_salt_with_pip() {
   pip install --upgrade pip

--- a/scripts/salt-setup.sh
+++ b/scripts/salt-setup.sh
@@ -3,7 +3,7 @@
 : ${DEBUG:=1}
 : ${DRY_RUN:-1}
 
-set -e -o pipefail -o errexit
+set -ex -o pipefail -o errexit
 
 function prepare {
   sudo chown -R root:root /tmp/saltstack

--- a/scripts/salt_requirements.txt
+++ b/scripts/salt_requirements.txt
@@ -3,3 +3,5 @@ virtualenvwrapper
 CherryPy
 pyzmq==${PYZMQ_VERSION}
 salt==${SALT_VERSION}
+tornado===4.2.1
+msgpack-python


### PR DESCRIPTION
I had better results with 7.7 than 7.5 and it does not require backend changes so I think we should upgrade to this version. 