### PR TITLE
CB-8925, CB-8926: CIS hardening

### DIFF
--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -1,4 +1,4 @@
-#CentOS Disable unused filesystems
+#### CIS: Disable unused filesystems
 #https://jira.cloudera.com/browse/CB-8897
 
 {% if pillar['OS'] == 'centos7' %}
@@ -25,7 +25,7 @@
         - onlyif: "lsmod | grep {{ fs }}"
 {% endfor %}
 
-#CentOS - Harden SSH Configurations
+#### CIS: Harden SSH Configurations
 #https://jira.cloudera.com/browse/CB-8933
 
 sshd_harden_addressX11:
@@ -127,14 +127,14 @@ sshd_harden_LogLevel:
     - repl: "LogLevel INFO"
     - append_if_not_found: True
 
-# CIS - Ensure unnecessary services/softwareClients are removed
+#### CIS: Ensure unnecessary services/softwareClients are removed
 # https://jira.cloudera.com/browse/CB-8926
 
 Ensure_X_Window_System_is_not_installed:
   cmd.run:
         - name: yum remove xorg-x11*
 
-# CIS - Ensure core dumps are restricted
+#### CIS: Ensure core dumps are restricted
 # https://jira.cloudera.com/browse/CB-8925
 
 #Restrict_Core_dumps_part1:
@@ -145,10 +145,9 @@ Create_limits.conf:
 Update_limits.conf:
   file.replace:
     - name: /etc/security/limits.conf
-    - pattern: "* hard core 0"
+    - pattern: "\* hard core 0"
     - repl: "* hard core 0"
     - append_if_not_found: True
-
 #Restrict_Core_dumps_part2:
 Create_sysctl.conf:
   cmd.run:

--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -134,4 +134,21 @@ Ensure_X_Window_System_is_not_installed:
   cmd.run:
         - name: yum remove xorg-x11*
 
+# CIS - Ensure core dumps are restricted
+# https://jira.cloudera.com/browse/CB-8925
+
+Restrict_Core_dumps:
+  file.replace:
+    - name: /etc/security/limits.conf
+    - pattern: "* hard core 0"
+    - repl: "* hard core 0"
+    - append_if_not_found: True
+  file.replace:
+    - name: /etc/sysctl.conf
+    - pattern: "fs.suid_dumpable = 0"
+    - repl: "fs.suid_dumpable = 0"
+    - append_if_not_found: True
+  cmd.run:
+    - name: sysctl -w fs.suid_dumpable=0
+
 {% endif %}

--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -145,8 +145,8 @@ Create_limits.conf:
 Update_limits.conf:
   file.replace:
     - name: /etc/security/limits.conf
-    - pattern: "\* hard core 0"
-    - repl: "* hard core 0"
+    - pattern: '\* hard core 0'
+    - repl: '* hard core 0'
     - append_if_not_found: True
 #Restrict_Core_dumps_part2:
 Create_sysctl.conf:

--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -137,19 +137,30 @@ Ensure_X_Window_System_is_not_installed:
 # CIS - Ensure core dumps are restricted
 # https://jira.cloudera.com/browse/CB-8925
 
-Restrict_Core_dumps_part1:
+#Restrict_Core_dumps_part1:
+Create_limits.conf:
+  cmd.run:
+    - name: touch /etc/security/limits.conf
+    - unless: test -f /etc/security/limits.conf
+Update_limits.conf:
   file.replace:
     - name: /etc/security/limits.conf
     - pattern: "* hard core 0"
     - repl: "* hard core 0"
     - append_if_not_found: True
-Restrict_Core_dumps_part2:
+
+#Restrict_Core_dumps_part2:
+Create_sysctl.conf:
+  cmd.run:
+    - name: touch /etc/sysctl.conf
+    - unless: test -f /etc/sysctl.conf
+Update_sysctl.conf:
   file.replace:
     - name: /etc/sysctl.conf
     - pattern: "fs.suid_dumpable = 0"
     - repl: "fs.suid_dumpable = 0"
     - append_if_not_found: True
+Disable_dump:  
   cmd.run:
     - name: sysctl -w fs.suid_dumpable=0
-
 {% endif %}

--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -126,4 +126,12 @@ sshd_harden_LogLevel:
     - pattern: "^LogLevel"
     - repl: "LogLevel INFO"
     - append_if_not_found: True
+
+# CIS - Ensure unnecessary services/softwareClients are removed
+# https://jira.cloudera.com/browse/CB-8926
+
+Ensure_X_Window_System_is_not_installed:
+  cmd.run:
+        - name: yum remove xorg-x11*
+
 {% endif %}

--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -132,7 +132,7 @@ sshd_harden_LogLevel:
 
 Ensure_X_Window_System_is_not_installed:
   cmd.run:
-        - name: yum remove xorg-x11*
+    - name: yum remove xorg-x11*
 
 #### CIS: Ensure core dumps are restricted
 # https://jira.cloudera.com/browse/CB-8925

--- a/saltstack/base/salt/cis-controls/init.sls
+++ b/saltstack/base/salt/cis-controls/init.sls
@@ -137,12 +137,13 @@ Ensure_X_Window_System_is_not_installed:
 # CIS - Ensure core dumps are restricted
 # https://jira.cloudera.com/browse/CB-8925
 
-Restrict_Core_dumps:
+Restrict_Core_dumps_part1:
   file.replace:
     - name: /etc/security/limits.conf
     - pattern: "* hard core 0"
     - repl: "* hard core 0"
     - append_if_not_found: True
+Restrict_Core_dumps_part2:
   file.replace:
     - name: /etc/sysctl.conf
     - pattern: "fs.suid_dumpable = 0"


### PR DESCRIPTION
This PR contains below updates:
1. CB-8926: Ensuring X-Window system is not installed
2. CB-8925: Restricting Core Dumps

The changes were tested for both aws and azure and the results can be seen below:
**AWS**
_http://build.eng.hortonworks.com:8080/job/cloudbreak-image-burn-salt-v3/14945/
http://build.eng.hortonworks.com:8080/job/cloudbreak-multi-packer-image-builder-salt-v3/2538/
http://build.eng.hortonworks.com:8080/job/imagecatalog-v3-append/1788/
http://ci-cloudbreak.eng.hortonworks.com/view/e2e-test/job/api-e2e-imagevalidator-aws/1056/_
**Azure**
_http://build.eng.hortonworks.com:8080/job/cloudbreak-image-burn-salt-v3/14946/
http://build.eng.hortonworks.com:8080/job/cloudbreak-multi-packer-image-builder-salt-v3/2540/
http://build.eng.hortonworks.com:8080/job/imagecatalog-v3-append/1790/
http://ci-cloudbreak.eng.hortonworks.com/view/e2e-test/job/api-e2e-imagevalidator-azure/1028/_