### PR TITLE
CB-12248 Set the net.ipv4.tcp_keepalive_time to 300 to avoid rare NLB…

### DIFF
--- a/saltstack/base/salt/prerequisites/sysctl.sls
+++ b/saltstack/base/salt/prerequisites/sysctl.sls
@@ -14,6 +14,10 @@ net.ipv4.ip_local_port_range:
   sysctl.present:
     - value: "32768 61000"
 
+net.ipv4.tcp_keepalive_time:
+  sysctl.present:
+    - value: 300
+
 net.core.netdev_max_backlog:
    sysctl.present:
     - value: 20000


### PR DESCRIPTION
… timeouts

1. In DE HA cluster there is an occasional timeout for beeline queries.
2. NLB idle-timeout is 350s compared to the system keepalive time of 2 hours in manager node.
3. To make sure the clients never get an RST because the NLB connection was idle-timeout reduce keep alive timeout value below 350.

No testing done, based on an analysis from a blog post https://medium.com/tenable-techblog/lessons-from-aws-nlb-timeouts-5028a8f65dda