### PR TITLE
CB-9459 Adds sha checksum support to validate KEYTRUSTEE_SERVER parcel.

### DIFF
--- a/saltstack/hortonworks/salt/pre-warm/tmp/install_cdh.sh
+++ b/saltstack/hortonworks/salt/pre-warm/tmp/install_cdh.sh
@@ -46,6 +46,8 @@ download_cdh_parcel() {
     verify_parcel_checksum "sha1"
   elif  curl -sLf "${STACK_BASEURL}/${PARCELS_NAME}.sha256" -o /dev/null; then
     verify_parcel_checksum "sha256"
+  elif  curl -sLf "${STACK_BASEURL}/${PARCELS_NAME}.sha" -o /dev/null; then
+    verify_parcel_checksum "sha"
   else
     echo "Unable to locate sha file."
     exit 1


### PR DESCRIPTION
KEYTRUSTEE_SERVER is available with sha checksum what was not supported before.
http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/6656988/cdh/7.x/parcels/

Adding support to validate sha checksums when burning a prewarmed image.