### PR TITLE
CB-15450. Patch stageuser and user commands for better performance

### DIFF
--- a/saltstack/freeipa/salt/freeipa/init.sls
+++ b/saltstack/freeipa/salt/freeipa/init.sls
@@ -39,3 +39,17 @@ install_freeipa_healthagent_rpm:
 net.ipv6.conf.lo.disable_ipv6:
   sysctl.present:
     - value: 0
+
+/usr/lib/python2.7/site-packages/ipaserver/plugins/stageuser.py:
+  file.patch:
+    - source: salt://{{ slspath }}/tmp/stageuser.py.patch
+    - hash: md5=c34ee2a14a0480f07faef36507626bc6
+    - require:
+      - freeipa-install
+
+/usr/lib/python2.7/site-packages/ipaserver/plugins/user.py:
+  file.patch:
+    - source: salt://{{ slspath }}/tmp/user.py.patch
+    - hash: md5=47508b761dfe42f173eee53a90bfb4db
+    - require:
+      - freeipa-install

--- a/saltstack/freeipa/salt/freeipa/tmp/stageuser.py.patch
+++ b/saltstack/freeipa/salt/freeipa/tmp/stageuser.py.patch
@@ -1,0 +1,34 @@
+--- stageuser.py.orig	2022-01-31 13:33:25.989475331 -0600
++++ stageuser.py	2022-02-01 17:12:51.007022077 -0600
+@@ -727,26 +727,12 @@
+                              "active %s", active_dn)
+             raise
+ 
+-        # add the user we just created into the default primary group
+-        config = ldap.get_ipa_config()
+-        def_primary_group = config.get('ipadefaultprimarygroup')
+-        group_dn = self.api.Object['group'].get_dn(def_primary_group)
++        # Return an empty entity to avoid the performance penalty of retrieving
++        # the activated user
++        result = {}
++        result['result'] = {}
++        result['value'] = args[-1]
+ 
+-        # if the user is already a member of default primary group,
+-        # do not raise error
+-        # this can happen if automember rule or default group is set
+-        try:
+-            ldap.add_entry_to_group(active_dn, group_dn)
+-        except errors.AlreadyGroupMember:
+-            pass
+-
+-        # Now retrieve the activated entry
+-        result = self.api.Command.user_show(
+-            args[-1],
+-            all=options.get('all', False),
+-            raw=options.get('raw', False),
+-            version=options.get('version'),
+-        )
+         result['summary'] = unicode(
+             _('Stage user %s activated' % staging_dn[0].value))
+ 

--- a/saltstack/freeipa/salt/freeipa/tmp/user.py.patch
+++ b/saltstack/freeipa/salt/freeipa/tmp/user.py.patch
@@ -1,0 +1,21 @@
+--- user.py.orig	2022-01-31 13:33:26.231995098 -0600
++++ user.py	2022-02-01 17:14:20.753236423 -0600
+@@ -589,18 +589,6 @@
+ 
+     def post_callback(self, ldap, dn, entry_attrs, *keys, **options):
+         assert isinstance(dn, DN)
+-        config = ldap.get_ipa_config()
+-        # add the user we just created into the default primary group
+-        def_primary_group = config.get('ipadefaultprimarygroup')
+-        group_dn = self.api.Object['group'].get_dn(def_primary_group)
+-
+-        # if the user is already a member of default primary group,
+-        # do not raise error
+-        # this can happen if automember rule or default group is set
+-        try:
+-            ldap.add_entry_to_group(dn, group_dn)
+-        except errors.AlreadyGroupMember:
+-            pass
+ 
+         # Fetch the entry again to update memberof, mep data, etc updated
+         # at the end of the transaction.


### PR DESCRIPTION
This commit patches user and stageuser commands to skip some
behaviors that take a long time but are not needed for our
use case.

stageuser_activate has been modified to:
  - not add user to default group (ipausers)
  - not run a query to populate the return value

user_disable and user_del have been modified to:
  - not check whether the user being disabled/deleted is the
    last enabled member of a protected group (i.e., admins).
    This check was performed regardless of whether the user
    is a member of the admins group or not. Usersync has
    protections to not modify the admin user, so this check
    is extraneous. A flag was added to this check so that the
    default behavior is maintained for callers outside of
    usersync.

user_add has been modified to:
  - not add user to the default group (ipausers)