### PR TITLE
CB-8662: Update the CDP health agent for FreeIPA

### DIFF
--- a/saltstack/freeipa/salt/freeipa/init.sls
+++ b/saltstack/freeipa/salt/freeipa/init.sls
@@ -5,7 +5,7 @@
       + '.x86_64.rpm' %}
 
 {% set freeipa_healthagent_base_url = 'https://cloudera-service-delivery-cache.s3.amazonaws.com/freeipa-health-agent/packages/' %}
-{% set freeipa_healthagent_version = '0.1-20200811155428gitb402599' %}
+{% set freeipa_healthagent_version = '0.1-20201005182915gitddf435a' %}
 {% set freeipa_healthagent_rpm_url = freeipa_healthagent_base_url
       + 'freeipa-health-agent-' + freeipa_healthagent_version
       + '.x86_64.rpm' %}


### PR DESCRIPTION
Update the CDP health agent for FreeIPA to have improved health status
for the various plugins.