### PR TITLE
CDPAM-1403 | Add logrotate conf to enable log rotation for ccmv2 agent logs

### DIFF
--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/etc/logrotate/conf/ccmv2-inverting-proxy-agent
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/etc/logrotate/conf/ccmv2-inverting-proxy-agent
@@ -1,0 +1,6 @@
+/var/log/ccmv2-inverting-proxy-agent.log {
+    missingok
+    notifempty
+    size 128M
+    rotate 6
+}

--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/init.sls
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/init.sls
@@ -24,3 +24,11 @@
     - source: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/10357171/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/inverting-proxy-forwarding-agent
     - source_hash: md5=7f70dfabc86b9afaa827b3dde851e3a6
     - mode: 740
+
+/etc/logrotate/conf/ccmv2-inverting-proxy-agent:
+  file.managed:
+    - name: /etc/logrotate.d/ccmv2-inverting-proxy-agent
+    - source: salt://{{ slspath }}/etc/logrotate/conf/ccmv2-inverting-proxy-agent
+    - user: root
+    - group: root
+    - mode: 644


### PR DESCRIPTION
In this PR I have added a logrotate configuration file for ccmv2-inverting-proxy-agent's log to rotate the log every 6 days or when the size is 128MB. The `init.sls` script is updated to trigger this logrotate policy as well.
The configuration follows the rules for https://github.com/hortonworks/cloudbreak/blob/master/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/ipabackup. 
