### PR TITLE
CB-18227: Lowered ClientAliveInterval even further

### DIFF
--- a/saltstack/final/salt/cis-controls/init.sls
+++ b/saltstack/final/salt/cis-controls/init.sls
@@ -102,7 +102,7 @@ sshd_harden_sshIdealTime_ClientAliveInterval:
   file.replace:
     - name: /etc/ssh/sshd_config
     - pattern: "^ClientAliveInterval.*"
-    - repl: "ClientAliveInterval 235"
+    - repl: "ClientAliveInterval 180"
     - append_if_not_found: True
 sshd_harden_sshIdealTime_ClientAliveCountMax:
   file.replace:


### PR DESCRIPTION
Apparently the Azure Marketplace publishing process does not accept the highest value (235), which should be accepted btw. according to their documentation.