### PR TITLE
CB-9183: [CCMv2] Make inverting proxy agent a part of ami/image

### DIFF
--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/cdp/bin/ccmv2/run-inverting-proxy-agent.sh
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/cdp/bin/ccmv2/run-inverting-proxy-agent.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ux
+#
+# Copyright (C) 2020 Cloudera, Inc.
+#
+
+SCRIPT=`basename "$0"`
+BACKEND_ID=$1
+
+. /cdp/bin/ccmv2/inverting-proxy-agent-values-${BACKEND_ID}.sh
+
+exec /cdp/bin/ccmv2/inverting-proxy-agent -scheme ${SCHEME} -proxy ${INVERTING_PROXY_URL} -host ${BACKEND_ADDRESS} -backend ${BACKEND_ID} -disable-gce-vm-header=true -trusted-proxy-cert-path ${TRUSTED_PROXY_CERT_PATH} -trusted-backend-cert-path ${TRUSTED_BACKEND_CERT_PATH} -cert-path ${AGENT_CERT_PATH} -key-path ${AGENT_KEY_PATH}

--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -ux
+#
+# Copyright (C) 2020 Cloudera, Inc.
+#
+
+ARG_ERR=0
+
+if [[ "$#" -lt 7 || "$#" -gt 9 ]]; then
+  echo "Wrong number of arguments passed. The script requires 8 arguments to be passed for 'BACKEND_ID', 'BACKEND_HOST', 'BACKEND_PORT', 'AGENT_KEY_PATH', 'AGENT_CERT_PATH', 'TRUSTED_BACKEND_CERT_PATH' AND 'TRUSTED_PROXY_CERT_PATH'."
+  echo "An optional 8th argument for 'INVERTING_PROXY_URL' can be passed. If not passed, the environment variable INVERTING_PROXY_URL will be used."
+  echo "An optional 9th argument for 'SCHEME' can be passed. If not passed, the value 'https' will be used."
+  ARG_ERR=1
+fi
+
+INVERTING_PROXY_URL=${8:-$INVERTING_PROXY_URL}
+
+if [ -z "$INVERTING_PROXY_URL" ]; then
+  echo "Required variable 'INVERTING_PROXY_URL' is not set to a value. The script will exit now."
+  ARG_ERR=1
+fi
+
+SCHEME=${9:-https}
+
+if [ $ARG_ERR -eq 1 ] ; then
+  exit 1
+fi
+
+BACKEND_ID=$1
+BACKEND_HOST=$2
+BACKEND_PORT=$3
+AGENT_KEY_PATH=$4
+AGENT_CERT_PATH=$5
+TRUSTED_BACKEND_CERT_PATH=$6
+TRUSTED_PROXY_CERT_PATH=$7
+
+VALUES_FILE=/cdp/bin/ccmv2/inverting-proxy-agent-values-${BACKEND_ID}.sh
+
+cat > ${VALUES_FILE} <<EOF
+INVERTING_PROXY_URL=${INVERTING_PROXY_URL}
+BACKEND_ID=${BACKEND_ID}
+BACKEND_ADDRESS=${BACKEND_HOST}:${BACKEND_PORT}
+AGENT_KEY_PATH=${AGENT_KEY_PATH}
+AGENT_CERT_PATH=${AGENT_CERT_PATH}
+TRUSTED_BACKEND_CERT_PATH=${TRUSTED_BACKEND_CERT_PATH}
+TRUSTED_PROXY_CERT_PATH=${TRUSTED_PROXY_CERT_PATH}
+SCHEME=${SCHEME}
+EOF
+
+if [ -f "$VALUES_FILE" ]; then
+    chmod 740 ${VALUES_FILE}
+fi
+
+systemctl enable ccmv2-inverting-proxy-agent@${BACKEND_ID}.service
+systemctl restart ccmv2-inverting-proxy-agent@${BACKEND_ID}.service

--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/etc/systemd/system/ccmv2-inverting-proxy-agent@.service
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/etc/systemd/system/ccmv2-inverting-proxy-agent@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description= ClusterConnectivityManagementV2 Inverting proxy agent service for user %i
+ConditionPathExists=/cdp/bin/ccmv2/inverting-proxy-agent-values-%i.sh
+ConditionPathExists=/cdp/bin/ccmv2/inverting-proxy-agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/cdp/bin/ccmv2/run-inverting-proxy-agent.sh %i
+Restart=always
+TimeoutStopSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/init.sls
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/init.sls
@@ -1,0 +1,19 @@
+/cdp/bin/ccmv2/run-inverting-proxy-agent.sh:
+  file.managed:
+    - name: /cdp/bin/ccmv2/run-inverting-proxy-agent.sh
+    - makedirs: True
+    - source: salt://{{ slspath }}/cdp/bin/ccmv2/run-inverting-proxy-agent.sh
+    - mode: 740
+
+/cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh:
+  file.managed:
+    - name: /cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh
+    - makedirs: True
+    - source: salt://{{ slspath }}/cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh
+    - mode: 740
+
+/etc/systemd/system/ccmv2-inverting-proxy-agent@.service:
+  file.managed:
+    - name: /etc/systemd/system/ccmv2-inverting-proxy-agent@.service
+    - makedirs: True    
+    - source: salt://{{ slspath }}/etc/systemd/system/ccmv2-inverting-proxy-agent@.service

--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -147,6 +147,41 @@ setup_ccm() {
   fi
 }
 
+setup_ccmv2() {
+  : ${CCM_V2_INVERTING_PROXY_CERTIFICATE:? required}
+  : ${CCM_V2_INVERTING_PROXY_HOST:? required}
+  : ${CCM_V2_AGENT_CERTIFICATE:? required}
+  : ${CCM_V2_AGENT_ENCIPHERED_KEY:? required}
+  : ${CCM_V2_AGENT_KEY_ID:? required}
+  : ${CCM_V2_AGENT_CRN:? required}
+  : ${CCM_V2_AGENT_BACKEND_ID_PREFIX:? required}
+
+  BACKEND_ID="${CCM_V2_AGENT_BACKEND_ID_PREFIX}${INSTANCE_ID}"
+  BACKEND_HOST="localhost"
+  BACKEND_PORT="9443"
+
+  mkdir -p /etc/ccmv2
+
+  IV=436c6f7564657261436c6f7564657261
+  AGENT_KEY_PATH=/etc/ccmv2/ccmv2-key.enc
+  echo ${CCM_V2_AGENT_ENCIPHERED_KEY} | openssl enc -aes-128-cbc -d -A -a -K ${CCM_V2_AGENT_KEY_ID} -iv ${IV} > ${AGENT_KEY_PATH}
+  chmod 400 "$AGENT_KEY_PATH"
+
+  AGENT_CERT_PATH=/etc/ccmv2/ccmv2-cert.enc
+  echo "$CCM_V2_AGENT_CERTIFICATE" | base64 --decode > "$AGENT_CERT_PATH"
+  chmod 400 "$AGENT_CERT_PATH"
+
+  TRUSTED_BACKEND_CERT_PATH="/etc/certs/cluster.pem"
+
+  TRUSTED_PROXY_CERT_PATH=/etc/ccmv2/ccmv2-proxy-cert.enc
+  echo "$CCM_V2_INVERTING_PROXY_CERTIFICATE" | base64 --decode > "$TRUSTED_PROXY_CERT_PATH"
+  chmod 400 "$TRUSTED_PROXY_CERT_PATH"
+
+  INVERTING_PROXY_URL="$CCM_V2_INVERTING_PROXY_HOST"
+
+  update-inverting-proxy-agent-values.sh "$BACKEND_ID" "$BACKEND_HOST" "$BACKEND_PORT" "$AGENT_KEY_PATH" "$AGENT_CERT_PATH" "$TRUSTED_BACKEND_CERT_PATH" "$TRUSTED_PROXY_CERT_PATH" "$INVERTING_PROXY_URL"
+}
+
 setup_ssh_proxy() {
   : ${PROXY_HOST:? required}
   : ${PROXY_PORT:? required}
@@ -205,7 +240,10 @@ main() {
 
     if [[ "$IS_CCM_ENABLED" == "true" ]]; then
       setup_ccm
+    elif [[ "$IS_CCM_V2_ENABLED" == "true" ]]; then
+      setup_ccmv2
     fi
+
     echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/cb-init-executed
   fi
   [ -e /usr/bin/ssh-aliases ] && /usr/bin/ssh-aliases create

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -15,6 +15,7 @@ base:
     - fluent
 {% endif %}
     - ccm-client
+    - ccmv2-inverting-proxy-agent
 {% if salt['environ.get']('INCLUDE_CIS') == 'Yes' %}
     - cis-controls
 {% endif %}

--- a/saltstack/hortonworks/salt/ccmv2-inverting-proxy-agent/init.sls
+++ b/saltstack/hortonworks/salt/ccmv2-inverting-proxy-agent/init.sls
@@ -1,0 +1,6 @@
+/cdp/bin/ccmv2/inverting-proxy-agent:
+  file.managed:
+    - makedirs: True
+    - source: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/7630277/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/inverting-proxy-forwarding-agent 
+    - source_hash: md5=c52126bcf800aa7f1d144eb8f183090f
+    - mode: 740

--- a/saltstack/hortonworks/salt/top.sls
+++ b/saltstack/hortonworks/salt/top.sls
@@ -15,6 +15,7 @@ hortonworks:
     - java
 {% endif %}
     - pre-warm
+    - ccmv2-inverting-proxy-agent
 {% if salt['environ.get']('INCLUDE_METERING') == 'Yes' %}
     - metering
 {% if grains['os_family'] == 'Suse' and grains['osmajorrelease'] | int == 12 %}


### PR DESCRIPTION
Salt stack is extended with install of ccmv2-inverting-proxy-agent.