### PR TITLE
CDPR-16: Resolve to make the telemetry and logging agent packages configurable

### DIFF
--- a/saltstack/base/salt/fluent/init.sls
+++ b/saltstack/base/salt/fluent/init.sls
@@ -1,8 +1,9 @@
 ## see more at internal repo: thunderhead/fluent-service-packager
 {% set os = salt['environ.get']('OS') %}
 {% set cdp_logging_agent_rpm_repo_url = salt['environ.get']('CDP_LOGGING_AGENT_RPM_URL') %}
+{% set include_fluent = salt['environ.get']('INCLUDE_FLUENT') %}
 
-{% if cdp_logging_agent_rpm_repo_url %}
+{% if cdp_logging_agent_rpm_repo_url and include_fluent == "Yes" %}
 {% if os.startswith("centos") or os.startswith("redhat") %}
 # this will install redhat-lsb-core on freeipa images
 install_lsb_core_for_fluent:

--- a/saltstack/base/salt/telemetry/init.sls
+++ b/saltstack/base/salt/telemetry/init.sls
@@ -1,8 +1,9 @@
 ## see more at internal repo: thunderhead/cdp-telemetry-cli
 {% set os = salt['environ.get']('OS') %}
 {% set cdp_telemetry_rpm_repo_url = salt['environ.get']('CDP_TELEMETRY_RPM_URL') %}
+{% set include_cdp_telemetry = salt['environ.get']('INCLUDE_CDP_TELEMETRY') %}
 
-{% if cdp_telemetry_rpm_repo_url %}
+{% if cdp_telemetry_rpm_repo_url and include_cdp_telemetry == "Yes" %}
 {% if os.startswith("centos") or os.startswith("redhat") or os == "amazonlinux2" %}
 install_cdp_telemetry_rpm:
   cmd.run:

--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -46,14 +46,14 @@ packer_in_container() {
     jq 'del(."post-processors")' packer.json > packer_no_pp.json
     packerFile="packer_no_pp.json"
   fi
-  if [[ "$INCLUDE_CDP_TELEMETRY" == "Yes" ]]; then
+  if [[ "$INCLUDE_CDP_TELEMETRY" == "Yes" && -z "$CDP_TELEMETRY_RPM_URL" ]]; then
     CDP_TELEMETRY_BASE_URL="https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-telemetry/"
     if [[ "$CDP_TELEMETRY_VERSION" == "" ]]; then
       CDP_TELEMETRY_VERSION=$(curl -L -k -s ${CDP_TELEMETRY_BASE_URL}AVAILABLE_VERSIONS | head -1)
     fi
     CDP_TELEMETRY_RPM_URL="${CDP_TELEMETRY_BASE_URL}cdp_telemetry-${CDP_TELEMETRY_VERSION}.x86_64.rpm"
   fi
-  if [[ "$INCLUDE_FLUENT" == "Yes" ]]; then
+  if [[ "$INCLUDE_FLUENT" == "Yes" && -z "$CDP_LOGGING_AGENT_RPM_URL" ]]; then
     CDP_LOGGING_AGENT_BASE_URL="https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-logging-agent/"
     if [[ "$CDP_LOGGING_AGENT_VERSION" == "" ]]; then
       CDP_LOGGING_AGENT_VERSION=$(curl -L -k -s ${CDP_LOGGING_AGENT_BASE_URL}AVAILABLE_VERSIONS | head -1)


### PR DESCRIPTION
Telemetry and logging agent can be configured by own urls. If the parameters are stayed empty then the latest versions will be installed.