### PR TITLE
CB-11774 Include stack patch version and seconds into the image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ SALT_VERSION ?= 3000.8
 SALT_PATH ?= /opt/salt_$(SALT_VERSION)
 PYZMQ_VERSION ?= 19.0
 PYTHON_APT_VERSION ?= 1.1.0_beta1ubuntu0.16.04.1
-STACK_VERSION_SHORT=$(STACK_TYPE)-$(shell echo $(STACK_VERSION) | tr -d . | cut -c1-2 )
+STACK_VERSION_SHORT=$(STACK_TYPE)-$(shell echo $(STACK_VERSION) | tr -d . | cut -c1-3 )
 ifndef IMAGE_NAME
-	IMAGE_NAME ?= $(BASE_NAME)-$(shell echo $(STACK_VERSION_SHORT) | tr '[:upper:]' '[:lower:]')-$(shell date +%y%m%d%H%M)$(IMAGE_NAME_SUFFIX)
+	IMAGE_NAME ?= $(BASE_NAME)-$(shell echo $(STACK_VERSION_SHORT) | tr '[:upper:]' '[:lower:]')-$(shell date +%y%m%d%H%M%S)$(IMAGE_NAME_SUFFIX)
 endif
 
 IMAGE_SIZE ?= 30


### PR DESCRIPTION
Image name length change affects GCP and Azure. Both are verified:
http://ci-cloudbreak.eng.hortonworks.com/view/e2e-test/job/api-e2e-imagevalidator-azure/1123/
http://ci-cloudbreak.eng.hortonworks.com/view/e2e-test/job/api-e2e-imagevalidator-gcp/178/