### PR TITLE
CDPAM-1544 | Update the inverting proxy agent version with the fix for CDPAM-1544

### DIFF
--- a/saltstack/base/salt/ccmv2-inverting-proxy-agent/init.sls
+++ b/saltstack/base/salt/ccmv2-inverting-proxy-agent/init.sls
@@ -21,8 +21,8 @@
 /cdp/bin/ccmv2/inverting-proxy-agent:
   file.managed:
     - makedirs: True
-    - source: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/12177414/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/inverting-proxy-forwarding-agent
-    - source_hash: md5=3f8c5a823764596da602bc8f72f6ef35
+    - source: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/12345618/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/inverting-proxy-forwarding-agent
+    - source_hash: md5=ac83887cf11d4b8498dc9bd51311a9da
     - mode: 740
 
 /etc/logrotate/conf/ccmv2-inverting-proxy-agent:


### PR DESCRIPTION
Downgrade go version to 1.14.8 to suppress the issue with using wildcards in CN field of inverting proxy server cert