### PR TITLE
CB-12420: Remove node exporter from FreeIPA health agent checks

### DIFF
--- a/saltstack/freeipa/salt/freeipa/init.sls
+++ b/saltstack/freeipa/salt/freeipa/init.sls
@@ -5,7 +5,7 @@
       + '.x86_64.rpm' %}
 
 {% set freeipa_healthagent_base_url = 'https://cloudera-service-delivery-cache.s3.amazonaws.com/freeipa-health-agent/packages/' %}
-{% set freeipa_healthagent_version = '0.1-20201005182915gitddf435a' %}
+{% set freeipa_healthagent_version = '0.1-20210511182923git9197412' %}
 {% set freeipa_healthagent_rpm_url = freeipa_healthagent_base_url
       + 'freeipa-health-agent-' + freeipa_healthagent_version
       + '.x86_64.rpm' %}


### PR DESCRIPTION
Remove node exporter check from the health agent as we are going to remove this from the images. The thunderhead jenkins build is " Agent Cloudera FreeIPA Health freeipa-health-agent = 0.1-20210511182923git9197412 freeipa-health-agent(x86-64) = 0.1-20210511182923git9197412"