### PR TITLE
CDPAM-1531. Update cdp-telemetry version (role: v8 , version: 0.4.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ FLUENT_PREWARM_TAG ?= "fluent_prewarmed_v3"
 # This needs to be changed if there is a version change in metering heartbeat component. See usage in the salt files in the Cloudbreak repo.
 METERING_PREWARM_TAG ?= "metering_prewarmed_v3"
 # This needs to be changed if there is a version change in cdp-telemetry cli component. See usage in the salt files in the Cloudbreak repo.
-CDP_TELEMETRY_PREWARM_TAG ?= "cdp_telemetry_prewarmed_v7"
+CDP_TELEMETRY_PREWARM_TAG ?= "cdp_telemetry_prewarmed_v8"
 # This needs to be changed if there is a version change in components other than fluent, or if there are relevant changes to the salt scripts in Cloudbreak.
 PREWARM_TAG ?= "prewarmed_v1"
 

--- a/saltstack/base/salt/telemetry/init.sls
+++ b/saltstack/base/salt/telemetry/init.sls
@@ -1,6 +1,6 @@
 ## see more at internal repo: thunderhead/cdp-telemetry-cli
 {% set os = salt['environ.get']('OS') %}
-{% set cdp_telemetry_version = '0.4.2' %}
+{% set cdp_telemetry_version = '0.4.3' %}
 {% set cdp_telemetry_rpm_location = 'https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-telemetry/'%}
 {% set cdp_telemetry_rpm_repo_url = cdp_telemetry_rpm_location + 'cdp_telemetry-' + cdp_telemetry_version + '.x86_64.rpm' %}
 


### PR DESCRIPTION
see https://github.com/hortonworks/cloudbreak-images/pull/551 regarding the changes (cdp-telemetry - cdp-doctor support for the commands)