### PR TITLE
CB-14431: Chrony is not restarted if it crashes

### DIFF
--- a/saltstack/base/salt/chrony/init.sls
+++ b/saltstack/base/salt/chrony/init.sls
@@ -1,0 +1,15 @@
+chronyRestart:
+  file.line:
+    - name: /usr/lib/systemd/system/chronyd.service
+    - mode: ensure
+    - content: "Restart=always"
+    - after: \[Service\]
+    - backup: False
+
+chronyRestartSec:
+  file.line:
+    - name: /usr/lib/systemd/system/chronyd.service
+    - mode: ensure
+    - content: "RestartSec=5"
+    - after: "Restart=always"
+    - backup: False

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -12,10 +12,12 @@ base:
     - performance
 {% if salt['environ.get']('INCLUDE_CDP_TELEMETRY') == 'Yes' %}
     - telemetry
-{% endif %}{% if salt['environ.get']('INCLUDE_FLUENT') == 'Yes' %}
+{% endif %}
+{% if salt['environ.get']('INCLUDE_FLUENT') == 'Yes' %}
     - fluent
 {% endif %}
     - ccm-client
     - ccmv2
     - custom
     - mount
+    - chrony


### PR DESCRIPTION
We got news from a customer that chrony crashed on their VMs, even though the customer has failed to produce evidence for this so far.

I checked that after killing chrony it is not restarted, since in the unit file there is no restart on failure  set.
