### PR TITLE
CB-8414 Enable SSL on Salt-API (rest_cherrypy)

### DIFF
--- a/saltstack/base/salt/nginx/etc/nginx/ssl.conf
+++ b/saltstack/base/salt/nginx/etc/nginx/ssl.conf
@@ -66,8 +66,8 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
     location ~ /saltapi/(?<section>.*) {
-        proxy_pass         http://saltapi/$section$is_args$args;
-          proxy_read_timeout 300;
+        proxy_pass         https://saltapi/$section$is_args$args;
+        proxy_read_timeout 300;
         proxy_redirect     off;
         proxy_set_header   Host $host;
         proxy_set_header   X-Forwarded-Host $server_name;

--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -170,6 +170,13 @@ update_reverse_tunnel_values() {
   /cdp/bin/update-reverse-tunnel-values.sh "$1" "$2"
 }
 
+create_saltapi_certificates() {
+  source activate_salt_env
+  salt-call --local tls.create_self_signed_cert CN='saltapi' days=3650 replace=Tru
+  deactivate
+  rm -f /etc/salt/minion_id
+}
+
 main() {
   configure-salt-bootstrap
   reload_sysconf
@@ -184,6 +191,7 @@ main() {
         setup_tls
         start_nginx
       fi
+      create_saltapi_certificates
     fi
 
     INSTANCE_ID=

--- a/saltstack/base/salt/salt/etc/salt/master.d/custom.conf
+++ b/saltstack/base/salt/salt/etc/salt/master.d/custom.conf
@@ -13,4 +13,5 @@ external_auth:
 rest_cherrypy:
   host: 127.0.0.1
   port: 3080
-  disable_ssl: True
+  ssl_crt: /etc/pki/tls/certs/saltapi.crt
+  ssl_key: /etc/pki/tls/certs/saltapi.key

--- a/scripts/salt_requirements.txt
+++ b/scripts/salt_requirements.txt
@@ -5,3 +5,4 @@ pyzmq==${PYZMQ_VERSION}
 salt==${SALT_VERSION}
 tornado===4.2.1
 msgpack-python
+PyOpenSSL


### PR DESCRIPTION
This commit:
- adds PyOpenSSL as a requirement for salt pip install
- add cert generation to `user-data-helper` script for salt-api
- turns on SSL for salt-api
- changes nginx configuration to use salt-api via SSL

Depends on: https://github.com/hortonworks/cloudbreak/pull/8922

This change is not backward compatible with older CB versions.

**Wait for CB 2.30 to reach prod**