### PR TITLE
CDPAM-1816 | access logs dont get created for jumpgate agent

### DIFF
--- a/saltstack/base/salt/ccmv2/init.sls
+++ b/saltstack/base/salt/ccmv2/init.sls
@@ -16,4 +16,4 @@
 install_jumpgate_agent:
   pkg.installed:
     - sources:
-      - jumpgate-agent: https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/14365581/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm
+      - jumpgate-agent: https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/15246760/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm


### PR DESCRIPTION
The test builds haven't been triggered yet due to https://jira.cloudera.com/browse/RELENG-14321 . In the meantime, please review this.

The build number is **1.0.0-b137**