### PR TITLE
Making the CIS-Benchmark controls as default

### DIFF
--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -15,7 +15,5 @@ base:
     - fluent
 {% endif %}
     - ccm-client
-{% if salt['environ.get']('INCLUDE_CIS') == 'Yes' %}
     - cis-controls
-{% endif %}
     - custom


### PR DESCRIPTION
This will make sure cis-hardening controls are runs as default.