### PR TITLE
CDPR-52: Prevent dnsmasq from starting on RHEL VMs

### DIFF
--- a/saltstack/base/salt/prerequisites/dnsmasq.sls
+++ b/saltstack/base/salt/prerequisites/dnsmasq.sls
@@ -1,3 +1,4 @@
-ensure_service_dnsmasq_disabled:
-  service.disabled:
+stop_and_disable_dnsmasq:
+  service.dead:
+    - enable: False
     - name: dnsmasq


### PR DESCRIPTION
Dnsmasq needs to be stopped and disabled otherwise unbound service will not start.