### PR TITLE
CB-16037: Extend the proper manifest file name with build id in upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ push-to-metadata-repo: cleanup-metadata-repo
 
 upload-package-list:
 ifdef IMAGE_NAME
-	$(eval UUID:=$(shell (cat $(IMAGE_NAME).json | jq -r '.uuid // empty')))
+	$(eval UUID:=$(shell (cat $(IMAGE_NAME)_$(METADATA_FILENAME_POSTFIX).json | jq -r '.uuid // empty')))
 	make UUID=${UUID} copy-manifest-to-s3-bucket
 endif
 


### PR DESCRIPTION
There was a file name error which affects the uploading of manifest files, the proper file name should be extended with the build id.

