### PR TITLE
CB-9635 Fix tunnel initiator id being empty while setting up reverse …

### DIFF
--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -199,6 +199,8 @@ main() {
       INSTANCE_ID="`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`"
     elif [[ "$CLOUD_PLATFORM" == "AZURE" ]]; then
       INSTANCE_ID="`wget -q -O - --header="Metadata: true" 'http://169.254.169.254/metadata/instance/compute/name?api-version=2017-08-01&format=text'`"
+    elif [[ "$CLOUD_PLATFORM" == "GCP" ]]; then
+      INSTANCE_ID="`wget -q -O - --header="Metadata-Flavor: Google" 'http://metadata.google.internal/computeMetadata/v1/instance/name'`"
     fi
 
     if [[ "$IS_CCM_ENABLED" == "true" ]]; then


### PR DESCRIPTION
…SSH tunnel

1. For AWS and Azure we use the instance id as the tunnel initiator id.
2. In GCP instance-id means the long id (4126165857841987474) of the instance, but mina is actually using the instance name (demogcpfreeipa-m-0-20201109175052), so choosing the instance name.

Localized testing of getting proper instance id per mina service was done using an already running instance. We need a new image to test end to end.