### PR TITLE
CB-18227: Changed SSHD ClientAliveInterval to 235

### DIFF
--- a/saltstack/final/salt/cis-controls/init.sls
+++ b/saltstack/final/salt/cis-controls/init.sls
@@ -95,12 +95,14 @@ sshd_harden_addressLoginGraceTime:
     - repl: "LoginGraceTime 60"
     - append_if_not_found: True
 
-#the value was kept as high as 1800, otherwise e2e test fails.
+# 235 is the max value for ClientAliveInterval allowed by Azure Marketplace,
+# however during the VM provisioning stage Cloudbreak will set this to 1800, 
+# which is essential for our own image validation process.
 sshd_harden_sshIdealTime_ClientAliveInterval:
   file.replace:
     - name: /etc/ssh/sshd_config
     - pattern: "^ClientAliveInterval.*"
-    - repl: "ClientAliveInterval 1800"
+    - repl: "ClientAliveInterval 235"
     - append_if_not_found: True
 sshd_harden_sshIdealTime_ClientAliveCountMax:
   file.replace:


### PR DESCRIPTION
Basically this is the highest value allowed by Azure Marketplace,
however CB will change this to 1800 during instance provisioning,
because a much larger value is essential to our own image validation
and E2E processes.

**Also DON'T MERGE this before Cloudbreak 2.62.0-b84 reaches production
or you unleash Ragnarok on us by crippling image releases!**

Warned you...