### PR TITLE
CB-8933:CIS-SSH Harden-Setting LogLevel as INFO

### DIFF
--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -36,4 +36,10 @@ sshd_harden_ApprovedMACs:
     - repl: "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
     - append_if_not_found: True
 
+sshd_harden_LogLevel:
+  file.replace:
+    - name: /etc/ssh/sshd_config
+    - pattern: "^LogLevel"
+    - repl: "LogLevel INFO"
+    - append_if_not_found: True
 {% endif %}

--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -21,4 +21,19 @@
         - name: modprobe -r {{ fs }} && rmmod {{ fs }}
         - onlyif: "lsmod | grep {{ fs }}"
 {% endfor %}
+
+sshd_harden_ApprovedCiphers:
+  file.replace:
+    - name: /etc/ssh/sshd_config
+    - pattern: "^Ciphers"
+    - repl: "Ciphers aes256-ctr,aes192-ctr,aes128-ctr"
+    - append_if_not_found: True
+
+sshd_harden_ApprovedMACs:
+  file.replace:
+    - name: /etc/ssh/sshd_config
+    - pattern: "^MACs"
+    - repl: "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com"
+    - append_if_not_found: True
+
 {% endif %}


### PR DESCRIPTION
By default the SSH LogLevel is set as INFO. It was flagged by aws inspector since the parameter was commented out in current sshd config file.