### PR TITLE
Improves CIS based on recent test failures

### DIFF
--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -74,12 +74,13 @@ sshd_harden_addressLoginGraceTime:
     - repl: "LoginGraceTime 60"
     - append_if_not_found: True
 
-sshd_harden_sshIdealTime:
-  file.replace:
-    - name: /etc/ssh/sshd_config
-    - pattern: "^ClientAliveInterval.*"
-    - repl: "ClientAliveInterval 600 ClientAliveCountMax 0"
-    - append_if_not_found: True
+# Broken in e2e tests - see CB-8933 / CB-10728
+#sshd_harden_sshIdealTime:
+#  file.replace:
+#    - name: /etc/ssh/sshd_config
+#    - pattern: "^ClientAliveInterval.*"
+#    - repl: "ClientAliveInterval 600 ClientAliveCountMax 0"
+#    - append_if_not_found: True
 
 sshd_harden_ssh2:
   file.replace:

--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -2,7 +2,10 @@
 #https://jira.cloudera.com/browse/CB-8897
 
 {% if pillar['OS'] == 'centos7' %}
-{% set filesystems = ['cramfs', 'freevxfs', 'jffs2', 'hfs', 'hfsplus', 'squashfs', 'udf'] %}
+
+# fat is required
+# udf is required for Azure to mount cdrom - See CB-11012
+{% set filesystems = ['cramfs', 'freevxfs', 'jffs2', 'hfs', 'hfsplus', 'squashfs'] %}
 
 {% for fs in filesystems %}
 

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -16,7 +16,5 @@ base:
 {% endif %}
     - ccm-client
     - ccmv2-inverting-proxy-agent
-{% if salt['environ.get']('INCLUDE_CIS') == 'Yes' %}
     - cis-controls
-{% endif %}
     - custom


### PR DESCRIPTION
There are 3 separate commits in this PR:
* Remove SSH ClientAlive timeout since @bormanbhaskar noticed it caused e2e test failures
** This was previously handled in https://github.com/hortonworks/cloudbreak-images/commit/fb48c04f78035f771ce21b7002e204ee106556bf
* Ensure udf filesystem is not disabled due to Azure needing it
** This could probably be split into Azure specifically with conditionals - but added as a comment for later
* Reenabled the CIS controls by default
** This is a separate commit so if necessary it can be reverted separately and not tied into any of the functionality changes

If/when this is merged - would be good to keep the separate commits instead of squashing them together if possible.