### PR TITLE
CB-10822:Tune default value of net.ipv4.tcp_retries2 to 7 ootb for cdp clusters

### DIFF
--- a/saltstack/base/salt/prerequisites/sysctl.sls
+++ b/saltstack/base/salt/prerequisites/sysctl.sls
@@ -49,3 +49,7 @@ vm.dirty_background_ratio:
 vm.dirty_ratio:
   sysctl.present:
     - value: 80
+
+net.ipv4.tcp_retries2:
+  sysctl.present:
+    - value: 7


### PR DESCRIPTION
The value of net.ipv4.tcp_retries2 is changed to 7 which is 15 by default earlier. Screenshots for the value before and after the change (tested with base ami bake):

Before:
<img width="824" alt="Screenshot 2021-03-18 at 8 12 45 PM" src="https://user-images.githubusercontent.com/7271603/111645004-5e782900-8826-11eb-9eb5-942711408d66.png">

Post the change:

<img width="658" alt="Screenshot 2021-03-18 at 8 12 57 PM" src="https://user-images.githubusercontent.com/7271603/111645096-6cc64500-8826-11eb-8ae9-19732362b2d8.png">
