### PR TITLE
FIX: Java 11 missing symlink

### DIFF
--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -64,6 +64,12 @@ create_java11_java8_folder_compatibility_symlink:
     - target: /usr/lib/jvm/java/conf
     - follow_symlinks: True
 
+create_java11_java8_cacerts_symlink:
+  file.symlink:
+    - name: /usr/lib/jvm/java/jre/lib/security/cacerts
+    - target: /etc/pki/java/cacerts
+    - follow_symlinks: True
+
 {% endif %}
 
 add_openjdk_gplv2:


### PR DESCRIPTION
Our nodes won't start without this fix: 

```++ keytool -importkeystore -srckeystore /usr/lib/jvm/java/jre/lib/security/cacerts -srcstorepass changeit -destkeystore /opt/cacerts/cacerts.p12 -deststorepass changeit -deststoretype PKCS12
Importing keystore /usr/lib/jvm/java/jre/lib/security/cacerts to /opt/cacerts/cacerts.p12...
keytool error: java.io.FileNotFoundException: /usr/lib/jvm/java/jre/lib/security/cacerts (No such file or directory)```