### PR TITLE
CDPR-33 Install awscli from archive instead of package manager

### DIFF
--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -57,12 +57,28 @@ packages_install:
       - openldap
       - openldap-clients
       - openldap-devel
-#      - awscli
       - nmap-ncat
       - telnet
       - tcpdump
 
 {% if pillar['subtype'] != 'Docker' %}
+
+download_awscli:
+  archive.extracted:
+    - name: /tmp/awscli
+    - source: https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+    - archive_format: zip
+    - skip_verify: true
+    - enforce_toplevel: false
+
+install_awscli:
+  cmd.run:
+    - name: /tmp/awscli/aws/install -b /usr/bin
+
+remove_awscli_extract:
+  file.directory:
+    - name: /tmp/awscli
+    - clean: True
 
 download_azcopy:
   archive.extracted:


### PR DESCRIPTION
From AWS documentation: "Although the awscli package is available in repositories for other package managers such as apt and yum, these are not produced, managed, or supported by AWS. We recommend that you install the AWS CLI from only the official AWS distribution points"