### PR TITLE
CB-10358: Changes to user-data-helper script to support one way TLS between inverting proxy agent and nginx

### DIFF
--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -116,6 +116,12 @@ setup_tls() {
     echo "cert-tool exists on the fs (backward compatibility)"
     create_certificates_cert_tool
   fi
+
+  if [[ "$IS_CCM_V2_ENABLED" == "true" ]]; then
+    echo "CCMv2 is enabled while creating an environment so ssl client verification is turned off and localhost:9443 used"
+    sed -i -E "s/ssl_verify_client(\s)+on;/ssl_verify_client off;/" /etc/nginx/sites-enabled/ssl-template
+    sed -i -E "s/listen(\s)+9443;/listen       localhost:9443;/" /etc/nginx/sites-enabled/ssl-template
+  fi
 }
 
 setup_ccm() {


### PR DESCRIPTION
If CCMv2 is enabled while creating an environment, then ssl verify client parameter should be turned off and the nginx should listen in localhost:9443.