### PR TITLE
Revert "CB-12420: Remove node exporter from FreeIPA health agent checks"

### DIFF
--- a/saltstack/freeipa/salt/freeipa/init.sls
+++ b/saltstack/freeipa/salt/freeipa/init.sls
@@ -5,7 +5,7 @@
       + '.x86_64.rpm' %}
 
 {% set freeipa_healthagent_base_url = 'https://cloudera-service-delivery-cache.s3.amazonaws.com/freeipa-health-agent/packages/' %}
-{% set freeipa_healthagent_version = '0.1-20210511182923git9197412' %}
+{% set freeipa_healthagent_version = '0.1-20201005182915gitddf435a' %}
 {% set freeipa_healthagent_rpm_url = freeipa_healthagent_base_url
       + 'freeipa-health-agent-' + freeipa_healthagent_version
       + '.x86_64.rpm' %}


### PR DESCRIPTION
Reverts hortonworks/cloudbreak-images#564

as the version is wrong. 

The correct one is this one. And I've verified it by install the rpm
freeipa-health-agent-0.1-20210517150203gitab017e0.x86_64.rpm