### PR TITLE
CIS Controls as defaults

### DIFF
--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -18,7 +18,7 @@
         - repl: install {{ fs }} /bin/true
         - append_if_not_found: True
     cmd.run:
-        - name: modprobe -r {{ fs }} && rmmod {{ fs }}
+        - name: modprobe -r {{ fs }} && rmmod {{ fs }} > /dev/null 2>&1
         - onlyif: "lsmod | grep {{ fs }}"
 {% endfor %}
 {% endif %}

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -15,7 +15,5 @@ base:
     - fluent
 {% endif %}
     - ccm-client
-{% if salt['environ.get']('INCLUDE_CIS') == 'Yes' %}
     - cis-controls
-{% endif %}
     - custom


### PR DESCRIPTION
Have addressed the cause of below failed builds. These controls can be default now.

http://build.eng.hortonworks.com:8080/job/cloudbreak-multi-packer-image-builder-salt-v3/2077/
http://build.eng.hortonworks.com:8080/job/cloudbreak-multi-packer-image-builder-salt-v3/2078/