### PR TITLE
CB-7877. Update databus version for CB images (to support dynamic headers)

### DIFF
--- a/saltstack/base/salt/fluent/init.sls
+++ b/saltstack/base/salt/fluent/init.sls
@@ -2,7 +2,7 @@
 {% set cloudera_public_gem_repo = 'https://repository.cloudera.com/cloudera/api/gems/cloudera-gems/' %}
 {% set cloudera_azure_plugin_version = '1.0.1' %}
 {% set cloudera_azure_gen2_plugin_version = '0.3.1' %}
-{% set cloudera_databus_plugin_version = '1.0.4' %}
+{% set cloudera_databus_plugin_version = '1.0.5' %}
 {% set redaction_plugin_version = '0.1.2' %}
 
 {% if os.startswith("centos") or os.startswith("redhat") %}


### PR DESCRIPTION
update databus version -  there is a new field that can supprt to pass dynamic header fields for databus, for example: append some dynamic fields to kibana during file collection (which does not come from a static file, filecollector streams data to fluentd) 

to not need to re-build freeipa image yet. if it's built that's fine, the CB check on databus version only will update the gem if the value is lower (not higher)