### PR TITLE
CDPAM-1771: Cluster Proxy fails with Kubernetes due to an internal error

### DIFF
--- a/saltstack/base/salt/ccmv2/init.sls
+++ b/saltstack/base/salt/ccmv2/init.sls
@@ -16,4 +16,4 @@
 install_jumpgate_agent:
   pkg.installed:
     - sources:
-      - jumpgate-agent: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/14100647/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm
+      - jumpgate-agent: https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/14365581/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm


### PR DESCRIPTION
Bumps version of agent to 1.0.0-b117. This allows connections to remote un-trusted endpoints.

This is required for experiences to connect to vendor managed Kubernetes clusters.