### PR TITLE
CB-7348 Update AWS AMI to the latest Centos7 AMI

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -221,7 +221,7 @@
       "region": "us-west-1",
       "ami_regions": "{{ user `aws_ami_regions` }}",
       "ssh_pty": true,
-      "source_ami": "ami-074e2d6769f445be5",
+      "source_ami": "ami-098f55b4287a885ba",
       "instance_type": "{{ user `aws_instance_type` }}",
       "ssh_username": "centos",
       "ena_support": true,


### PR DESCRIPTION
CB-7348 Update AWS AMI to the latest Centos7 AMI

The following script was used to determine the AMI:
```
aws ec2 describe-images \                                                   
    --owners aws-marketplace \
    --filters '[
        {"Name": "name",                "Values": ["CentOS Linux 7*"]},
        {"Name": "virtualization-type", "Values": ["hvm"]},
        {"Name": "architecture",        "Values": ["x86_64"]},
        {"Name": "image-type",          "Values": ["machine"]}
    ]' \
    --query 'sort_by(Images, &CreationDate)[-1]' \
    --region us-west-1 \
    --output json
```