### PR TITLE
CB-9069: Root user login via SSH needs to be disabled

### DIFF
--- a/saltstack/base/salt/ccmv2/init.sls
+++ b/saltstack/base/salt/ccmv2/init.sls
@@ -1,4 +1,4 @@
-{% set jumpgate_agent_rpm_repo_url = salt['environ.get']('JUMPGATE_AGENT_RPM_URL') %}
+{% set jumpgate_agent_rpm_url = salt['environ.get']('JUMPGATE_AGENT_RPM_URL') %}
 
 /cdp/bin/ccmv2/generate-config.sh:
   file.managed:
@@ -15,7 +15,6 @@
     - group: root
     - mode: 644
 
-{% set jumpgate_agent_rpm_url = salt['environ.get']('JUMPGATE_AGENT_RPM_URL') %}
 {% if jumpgate_agent_rpm_url %}
 install_jumpgate_agent:
   pkg.installed:

--- a/saltstack/final/salt/cis-controls/init.sls
+++ b/saltstack/final/salt/cis-controls/init.sls
@@ -170,6 +170,17 @@ sshd_harden_MaxStartups:
     - repl: "maxstartups 10:30:60"
     - append_if_not_found: True
 
+#Root user login via SSH needs to be disabled from version 7.2.8
+{% set version = salt['environ.get']('STACK_VERSION') %}
+{% if version and version.split('.') | map('int') | list >= [7, 2, 8] %}
+sshd_harden_PermitRootLogin:
+  file.replace:
+    - name: /etc/ssh/sshd_config
+    - pattern: "^PermitRootLogin.*"
+    - repl: "PermitRootLogin no"
+    - append_if_not_found: True
+{%- endif %}
+
 #### CIS: Sudo Configuration
 #1.3.2 Ensure sudo commands use pty
 sudo_pty:


### PR DESCRIPTION
Root user login via SSH needs to be disabled from runtime version 7.2.8