### PR TITLE
CB-13841: Add the cloudbreak images repository revision number to the package version of freeipa image

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -281,6 +281,7 @@
         "CDP_LOGGING_AGENT_RPM_URL={{user `cdp_logging_agent_rpm_url`}}",
         "JUMPGATE_AGENT_RPM_URL={{user `jumpgate_agent_rpm_url`}}",
         "OS={{user `os`}}",
+        "GIT_REV={{user `git_rev`}}",
         "STACK_REPOSITORY_VERSION={{user `repository_version`}}",
         "COPY_AWS_MARKETPLACE_EULA={{user `copy_aws_marketplace_eula`}}",
         "ORACLE_JDK8_URL_RPM={{user `oracle_jdk8_url_rpm`}}",

--- a/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
@@ -5,6 +5,8 @@ set -x
 echo '{}' | jq --arg sb "$(salt-bootstrap --version | awk '{print $2}')" '. + {"salt-bootstrap": $sb}' > /tmp/package-versions.json
 cat /tmp/package-versions.json | jq --arg sv "$($SALT_PATH/bin/salt-call --local grains.get saltversion --out json | jq -r .local)" '. + {"salt": $sv}' > /tmp/package-versions.json
 
+cat /tmp/package-versions.json | jq --arg git_rev ${GIT_REV} '. + {"cloudbreak_images": $git_rev}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
+
 cat /tmp/package-versions.json | jq --arg inverting_proxy_agent_version "$(jumpgate-agent --version | awk 'NR==1{print $3}')" '. + {"inverting-proxy-agent": $inverting_proxy_agent_version}' > /tmp/package-versions.json
 JUMPGATE_AGENT_GBN_REGEX=".*\/([0-9]+)\/.*"
 if [[ $JUMPGATE_AGENT_RPM_URL =~ $JUMPGATE_AGENT_GBN_REGEX ]]; then

--- a/scripts/pp_json.sh
+++ b/scripts/pp_json.sh
@@ -6,7 +6,7 @@ if [ -f package-versions.json -a "$stack_version" != "" -a "$clustermanager_vers
     apk update && apk add jq
     cat package-versions.json
     if [ "$stack_type" == "CDH" ]; then
-        cat package-versions.json | jq --arg stack_version $stack_version --arg clustermanager_version $clustermanager_version --arg cm_build_number $cm_build_number --arg stack_build_number $stack_build_number --arg composite_gbn "$composite_gbn" --arg cloudbreak_images "$git_rev" '. += {"stack" : $stack_version,  "cm" : $clustermanager_version,  "cm-build-number" : $cm_build_number,  "cdh-build-number" : $stack_build_number, "composite_gbn": $composite_gbn, "cloudbreak_images": $cloudbreak_images}' > package-versions-tmp.json && mv package-versions-tmp.json package-versions.json
+        cat package-versions.json | jq --arg stack_version $stack_version --arg clustermanager_version $clustermanager_version --arg cm_build_number $cm_build_number --arg stack_build_number $stack_build_number --arg composite_gbn "$composite_gbn" '. += {"stack" : $stack_version,  "cm" : $clustermanager_version,  "cm-build-number" : $cm_build_number,  "cdh-build-number" : $stack_build_number, "composite_gbn": $composite_gbn}' > package-versions-tmp.json && mv package-versions-tmp.json package-versions.json
 
         for parcel in ${parcel_list_with_versions//,/ } ; do 
             parcel_versions=(`echo $parcel | tr ':' ' '`)


### PR DESCRIPTION
The package versions block of freeIPA related images should also be extended with the cloudbreak images repository revision number similarly to the cb images therefore the necessary code snippet was moved to a common part which is executed in both cases .