### PR TITLE
CB-10271 - cloudera-scm user needs to be managed outside of CM

### DIFF
--- a/saltstack/base/salt/prerequisites/init.sls
+++ b/saltstack/base/salt/prerequisites/init.sls
@@ -1,4 +1,5 @@
 include:
+  - {{ slspath }}.user_uid
   - {{ slspath }}.repository
   - {{ slspath }}.packages
   - {{ slspath }}.sudo
@@ -16,9 +17,9 @@ include:
   - {{ slspath }}.umask
   - {{ slspath }}.jinja
   - {{ slspath }}.corkscrew
-{% if  pillar['OS'].startswith('ubuntu') %}
+{% if pillar['OS'].startswith('ubuntu') %}
   - {{ slspath }}.disable-unattended-upgrades
- {% endif %}
+{% endif %}
 
 /usr/bin/:
   file.recurse:

--- a/saltstack/base/salt/prerequisites/user_uid.sls
+++ b/saltstack/base/salt/prerequisites/user_uid.sls
@@ -1,0 +1,34 @@
+{% set ids = salt['grains.filter_by']({
+    'amazon-ebs': {
+        'cloudera_scm_user': '992',
+        'cloudera_scm_group': '988',
+    },
+    'azure-arm': {
+        'cloudera_scm_user': '991',
+        'cloudera_scm_group': '987',
+    },
+    'googlecompute': {
+        'cloudera_scm_user': '992',
+        'cloudera_scm_group': '988',
+    },
+},
+grain='builder_type',
+default='amazon-ebs'
+)%}
+
+create_cloudera_scm_group:
+  group.present:
+    - name: cloudera-scm
+    - gid: {{ ids.cloudera_scm_group }} 
+
+create_cloudera_scm_user:
+  user.present:
+    - name: cloudera-scm
+    - fullname: Cloudera Manager
+    - shell: /sbin/nologin
+    - home: /var/lib/cloudera-scm-server
+    - createhome: False
+    - uid: {{ ids.cloudera_scm_user }}
+    - gid: {{ ids.cloudera_scm_group }}     
+    - groups:
+      - cloudera-scm

--- a/scripts/salt-setup.sh
+++ b/scripts/salt-setup.sh
@@ -52,6 +52,15 @@ function add_single_role_for_cluster_salt {
   echo "${role}" >> /etc/salt/prewarmed_roles
 }
 
+function add_builder_type_grain {
+  echo "Adding ${PACKER_BUILDER_TYPE} to the grains"
+cat << EOF >> /tmp/saltstack/config/minion
+grains:
+  builder_type:
+    - ${PACKER_BUILDER_TYPE}
+EOF
+}
+
 function add_prewarmed_roles {
   if [ "${INCLUDE_FLUENT}" == "Yes" ]; then
     # Note: This will need to be changed if making changes to versions etc in the prewarmed image.
@@ -89,6 +98,7 @@ function delete_unnecessary_files() {
 
 : ${CUSTOM_IMAGE_TYPE:=$1}
 
+add_builder_type_grain
 case ${CUSTOM_IMAGE_TYPE} in
   base|"")
     echo "Running highstate for Base.."


### PR DESCRIPTION
This PR implements 2 things:
1, creates static grain called builder_type based on env var PACKER_BUILDER_TYPE to be able to distinguish between cloud platform builds
2, populates ids jinja dictionary with the correct platform-specific uid and gid of cloudera-scm

Test:
Burnt non-default image with id 0edf9095-e87f-4f9e-8b32-066e2af1ca2e in dev catalog, validated with SDX and Data Hub launch.