### PR TITLE
CB-7988 Remove auto join from salt master configuration

### DIFF
--- a/saltstack/base/salt/salt/etc/salt/master.d/custom.conf
+++ b/saltstack/base/salt/salt/etc/salt/master.d/custom.conf
@@ -1,5 +1,4 @@
 
-auto_accept: True
 log_level_logfile: debug
 master_sign_pubkey: True
 


### PR DESCRIPTION
As the code which handles fingerprint matching and accepting minions reached prod
we can safely remove autojoin

tested:
- created image from local
- from the new image distrox provisioned
- upscale
- downscale