### PR TITLE
CB-7813 add ConnectTimeout parameter to auto ssh command

### DIFF
--- a/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
@@ -33,6 +33,6 @@ else
     USER=${CCM_TUNNEL_INITIATOR_ID}_${ROLE}
 fi
 
-exec autossh -M 0 -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" \
+exec autossh -M 0 -o "ConnectTimeout 30" -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" \
 -o UserKnownHostsFile=${CCM_PUBLIC_KEY_FILE} -N -T -R ${LOCAL_IP}:0:localhost:${CCM_TUNNEL_SERVICE_PORT} \
 -i ${PRIVATE_KEY} -p ${CCM_SSH_PORT} ${USER}@${CCM_HOST} -vvv


### PR DESCRIPTION
Autossh process relies on the underlying SSH command to fail
after 1,5 minutes (30 * 3 sec) and restarts the tunnel upon such
connection failure. However if you cut the circuit towards to
the LB and the SSH command is not able to re-connect to the server
it just hangs. If it hangs autossh will not be able to detect the
failure as the SSH command is live, but does not do anything and
all extra monitoring is disabled with M 0. If we introduce the
ConnectTimeout option to the SSH command it will not hang, but fail
after the given time in seconds and autossh will be able to restart
the command.