### PR TITLE
CB-11684 | Do not create private key file if already present

### DIFF
--- a/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
@@ -26,7 +26,7 @@ if [ ! -f ${PRIVATE_KEY} ]; then
             -iv ${IV} > ${PRIVATE_KEY}
     fi
 else
-    echo "Private key file already exists at ${PRIVATE_KEY}"
+    echo "Private key file already exists at ${PRIVATE_KEY}. Would continue with restart. "
 fi
 
 chmod 400 ${PRIVATE_KEY}

--- a/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
@@ -16,13 +16,17 @@ ROOT_FOLDER=/etc/autossh
 mkdir -p $ROOT_FOLDER
 PRIVATE_KEY=${ROOT_FOLDER}/pk.key
 
-if grep -q "BEGIN" ${CCM_ENCIPHERED_PRIVATE_KEY_FILE}; then
-    cat ${CCM_ENCIPHERED_PRIVATE_KEY_FILE} > ${PRIVATE_KEY}
+if [ ! -f ${PRIVATE_KEY} ]; then
+    if grep -q "BEGIN" ${CCM_ENCIPHERED_PRIVATE_KEY_FILE}; then
+        cat ${CCM_ENCIPHERED_PRIVATE_KEY_FILE} > ${PRIVATE_KEY}
+    else
+        IV=436c6f7564657261436c6f7564657261
+        cat ${CCM_ENCIPHERED_PRIVATE_KEY_FILE} | openssl enc -aes-128-cbc -d -A -a \
+            -K $(xxd -pu <<< $(echo ${CCM_KEY_ID} | cut -c1-16) | cut -c1-32) \
+            -iv ${IV} > ${PRIVATE_KEY}
+    fi
 else
-    IV=436c6f7564657261436c6f7564657261
-    cat ${CCM_ENCIPHERED_PRIVATE_KEY_FILE} | openssl enc -aes-128-cbc -d -A -a \
-        -K $(xxd -pu <<< $(echo ${CCM_KEY_ID} | cut -c1-16) | cut -c1-32) \
-        -iv ${IV} > ${PRIVATE_KEY}
+    echo "Private key file already exists at ${PRIVATE_KEY}"
 fi
 
 chmod 400 ${PRIVATE_KEY}


### PR DESCRIPTION
As part of [ENGESC-7388](https://jira.cloudera.com/browse/ENGESC-7388), we found that when storage is completely filled up on customer's cluster node and if autossh process gets restarted then the private key file gets corrupted and caused tunnel down downtime due to authentication failure which is not expected behavior. so As part of this PR, I am adding a check which would create a private key file only if it is not present and we can be safe from that restart scenario as on restart file would be already there.