### PR TITLE
CB-15727 Remove old kernels

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -295,7 +295,11 @@
     },
     {
       "type": "shell",
-      "script": "scripts/salt-setup.sh",
+      "scripts": [
+        "scripts/salt-setup.sh",
+        "scripts/reboot.sh",
+        "scripts/salt-final.sh"
+      ],
       "expect_disconnect": true,
       "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }} ",
       "environment_vars": [

--- a/saltstack/base/salt/prerequisites/user.sls
+++ b/saltstack/base/salt/prerequisites/user.sls
@@ -1,9 +1,3 @@
-{% if salt['environ.get']('OS').startswith("centos") %}
-centos_user_nologin_shell:
-  cmd.run:
-    - name: usermod centos -s /usr/sbin/nologin
-{% endif %}
-
 create_cloudbreak_user:
   user.present:
     - name: cloudbreak

--- a/saltstack/final/salt/cleanup/init.sls
+++ b/saltstack/final/salt/cleanup/init.sls
@@ -6,9 +6,11 @@ include:
 {% if pillar['subtype'] != 'Docker' %}
   - {{ slspath }}.hostname
 {% endif %}
+  - {{ slspath }}.kernel
   - {{ slspath }}.package
   - {{ slspath }}.sync_fs
   - {{ slspath }}.salt
 {% if not salt['file.directory_exists']('/vagrant') %}
   - {{ slspath }}.cloud-init
 {% endif %}
+  - {{ slspath }}.user

--- a/saltstack/final/salt/cleanup/kernel.sls
+++ b/saltstack/final/salt/cleanup/kernel.sls
@@ -1,0 +1,19 @@
+{% if grains['os_family'] == 'RedHat' %}
+
+current_kernel:
+  cmd.run:
+    - name: uname -r
+
+list_installed_kernels_before_cleanup:
+  cmd.run:
+    - name: rpm -q kernel
+
+package_cleanup_oldkernels:
+  cmd.run:
+    - name: package-cleanup --oldkernels --count=1 -y
+
+list_installed_kernels_after_cleanup:
+  cmd.run:
+    - name: rpm -q kernel
+
+{% endif %}

--- a/saltstack/final/salt/cleanup/user.sls
+++ b/saltstack/final/salt/cleanup/user.sls
@@ -1,0 +1,8 @@
+{% if grains['os'] == 'CentOS' %}
+
+set_centos_nologin_shell:
+  user.present:
+    - name: centos
+    - shell: /usr/sbin/nologin
+
+{% endif %}

--- a/scripts/reboot.sh
+++ b/scripts/reboot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Rebooting before validation and cleanup"
+reboot

--- a/scripts/salt-final.sh
+++ b/scripts/salt-final.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+: ${DEBUG:=1}
+: ${DRY_RUN:-1}
+
+set -ex -o pipefail -o errexit
+
+function copy_resources {
+  local saltenv=${1}
+  sudo mkdir -p /srv/salt/${saltenv} /srv/pillar/${saltenv}
+  sudo cp -R /tmp/saltstack/${saltenv}/salt/* /srv/salt/${saltenv}
+  if [ -d "/tmp/saltstack/${saltenv}/pillar" ]
+  then
+    sudo cp -R /tmp/saltstack/${saltenv}/pillar/* /srv/pillar/${saltenv}
+  fi
+}
+
+function highstate {
+  local saltenv=${1}
+  copy_resources ${saltenv}
+  ${SALT_PATH}/bin/salt-call --no-color --local state.highstate saltenv=${saltenv} --retcode-passthrough -l info --log-file=/tmp/salt-build-${saltenv}.log --log-file-level=info --config-dir=/tmp/saltstack/config
+}
+
+echo "Running validation and cleanup"
+highstate "final"

--- a/scripts/salt-setup.sh
+++ b/scripts/salt-setup.sh
@@ -117,7 +117,3 @@ apply_optional_states
 
 echo "Adding prewarmed roles for salt used in final image"
 add_prewarmed_roles
-
-echo "Running validation and cleanup"
-highstate "final"
-


### PR DESCRIPTION
To be able to remove old kernels after system update, the machine has to be rebooted. To achieve this, the final saltstate was extracted to a new salt-final.sh script, and a reboot is issued before running it.