### PR TITLE
CB-10969 | Update the CB user data script and corresponding files to …

### DIFF
--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/cdp/bin/ccmv2/run-inverting-proxy-agent.sh
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/cdp/bin/ccmv2/run-inverting-proxy-agent.sh
@@ -8,4 +8,4 @@ BACKEND_ID=$1
 
 . /cdp/bin/ccmv2/inverting-proxy-agent-values-${BACKEND_ID}.sh
 
-exec /cdp/bin/ccmv2/inverting-proxy-agent -scheme ${SCHEME} -proxy ${INVERTING_PROXY_URL} -host ${BACKEND_ADDRESS} -backend ${BACKEND_ID} -disable-gce-vm-header=true -trusted-proxy-cert-path ${TRUSTED_PROXY_CERT_PATH} -trusted-backend-cert-path ${TRUSTED_BACKEND_CERT_PATH} -cert-path ${AGENT_CERT_PATH} -key-path ${AGENT_KEY_PATH}
+exec /cdp/bin/ccmv2/inverting-proxy-agent -scheme ${SCHEME} -proxy ${INVERTING_PROXY_URL} -host ${BACKEND_ADDRESS} -backend ${BACKEND_ID} -disable-gce-vm-header=true -trusted-proxy-cert-path ${TRUSTED_PROXY_CERT_PATH} -trusted-backend-cert-path ${TRUSTED_BACKEND_CERT_PATH} -cert-path ${AGENT_CERT_PATH} -key-path ${AGENT_KEY_PATH} -http-proxy-url=${HTTP_PROXY_URL}

--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh
@@ -5,10 +5,11 @@
 
 ARG_ERR=0
 
-if [[ "$#" -lt 7 || "$#" -gt 9 ]]; then
-  echo "Wrong number of arguments passed. The script requires 8 arguments to be passed for 'BACKEND_ID', 'BACKEND_HOST', 'BACKEND_PORT', 'AGENT_KEY_PATH', 'AGENT_CERT_PATH', 'TRUSTED_BACKEND_CERT_PATH' AND 'TRUSTED_PROXY_CERT_PATH'."
+if [[ "$#" -lt 7 || "$#" -gt 10 ]]; then
+  echo "Wrong number of arguments passed. The script requires 7 arguments to be passed for 'BACKEND_ID', 'BACKEND_HOST', 'BACKEND_PORT', 'AGENT_KEY_PATH', 'AGENT_CERT_PATH', 'TRUSTED_BACKEND_CERT_PATH' AND 'TRUSTED_PROXY_CERT_PATH'."
   echo "An optional 8th argument for 'INVERTING_PROXY_URL' can be passed. If not passed, the environment variable INVERTING_PROXY_URL will be used."
-  echo "An optional 9th argument for 'SCHEME' can be passed. If not passed, the value 'https' will be used."
+  echo "An optional 9th argument for 'HTTP_PROXY_URL' can be passed. If not passed, no proxy will be used."
+  echo "An optional 10th argument for 'SCHEME' can be passed. If not passed, the value 'https' will be used."
   ARG_ERR=1
 fi
 
@@ -19,7 +20,9 @@ if [ -z "$INVERTING_PROXY_URL" ]; then
   ARG_ERR=1
 fi
 
-SCHEME=${9:-https}
+HTTP_PROXY_URL=${9:-""}
+
+SCHEME=${10:-https}
 
 if [ $ARG_ERR -eq 1 ] ; then
   exit 1
@@ -44,6 +47,7 @@ AGENT_CERT_PATH=${AGENT_CERT_PATH}
 TRUSTED_BACKEND_CERT_PATH=${TRUSTED_BACKEND_CERT_PATH}
 TRUSTED_PROXY_CERT_PATH=${TRUSTED_PROXY_CERT_PATH}
 SCHEME=${SCHEME}
+HTTP_PROXY_URL=${HTTP_PROXY_URL}
 EOF
 
 if [ -f "$VALUES_FILE" ]; then

--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -190,7 +190,11 @@ setup_ccmv2() {
   # A more sophisticated solution might need to be patched in later - tbh the script originally expected a full url with protocol scheme and closing slash
   INVERTING_PROXY_FULL_URL="https://$INVERTING_PROXY_URL/"
 
-  /cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh "$BACKEND_ID" "$BACKEND_HOST" "$BACKEND_PORT" "$AGENT_KEY_PATH" "$AGENT_CERT_PATH" "$TRUSTED_BACKEND_CERT_PATH" "$TRUSTED_PROXY_CERT_PATH" "$INVERTING_PROXY_FULL_URL"
+  if [[ "$IS_PROXY_ENABLED" == "true" ]]; then
+    HTTP_PROXY_URL="http://$PROXY_HOST:$PROXY_PORT"
+  fi
+
+  /cdp/bin/ccmv2/update-inverting-proxy-agent-values.sh "$BACKEND_ID" "$BACKEND_HOST" "$BACKEND_PORT" "$AGENT_KEY_PATH" "$AGENT_CERT_PATH" "$TRUSTED_BACKEND_CERT_PATH" "$TRUSTED_PROXY_CERT_PATH" "$INVERTING_PROXY_FULL_URL" "$HTTP_PROXY_URL"
 }
 
 setup_ssh_proxy() {


### PR DESCRIPTION
…include an argument to support http proxy while running inverting proxy agent.

The variable `IS_PROXY_ENABLED` passed on from CB java code that signifies if a non transparent proxy is used or not for env creation. Based on this value, we construct the http proxy URL using the variables `PROXY_HOST` and `PROXY_PORT`. This is identical to what is done for CCMv1.

Please note that the assumption here is that the variables `IS_PROXY_ENABLED`, `PROXY_HOST` and `PROXY_PORT` continue to work like they do in the case of CCMv1

Tested the changes on a local CDH cluster to see if the scripts work and they work as expected.

@TheTinkerDad please add others for review as required.

Thanks