### PR TITLE
CDPAM-1373 | update the URL for inverting proxy agent

### DIFF
--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/init.sls
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/init.sls
@@ -21,6 +21,6 @@
 /cdp/bin/ccmv2/inverting-proxy-agent:
   file.managed:
     - makedirs: True
-    - source: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/9337444/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/inverting-proxy-forwarding-agent
-    - source_hash: md5=49c57d64f5b3382d6cf1cd45cc104e73
+    - source: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/10285219/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/inverting-proxy-forwarding-agent
+    - source_hash: md5=b796af855d71492deaa80e4532a892a8
     - mode: 740


### PR DESCRIPTION
- Updated the GBN of the inverting proxy agent binary with the latest one.
- Updated the md5sum value of the latest agent binary file. `md5sum <path of the latest agent binary downloaded from RE portal>