### PR TITLE
CDPR-50: Makefile overwrites Jumpgate RPM URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,9 @@ INCLUDE_METERING ?= "Yes"
 CDP_TELEMETRY_VERSION ?= ""
 CDP_LOGGING_AGENT_VERSION ?= ""
 
-JUMPGATE_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/15246760/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm"
+ifndef JUMPGATE_AGENT_RPM_URL
+	JUMPGATE_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/15246760/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm"
+endif
 
 METADATA_FILENAME_POSTFIX ?= $(shell date +%s)
 


### PR DESCRIPTION
Currently on the master branch the Makefile provides an explicit value for the Jumpgate RPM URL, however on rhel_support this used to be something that comes from the caller - e.g. the wrapper script or from the Jenkins job. Now that master is merged to rhel_support to keep branch differences at a minimum, we ended up with a situation, where the explicit value always overwrites the parameterized one. 