### PR TITLE
CB-14344 OS is not mandatory in case of Azure cloud provider when cal…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER
 			AZURE_IMAGE_PUBLISHER ?= OpenLogic
 			AZURE_IMAGE_OFFER ?= CentOS
 			AZURE_IMAGE_SKU ?= 7.6
-		else
+		else ifdef OS
 $(error Unexpected OS type $(OS) for Azure)
 		endif
 	endif


### PR DESCRIPTION
…ling any make target so it should not fail on missing OS.