### PR TITLE
CB-14420 CB-14833 Enable Oozie HA and Knox HA failover testing in YCloud

### DIFF
--- a/docker/yarn-loadbalancer/configuration-files/haproxy.cfg
+++ b/docker/yarn-loadbalancer/configuration-files/haproxy.cfg
@@ -8,6 +8,7 @@ defaults
     timeout server 10000
 frontend localnodes
     bind *:443
+    bind *:11443
     mode tcp
     default_backend nodes
 backend nodes

--- a/docker/yarn-loadbalancer/image-runtime-scripts/start-services-script.sh
+++ b/docker/yarn-loadbalancer/image-runtime-scripts/start-services-script.sh
@@ -51,7 +51,7 @@ i=0
 for server in "${SERVERS[@]}"
 do
     server=$(echo ${server} | sed 's#\\##g')
-    printf "\tserver server%s %s check\n" "${i}" "${server}" >> /tmp/haproxy.cfg
+    printf "\tserver server%s %s check port 8443\n" "${i}" "${server}" >> /tmp/haproxy.cfg
     i=$((i+1))
 done
 


### PR DESCRIPTION
1. For Oozie HA to work YCloud needs to listen on multiple ports.
2. For Knox HA failover testing to work the check port of the HAproxy should be Knox port 8443