### PR TITLE
CB-14429 Use `pkill` to restart unbound in `dhclient-enter-hooks`

### DIFF
--- a/saltstack/hortonworks/salt/dhcp/etc/dhcp/dhclient-enter-hooks
+++ b/saltstack/hortonworks/salt/dhcp/etc/dhcp/dhclient-enter-hooks
@@ -157,7 +157,10 @@ make_resolv_conf() {
     fi
     
     log "Restart unbound"
-    systemctl restart unbound
+    log "$(ps aux | grep unbound)"
+    pkill -u unbound -SIGHUP unbound
+    log "Restarted unbound"
+    log "$(ps aux | grep unbound)"
 
     return 0
 }


### PR DESCRIPTION
- systemctl solution is causing deadlock and timeout in CentOS7, as unbound depends on the network to start, while it's restarted from the network phase
- old solution (`pkill -SIGHUP unbound`) doesn't work on RH7 as it kills the NetworkManager process as it also matches for `unbound`
eg output for `ps aux | grep unbound` before `pkill` on RH7:
```
2021-10-11 13:05:17 root       985  0.0  0.0  11692  1576 ?        S    13:05   0:00 /bin/bash /etc/NetworkManager/dispatcher.d/90-unbound eth0 up
root      1009  0.0  0.0  11692   648 ?        S    13:05   0:00 /bin/bash /etc/NetworkManager/dispatcher.d/90-unbound eth0 up
root      1011  0.0  0.0   9092   672 ?        S    13:05   0:00 grep unbound
```
- solution is to bind the `pkill` to the `unbound` user