### PR TITLE
CB-9982 Explicitly disable VM memory overcommit setting

### DIFF
--- a/saltstack/base/salt/prerequisites/sysctl.sls
+++ b/saltstack/base/salt/prerequisites/sysctl.sls
@@ -2,6 +2,10 @@ vm.swappiness:
   sysctl.present:
     - value: 0
 
+vm.overcommit_memory:
+  sysctl.present:
+    - value: 0
+
 net.ipv4.ip_local_reserved_ports:
   sysctl.present:
     - value: "41000-51000"


### PR DESCRIPTION
1. In other Clouds this value is by default set to zero, which means overcommit based on heuristics.
2. In GCP we take a default Centos image from that cloud which already has a setting of 1, which means enable overcommit.
3. This commit brings GCP to the baseline of what we have in other clouds.