### PR TITLE
CB-15729: Weird differences between AWS and Azure versions of the same Runtime image

### DIFF
--- a/scripts/generate-delta-package-list.sh
+++ b/scripts/generate-delta-package-list.sh
@@ -134,7 +134,7 @@ function get_rpm_differences() {
   check_rpm_file $COMPLETE_RPM_PACKAGE_LIST_PATH false
 
   echo "Determining the difference between the base and complete rpm package lists"
-  grep -vf $BASE_RPM_PACKAGE_LIST_PATH $COMPLETE_RPM_PACKAGE_LIST_PATH | sort > "$DELTA_RPM_PACKAGE_LIST_PATH"
+  grep -Fxvf $BASE_RPM_PACKAGE_LIST_PATH $COMPLETE_RPM_PACKAGE_LIST_PATH | sort > "$DELTA_RPM_PACKAGE_LIST_PATH"
   check_rpm_file $DELTA_RPM_PACKAGE_LIST_PATH true
   RPM_PACKAGE_DIFF_NUMBER=$(wc -l < "$DELTA_RPM_PACKAGE_LIST_PATH")
   echo "Found ${RPM_PACKAGE_DIFF_NUMBER} difference(s) between rpm packages"


### PR DESCRIPTION
Fixed the function that is used for calculating difference between base and completed rpm lists.