### PR TITLE
Remove unused pip deps.

### DIFF
--- a/saltstack/base/salt/prerequisites/pip.sls
+++ b/saltstack/base/salt/prerequisites/pip.sls
@@ -34,21 +34,6 @@ install_pyyaml:
     - name: pip install PyYAML --ignore-installed
     - unless: pip list | grep -E 'PyYAML'
 
-install_cm_client:
-  cmd.run:
-    - name: pip install cm-client==40.0.3 --ignore-installed
-    - unless: pip list | grep -E 'cm-client.*40.0.3'
-
-install_fluent_logger:
-  cmd.run:
-    - name: pip install fluent-logger>=0.9.6 --ignore-installed
-    - unless: pip list --no-index | grep -E 'fluent-logger'
-
-install_pid:
-  cmd.run:
-    - name: pip install pid --ignore-installed
-    - unless: pip list --no-index | grep -E 'pid'
-
 install_jq:
   file.managed:
     - name: /usr/bin/jq


### PR DESCRIPTION
filecollector: pid, fluent-logger
metrics collector: cm_client
(both filecollector and metrics collector is part of cdp-telemetry binary, which has these dependencies compiled to c code)