### PR TITLE
CB-8933: Harden SSH Configurations

### DIFF
--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -74,13 +74,6 @@ sshd_harden_addressLoginGraceTime:
     - repl: "LoginGraceTime 60"
     - append_if_not_found: True
 
-sshd_harden_sshIdealTime:
-  file.replace:
-    - name: /etc/ssh/sshd_config
-    - pattern: "^ClientAliveInterval.*"
-    - repl: "ClientAliveInterval 600 ClientAliveCountMax 0"
-    - append_if_not_found: True
-
 sshd_harden_ssh2:
   file.replace:
     - name: /etc/ssh/sshd_config

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -16,7 +16,5 @@ base:
 {% endif %}
     - ccm-client
     - ccmv2-inverting-proxy-agent
-{% if salt['environ.get']('INCLUDE_CIS') == 'Yes' %}
     - cis-controls
-{% endif %}
     - custom


### PR DESCRIPTION
Eliminating **SSH sshIdealTime** configuration due to e2e test failure for further investigation.