### PR TITLE
CB-16854: Change the salt version to 3002.8

### DIFF
--- a/scripts/get-salt-version.sh
+++ b/scripts/get-salt-version.sh
@@ -30,7 +30,7 @@ compare_version () {
 BASE_NAME=$1
 STACK_VERSION=$2
 
-SALT_VERSION=3004.1
+SALT_VERSION=3002.8
 
 if [[ $BASE_NAME == "cb" ]]; then
   if [[ ! -z "$STACK_VERSION" ]]; then


### PR DESCRIPTION
Since an error was reported for the latest version (3004.1), we switched to version 3002.8