### PR TITLE
CB-9814: Remove the centos6 support from the salt stack of images repository

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,14 +42,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         :salt_install_os => "centos"
       },
       {
-        :hostname => "centos6",
-        :box => "centos/6",
-        :ram => 1536,
-        :cpu => 2,
-        :custom_image_type => "hortonworks",
-        :salt_install_os => "centos"
-      },
-      {
         :hostname => "debian9",
         :box => "debian/stretch64",
         :ram => 1536,

--- a/docker/centos7.3/Dockerfile
+++ b/docker/centos7.3/Dockerfile
@@ -84,7 +84,7 @@ COPY docker/centos7.3/files/image-prep-scripts/hwx-internal-setup.sh /tmp/image-
 RUN /tmp/image-build-space/image-prep-scripts/hwx-internal-setup.sh
 #################################################################################
 
-# install iproute explicitly on centos7, it's present by default in centos6, debian7
+# install iproute explicitly on centos7, it's present by default in debian7
 RUN yum -y install iproute
 
 #################################################################################

--- a/docker/centos7.3/files/image-runtime-scripts/start-services-script.sh
+++ b/docker/centos7.3/files/image-runtime-scripts/start-services-script.sh
@@ -123,31 +123,4 @@ elif [[ ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"7.2.1511"x ) || ( x"$OS"
     systemctl enable sshd
     exec -l /usr/lib/systemd/systemd --system
     ############################### Centos7 #####################
-elif [[ ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"6.8"x ) || ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"6.9"x ) ]] ; then
-    ############################### Centos6 #####################
-    echo "waiting for network ..."
-
-    while : ; do
-        ip addr ls dev eth0 | grep "inet " && break
-        sleep 1
-    done > /dev/null 2>&1
-
-    echo "dumping network state before starting ssh ... "
-    ip addr show
-
-    echo "starting logging service.... "
-    /etc/init.d/rsyslog start
-
-    echo "starting sshd service ... "
-    /etc/init.d/sshd start
-
-    while : ; do
-        PID=`pidof sshd`
-        if [ "$PID" == "" ] ; then
-            echo "sshd is dead!" 1>&2
-            exit 1
-        fi
-        sleep 1
-    done
-    ############################### Centos6 #####################
 fi

--- a/docker/centos7.4/image-runtime-scripts/start-services-script.sh
+++ b/docker/centos7.4/image-runtime-scripts/start-services-script.sh
@@ -123,31 +123,4 @@ elif [[ ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"7.2.1511"x ) || ( x"$OS"
     systemctl enable sshd
     exec -l /usr/lib/systemd/systemd --system
     ############################### Centos7 #####################
-elif [[ ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"6.8"x ) || ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"6.9"x ) ]] ; then
-    ############################### Centos6 #####################
-    echo "waiting for network ..."
-
-    while : ; do
-        ip addr ls dev eth0 | grep "inet " && break
-        sleep 1
-    done > /dev/null 2>&1
-
-    echo "dumping network state before starting ssh ... "
-    ip addr show
-
-    echo "starting logging service.... "
-    /etc/init.d/rsyslog start
-
-    echo "starting sshd service ... "
-    /etc/init.d/sshd start
-
-    while : ; do
-        PID=`pidof sshd`
-        if [ "$PID" == "" ] ; then
-            echo "sshd is dead!" 1>&2
-            exit 1
-        fi
-        sleep 1
-    done
-    ############################### Centos6 #####################
 fi

--- a/docker/centos7.5/image-runtime-scripts/start-services-script.sh
+++ b/docker/centos7.5/image-runtime-scripts/start-services-script.sh
@@ -123,31 +123,4 @@ elif [[ ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"7.2.1511"x ) || ( x"$OS"
     systemctl enable sshd
     exec -l /usr/lib/systemd/systemd --system
     ############################### Centos7 #####################
-elif [[ ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"6.8"x ) || ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"6.9"x ) ]] ; then
-    ############################### Centos6 #####################
-    echo "waiting for network ..."
-
-    while : ; do
-        ip addr ls dev eth0 | grep "inet " && break
-        sleep 1
-    done > /dev/null 2>&1
-
-    echo "dumping network state before starting ssh ... "
-    ip addr show
-
-    echo "starting logging service.... "
-    /etc/init.d/rsyslog start
-
-    echo "starting sshd service ... "
-    /etc/init.d/sshd start
-
-    while : ; do
-        PID=`pidof sshd`
-        if [ "$PID" == "" ] ; then
-            echo "sshd is dead!" 1>&2
-            exit 1
-        fi
-        sleep 1
-    done
-    ############################### Centos6 #####################
 fi

--- a/docker/centos7.6/image-runtime-scripts/start-services-script.sh
+++ b/docker/centos7.6/image-runtime-scripts/start-services-script.sh
@@ -123,31 +123,4 @@ elif [[ ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"7.2.1511"x ) || ( x"$OS"
     systemctl enable sshd
     exec -l /usr/lib/systemd/systemd --system
     ############################### Centos7 #####################
-elif [[ ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"6.8"x ) || ( x"$OS"x == x"CentOS"x && x"$OS_VERSION"x == x"6.9"x ) ]] ; then
-    ############################### Centos6 #####################
-    echo "waiting for network ..."
-
-    while : ; do
-        ip addr ls dev eth0 | grep "inet " && break
-        sleep 1
-    done > /dev/null 2>&1
-
-    echo "dumping network state before starting ssh ... "
-    ip addr show
-
-    echo "starting logging service.... "
-    /etc/init.d/rsyslog start
-
-    echo "starting sshd service ... "
-    /etc/init.d/sshd start
-
-    while : ; do
-        PID=`pidof sshd`
-        if [ "$PID" == "" ] ; then
-            echo "sshd is dead!" 1>&2
-            exit 1
-        fi
-        sleep 1
-    done
-    ############################### Centos6 #####################
 fi

--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -45,7 +45,7 @@ packages_install:
       - deltarpm
       - nvme-cli
       - openssl
-  {% if pillar['OS'] in ('centos7', 'centos6', 'redhat7') %}
+  {% if pillar['OS'] in ('centos7', 'redhat7') %}
       - vim-common
   {% else %}
       - vim


### PR DESCRIPTION
The support of centos6 reached the end of life, therefore it should be removed from the salt stack.