### PR TITLE
Revert "Making the CIS-Benchmark controls as default"

### DIFF
--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -15,5 +15,7 @@ base:
     - fluent
 {% endif %}
     - ccm-client
+{% if salt['environ.get']('INCLUDE_CIS') == 'Yes' %}
     - cis-controls
+{% endif %}
     - custom


### PR DESCRIPTION
This reverts commit 6ab18da5a8f8053cfb3bbe69003915b4860496e4 as it breaks GCP and Azure image bakings