### PR TITLE
CB-8933: CIS-Harden SSH Configurations_part2

### DIFF
--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -21,4 +21,19 @@
         - name: modprobe -r {{ fs }} && rmmod {{ fs }}
         - onlyif: "lsmod | grep {{ fs }}"
 {% endfor %}
+
+sshd_harden_ApprovedCiphers:
+  file.replace:
+    - name: /etc/ssh/sshd_config
+    - pattern: "^Ciphers"
+    - repl: "Ciphers aes256-ctr,aes192-ctr,aes128-ctr"
+    - append_if_not_found: True
+
+sshd_harden_ApprovedMACs:
+  file.replace:
+    - name: /etc/ssh/sshd_config
+    - pattern: "^MACs"
+    - repl: "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
+    - append_if_not_found: True
+
 {% endif %}


### PR DESCRIPTION
### #Part2 of SSH hardening.
Below changes has been enforced in this PR
**5.2.11 Ensure only approved ciphers are used**
_Ciphers aes256-ctr,aes192-ctr,aes128-ctr_
**5.2.12 Ensure only approved MAC algorithms are used**
_MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com_