### PR TITLE
CB-17500 Install prometheus on base image

### DIFF
--- a/saltstack/base/salt/monitoring/cdp-prometheus.sls
+++ b/saltstack/base/salt/monitoring/cdp-prometheus.sls
@@ -1,0 +1,15 @@
+/opt/cdp-prometheus:
+  file.directory:
+    - name: /opt/cdp-prometheus
+    - user: root
+    - group: root
+    - mode: 700
+
+install_prometheus:
+  archive.extracted:
+    - name: /opt/cdp-prometheus/
+    - source: https://github.com/prometheus/prometheus/releases/download/v2.36.2/prometheus-2.36.2.linux-amd64.tar.gz
+    - source_hash: md5=f85cbfb9b2c4266ac4ece5a43efe28d2
+    - archive_format: tar
+    - enforce_toplevel: False
+    - options: --strip-components=1 --exclude='promtool'

--- a/saltstack/base/salt/monitoring/init.sls
+++ b/saltstack/base/salt/monitoring/init.sls
@@ -1,3 +1,4 @@
 include:
   - {{ slspath }}.node-exporter
   - {{ slspath }}.blackbox-exporter
+  - {{ slspath }}.cdp-prometheus

--- a/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
@@ -49,6 +49,10 @@ if [[ -f "/opt/blackbox_exporter/blackbox_exporter" ]]; then
 	blackbox_exporter_version=$(/opt/blackbox_exporter/blackbox_exporter --version 2>&1 | grep -Po "version (\d+\.)+\d+" | cut -d ' ' -f2)
 	cat /tmp/package-versions.json | jq --arg be_version $blackbox_exporter_version -r '. + {"blackbox-exporter": $be_version}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
 fi
+if [[ -f "/opt/cdp-prometheus/prometheus" ]]; then
+	prometheus_version=$(/opt/cdp-prometheus/prometheus --version 2>&1 | grep -Po "version (\d+\.)+\d+" | cut -d ' ' -f2)
+	cat /tmp/package-versions.json | jq --arg pr_version $prometheus_version -r '. + {"cdp-prometheus": $pr_version}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
+fi
 
 for package in "$@"
 do


### PR DESCRIPTION
Install prometheus that we will use for compute monitoring.

Jenkins builds:
- http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/6028/console
- http://build.eng.hortonworks.com/job/imagecatalog-v3-append/4360/console

I only changed the name of the package in the `/tmp/package-versions.json` from prometheus to cdp-prometheus.