### PR TITLE
CDPR-51: Interrupt the flow if parsing of package versions by regex not possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ CDP_TELEMETRY_VERSION ?= ""
 CDP_LOGGING_AGENT_VERSION ?= ""
 
 ifndef JUMPGATE_AGENT_RPM_URL
-	JUMPGATE_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/15246760/inverting-proxy/1.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm"
+	JUMPGATE_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/17100017/inverting-proxy/2.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm"
 endif
 
 METADATA_FILENAME_POSTFIX ?= $(shell date +%s)

--- a/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
@@ -8,9 +8,9 @@ cat /tmp/package-versions.json | jq --arg sv "$($SALT_PATH/bin/salt-call --local
 cat /tmp/package-versions.json | jq --arg git_rev ${GIT_REV} '. + {"cloudbreak_images": $git_rev}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
 
 JUMPGATE_AGENT_VERSION_INFO=$(jumpgate-agent --version)
-JUMPGATE_AGENT_VERSION_REGEX="jumpgate-agent version:\s(.*)"
+JUMPGATE_AGENT_VERSION_REGEX="jumpgate-agent version:\s([0-9]+\.[0-9]+\.[0-9]+\-b[0-9]+).*"
 if [[ $JUMPGATE_AGENT_VERSION_INFO =~ $JUMPGATE_AGENT_VERSION_REGEX ]]; then
-	cat /tmp/package-versions.json | jq --arg inverting_proxy_agent_version ${BASH_REMATCH[1]} '. + {"inverting-proxy-agent": $inverting_proxy_agent_version}' > /tmp/package-versions.json
+	cat /tmp/package-versions.json | jq --arg inverting_proxy_agent_version ${BASH_REMATCH[1]} '. + {"inverting-proxy-agent": $inverting_proxy_agent_version}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
 else
 	echo "It is not possible to retrieve the version of Jumpgate Agent from its --version param."
 	exit 1


### PR DESCRIPTION
If the package version generation is not possible due to the used regex is not match we should interrupt the flow.