### PR TITLE
CB-16538: Burn prewarmed images with JDK11 installed alongside JDK8

### DIFF
--- a/saltstack/hortonworks/pillar/java/init.sls
+++ b/saltstack/hortonworks/pillar/java/init.sls
@@ -29,9 +29,15 @@ openjdk_packages:
 {% elif salt['environ.get']('OS') == 'redhat7' %}
   - java-1.8.0-openjdk-headless
   - java-1.8.0-openjdk-devel
+  - java-11-openjdk-headless
+  - java-11-openjdk-devel
 {% else %}
   - java-1.8.0-openjdk-headless
   - java-1.8.0-openjdk-devel
   - java-1.8.0-openjdk-javadoc
   - java-1.8.0-openjdk-src
+  - java-11-openjdk-headless
+  - java-11-openjdk-devel
+  - java-11-openjdk-javadoc
+  - java-11-openjdk-src
 {% endif %}


### PR DESCRIPTION
We need JDK 11 installed alongside JDK8 on our prewarmed images