### PR TITLE
CB-10092: Adding an image for haproxy for YCloud loadbalancer support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build.sh
 !.dockerignore
 packer_no_pp.json
 test-folder
+*.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,10 @@ docker-build-centos76:
 	echo "Building image for ycloud2"
 	@ OS=centos7 OS_TYPE=redhat7 TAG=centos-76 DIR=centos7.6 make docker-build
 
+docker-build-yarn-loadbalancer:
+	echo "Building loadbalancer image for ycloud2"
+	@ OS=centos7 OS_TYPE=redhat7 TAG=yarn-loadbalancer DIR=yarn-loadbalancer make docker-build
+
 docker-build:
 	$(eval DOCKER_ENVS="OS=$(OS) OS_TYPE=$(OS_TYPE) SALT_VERSION=$(SALT_VERSION) SALT_PATH=$(SALT_PATH) PYZMQ_VERSION=$(PYZMQ_VERSION) PYTHON_APT_VERSION=$(PYTHON_APT_VERSION) TRACE=1")
 	$(eval DOCKER_BUILD_ARGS=$(shell echo ${DOCKER_ENVS} | xargs -n 1 echo "--build-arg " | xargs))

--- a/docker/yarn-loadbalancer/Dockerfile
+++ b/docker/yarn-loadbalancer/Dockerfile
@@ -1,0 +1,25 @@
+FROM docker-sandbox.infra.cloudera.com/cloudbreak/base-centos7.6:0.1.0.0-88
+ARG PRE_WARM_PARCELS
+ARG PRE_WARM_CSD
+
+ENV PRE_WARM_PARCELS=${PRE_WARM_PARCELS}
+ENV PRE_WARM_CSD=${PRE_WARM_CSD}
+
+#we build logic on the existance of this directory, please DO NOT REMOVE
+RUN mkdir /yarn-private
+RUN touch /yarn-private/logs
+
+# Haproxy setup.
+RUN yum install haproxy -y
+ADD docker/yarn-loadbalancer/configuration-files/haproxy.cfg /tmp/
+
+# Startup script.
+ADD docker/yarn-loadbalancer/image-runtime-scripts/start-services-script.sh /bootstrap/
+RUN chmod +x /bootstrap/start-services-script.sh
+
+#################################################################################
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+ENTRYPOINT ["/bootstrap/start-systemd"]
+CMD []

--- a/docker/yarn-loadbalancer/configuration-files/haproxy.cfg
+++ b/docker/yarn-loadbalancer/configuration-files/haproxy.cfg
@@ -1,0 +1,15 @@
+global
+    maxconn 2000
+defaults
+    retries 3
+    option redispatch
+    timeout connect 5000
+    timeout client 10000
+    timeout server 10000
+frontend localnodes
+    bind *:443
+    mode tcp
+    default_backend nodes
+backend nodes
+    mode tcp
+    balance roundrobin

--- a/docker/yarn-loadbalancer/image-runtime-scripts/start-services-script.sh
+++ b/docker/yarn-loadbalancer/image-runtime-scripts/start-services-script.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+###
+# CloudBreak uses unbound as a caching name server. Docker bind-mounts
+# /etc/resolv.conf file that is why resolvconf package cannot be used
+# as it tries to replace it with a symlink. A workaround is to tranform
+# resolv.conf into unbound configuration and set unbound as a nameserver.
+###
+echo 'forward-zone:' >/etc/unbound/conf.d/99-default.conf
+echo '  name: "."' >>/etc/unbound/conf.d/99-default.conf
+for nameserver in $(awk '/^nameserver/{print $2}' /etc/resolv.conf); do
+  echo "  forward-addr: ${nameserver}" >>/etc/unbound/conf.d/99-default.conf
+done
+
+echo 'forward-zone:' >>/etc/unbound/conf.d/99-default.conf
+echo '  name: "in-addr.arpa."' >>/etc/unbound/conf.d/99-default.conf
+for nameserver in $(awk '/^nameserver/{print $2}' /etc/resolv.conf); do
+  echo "  forward-addr: ${nameserver}" >>/etc/unbound/conf.d/99-default.conf
+done
+
+echo "nameserver 127.0.0.1" >/etc/resolv.conf
+
+#### Generate input for Ambari from container_limits generated dynamically by YARN
+echo "using container_limits to create system resource overrides for ambari"
+memoryMb=`cat container_limits | grep memory= | awk -F= '{print $2}'`
+memoryKb=`expr $memoryMb \* 1024`
+cpu=`cat container_limits | grep vcores= | awk -F= '{print $2}'`
+mkdir -p /yarn-private/ambari/
+cat <<EOF > /yarn-private/ambari/ycloud.json
+{
+    "processorcount": "$cpu",
+    "physicalprocessorcount": "$cpu",
+    "memorysize": "$memoryKb",
+    "memoryfree": "$memoryKb",
+    "memorytotal": "$memoryKb"
+}
+EOF
+
+echo "Successfully ran start-services-script." >> /yarn-private/logs
+
+# Run haproxy service.
+echo "Attempting to start haproxy service." >> /yarn-private/logs
+
+source /etc/cloudbreak-loadbalancer.props
+
+# Edit configuration file.
+SERVERS=(${servers})
+tabs 4
+
+i=0
+for server in "${SERVERS[@]}"
+do
+    server=$(echo ${server} | sed 's#\\##g')
+    printf "\tserver server%s %s check\n" "${i}" "${server}" >> /tmp/haproxy.cfg
+    i=$((i+1))
+done
+
+echo "Finished setting up haproxy.cfg!" >> /yarn-private/logs
+
+# Run haproxy.
+haproxy -f /tmp/haproxy.cfg &
+echo "Successfully started the haproxy service!" >> /yarn-private/logs
+
+# Finish.
+systemctl enable sshd
+exec -l /usr/lib/systemd/systemd --system


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-10092

This serves to add a new image to be used for YCloud datalake loadbalancers. I am curious as to how the image is put into the official Cloudera catalog, do I have to do anything for that or will it be done automatically?

Specifically, this will simply run the haproxy service, pointing at the gateway servers. I based this off the centos7 image and removed all of the extraneous Salt stuff. Please let me know if I can remove anything else to make this light.

This has been tested with a light duty  and a medium duty YCloud datalake and has worked. 

The test catalog that is in this branch will be deleted before I merge anything, I am just pointing my local cloudbreak at it for testing at the moment.

Thanks!