### PR TITLE
CB-14160: Makefile overwrites Jumpgate RPM URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,9 @@ INCLUDE_METERING ?= "Yes"
 CDP_TELEMETRY_VERSION ?= ""
 CDP_LOGGING_AGENT_VERSION ?= ""
 
-JUMPGATE_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/17100017/inverting-proxy/2.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm"
+ifndef JUMPGATE_AGENT_RPM_URL
+	JUMPGATE_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/17100017/inverting-proxy/2.x/redhat7/yum/tars/inverting-proxy/jumpgate-agent.rpm"
+endif
 
 METADATA_FILENAME_POSTFIX ?= $(shell date +%s)
 


### PR DESCRIPTION
The jumpgate agent url now is checked, if it is not specified then the its defined default url value will be introduced.