### PR TITLE
CB-7811 salt-boostrap restart directive should be 'always'

### DIFF
--- a/saltstack/base/salt/salt-bootstrap/etc/systemd/system/salt-bootstrap.service
+++ b/saltstack/base/salt/salt-bootstrap/etc/systemd/system/salt-bootstrap.service
@@ -13,7 +13,7 @@ Wants=waagent.service
 Wants=google-startup-scripts.service
 
 [Service]
-Restart=on-failure
+Restart=always
 TimeoutSec=15s
 RestartSec=5s
 ExecStart=/usr/sbin/salt-bootstrap


### PR DESCRIPTION
This commit modifies the systemd unit file belonging to
salt-bootstrap.
It will switch from `on-failure` to `always` as we experienced that
the process is killed accidentally by end users.
For more information regarding the `Restart` directive please see:
https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=