### PR TITLE
CB-8529: Starting Hue fails with longer stackname and 7.1.0 DE template

### DIFF
--- a/saltstack/base/salt/prerequisites/httpd.sls
+++ b/saltstack/base/salt/prerequisites/httpd.sls
@@ -9,6 +9,6 @@ create_okay_repo:
 
 install_httpd:
   pkg.latest:
-  	- name: httpd
+    - name: httpd
 
 {% endif %}

--- a/saltstack/base/salt/prerequisites/httpd.sls
+++ b/saltstack/base/salt/prerequisites/httpd.sls
@@ -1,0 +1,14 @@
+{% if pillar['OS'] == 'centos7' %}
+
+create_okay_repo:
+  pkgrepo.managed:
+    - name: okay
+    - humanname: "Extra OKay Packages for Enterprise Linux - $basearch"
+    - baseurl: "http://repo.okay.com.mx/centos/$releasever/$basearch/release"
+    - gpgcheck: 0
+
+install_httpd:
+  pkg.latest:
+  	- name: httpd
+
+{% endif %}

--- a/saltstack/base/salt/prerequisites/init.sls
+++ b/saltstack/base/salt/prerequisites/init.sls
@@ -18,7 +18,8 @@ include:
   - {{ slspath }}.corkscrew
 {% if  pillar['OS'].startswith('ubuntu') %}
   - {{ slspath }}.disable-unattended-upgrades
- {% endif %}
+{% endif %}
+  - {{ slspath }}.httpd
 
 /usr/bin/:
   file.recurse:


### PR DESCRIPTION
New httpd salt file is added to the prerequisites which removes the previously installed httpd and installs it again from a specified repository.