### PR TITLE
CB-8897:CIS-Disable filesystems that aren't needed

### DIFF
--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -18,7 +18,7 @@
         - repl: install {{ fs }} /bin/true
         - append_if_not_found: True
     cmd.run:
-        - name: modprobe -r {{ fs }} && rmmod {{ fs }}
+        - name: modprobe -r {{ fs }} && rmmod {{ fs }} > /dev/null 2>&1
         - onlyif: "lsmod | grep {{ fs }}"
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Addressed the cause of beneath failed CB image builds.

http://build.eng.hortonworks.com:8080/job/cloudbreak-multi-packer-image-builder-salt-v3/2077/
http://build.eng.hortonworks.com:8080/job/cloudbreak-multi-packer-image-builder-salt-v3/2078/