### PR TITLE
CB-18201: Implement a packer setup to generate RPM change logs from a VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,16 @@ build-aws-centos7:
 	GIT_TAG=$(GIT_TAG) \
 	./scripts/sparseimage/packer.sh build -color=false -force $(PACKER_OPTS)
 
+generate-aws-centos7-changelog:
+ifdef IMAGE_UUID
+ifdef SOURCE_IMAGE
+	$(ENVS) \
+	IMAGE_UUID=$(IMAGE_UUID) \
+	SOURCE_IMAGE=$(SOURCE_IMAGE) \
+	./scripts/changelog/packer.sh build -color=false -only=aws-centos7 -force $(PACKER_OPTS)
+endif
+endif
+
 copy-aws-images:
 	docker run -i --rm \
 		-v "${PWD}/scripts:/scripts" \
@@ -268,6 +278,16 @@ build-aws-gov-centos7:
 	NO_PROXY=172.20.0.0/16,127.0.0.1,localhost,169.254.169.254,internal,local,s3.us-gov-west-1.amazonaws.com,us-gov-west-1.eks.amazonaws.com \
 	./scripts/sparseimage/packer.sh build -color=false -force $(PACKER_OPTS)
 
+generate-aws-gov-centos7-changelog:
+ifdef IMAGE_UUID
+ifdef SOURCE_IMAGE
+	$(ENVS) \
+	IMAGE_UUID=$(IMAGE_UUID) \
+	SOURCE_IMAGE=$(SOURCE_IMAGE) \
+	./scripts/changelog/packer.sh build -color=false -only=aws-gov-centos7 -force $(PACKER_OPTS)
+endif
+endif
+
 copy-aws-gov-images:
 	docker run -i --rm \
 		-v "${PWD}/scripts:/scripts" \
@@ -301,6 +321,16 @@ build-gc-centos7:
 	GIT_BRANCH=$(GIT_BRANCH) \
 	GIT_TAG=$(GIT_TAG) \
 	./scripts/packer.sh build -color=false -only=gc-centos7 $(PACKER_OPTS)
+
+generate-gc-centos7-changelog:
+ifdef IMAGE_UUID
+ifdef SOURCE_IMAGE
+	$(ENVS) \
+	IMAGE_UUID=$(IMAGE_UUID) \
+	SOURCE_IMAGE=$(SOURCE_IMAGE) \
+	./scripts/changelog/packer.sh build -color=false -only=gc-centos7 -force $(PACKER_OPTS)
+endif
+endif
 
 build-azure-centos7:
 	$(ENVS) \
@@ -342,6 +372,17 @@ build-azure-redhat7:
 	./scripts/packer.sh build -color=false -only=arm-redhat7 $(PACKER_OPTS)
 ifeq ($(AZURE_INITIAL_COPY),true)
 	TRACE=1 AZURE_STORAGE_ACCOUNTS=$(AZURE_BUILD_STORAGE_ACCOUNT) ./scripts/azure-copy.sh
+endif
+
+generate-azure-centos7-changelog:
+ifdef IMAGE_UUID
+ifdef SOURCE_IMAGE
+	$(ENVS) \
+	IMAGE_UUID=$(IMAGE_UUID) \
+	SOURCE_IMAGE=$(SOURCE_IMAGE) \
+	BUILD_RESOURCE_GROUP_NAME=$(BUILD_RESOURCE_GROUP_NAME) \
+	./scripts/changelog/packer.sh build -color=false -only=arm-centos7 -force $(PACKER_OPTS)
+endif
 endif
 
 copy-azure-images:

--- a/scripts/changelog/packer.json
+++ b/scripts/changelog/packer.json
@@ -1,0 +1,176 @@
+{
+  "variables": {
+    "source_image": "{{ env `SOURCE_IMAGE` }}",
+    "image_uuid": "{{ env `IMAGE_UUID` }}",
+    "image_name": "{{ env `IMAGE_NAME` }}",
+    "image_size": "{{ env `IMAGE_SIZE` }}",
+    "subnet_id": "{{ env `SUBNET_ID` }}",
+    "vpc_id": "{{ env `VPC_ID` }}",
+    "image_owner": "{{ env `IMAGE_OWNER` }}",
+    "gcp_account_file": "{{env `GCP_ACCOUNT_FILE`}}",
+    "client_id": "{{ env `ARM_CLIENT_ID` }}",
+    "client_secret": "{{ env `ARM_CLIENT_SECRET` }}",
+    "subscription_id": "{{ env `ARM_SUBSCRIPTION_ID` }}",
+    "tenant_id": "{{ env `ARM_TENANT_ID` }}",
+    "resource_group_name": "{{ env `ARM_GROUP_NAME` }}",
+    "storage_account": "{{ env `ARM_STORAGE_ACCOUNT` }}",
+    "virtual_network_resource_group_name": "{{ env `VIRTUAL_NETWORK_RESOURCE_GROUP_NAME` }}"
+  },
+  "builders": [
+    {
+      "name": "aws-centos7",
+      "type": "amazon-ebs",
+      "region": "us-west-1",
+      "ssh_pty": true,
+      "source_ami": "{{ user `source_image` }}",
+      "instance_type": "t3.2xlarge",
+      "ssh_username": "centos",
+      "ena_support": true,
+      "skip_region_validation": true,
+      "tags": {
+        "builder": "packer",
+        "cb-creation-timestamp": "{{timestamp}}",
+        "owner": "{{ user `image_owner` }}"
+      },
+      "run_tags": {
+        "owner": "{{ user `image_owner` }}"
+      },
+      "ami_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "{{user `image_size`}}"
+        }
+      ],
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "{{user `image_size`}}"
+        }
+      ],
+      "ami_name": "{{ user `image_name`}}",
+      "subnet_id": "{{ user `subnet_id`}}",
+      "vpc_id": "{{ user `vpc_id`}}",
+      "skip_create_ami": true
+    },
+    {
+      "name": "aws-gov-centos7",
+      "type": "amazon-ebs",
+      "region": "us-gov-west-1",
+      "ssh_pty": true,
+      "source_ami": "{{ user `source_image` }}",
+      "instance_type": "t3.2xlarge",
+      "ssh_username": "centos",
+      "ena_support": true,
+      "skip_region_validation": true,
+      "tags": {
+        "builder": "packer",
+        "cb-creation-timestamp": "{{timestamp}}",
+        "owner": "{{ user `image_owner` }}"
+      },
+      "run_tags": {
+        "owner": "{{ user `image_owner` }}"
+      },
+      "ami_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "{{user `image_size`}}"
+        }
+      ],
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "{{user `image_size`}}"
+        }
+      ],
+      "ami_name": "{{ user `image_name`}}",
+      "subnet_id": "{{ user `subnet_id`}}",
+      "vpc_id": "{{ user `vpc_id`}}",
+      "skip_create_ami": true
+    },
+    {
+      "name": "arm-centos7",
+      "type": "azure-arm",
+      "client_id": "{{user `client_id`}}",
+      "client_secret": "{{user `client_secret`}}",
+      "subscription_id": "{{user `subscription_id`}}",
+      "tenant_id": "{{user `tenant_id`}}",
+      "resource_group_name": "{{user `resource_group_name`}}",
+      "storage_account": "{{user `storage_account`}}",
+      "capture_container_name": "packer",
+      "capture_name_prefix": "{{user `image_name`}}",
+      "image_url": "{{ user `source_image` }}",
+      "ssh_pty": "true",
+      "username": "cloudbreak",
+      "os_type": "Linux",
+      "ssh_username": "centos",
+      "ssh_password": "S3cr3t",
+      "location": "westus",
+      "vm_size": "Standard_D4",
+      "os_disk_size_gb": "{{user `image_size`}}",
+      "virtual_network_resource_group_name":"{{user `virtual_network_resource_group_name`}}",
+      "virtual_network_name": "{{user `vpc_id`}}",
+      "virtual_network_subnet_name": "{{user `subnet_id`}}",
+      "private_virtual_network_with_public_ip": "false",
+      "azure_tags": {
+        "builder": "packer",
+        "cb-creation-timestamp": "{{timestamp}}",
+        "owner": "{{ user `image_owner` }}"
+      },
+      "skip_create_image": true
+    },
+    {
+      "name": "gc-centos7",
+      "type": "googlecompute",
+      "disable_default_service_account" : true,
+      "account_file": "{{user `gcp_account_file`}}",
+      "source_image": "{{ user `source_image` }}",
+      "zone": "us-west2-a",
+      "project_id": "gcp-cdp-cb-images",
+      "network_project_id": "gcp-eng-network-enterprise",
+      "ssh_username": "centos",
+      "ssh_pty": "true",
+      "machine_type": "n1-standard-2",
+      "preemptible": false,
+      "omit_external_ip": "true",
+      "use_internal_ip": "true",
+      "network": "{{user `vpc_id`}}",
+      "subnetwork": "{{user `subnet_id`}}",
+      "image_name": "{{user `image_name`}}",
+      "disk_size": "{{user `image_size`}}",
+      "state_timeout": "15m",
+      "tags": [
+        "builder--packer",
+        "cb-creation-timestamp--{{timestamp}}",
+        "owner--{{ user `image_owner` | clean_resource_name }}",
+        "gcp-dev-cloudbreak-ingress-internet-deny",
+        "gcp-dev-cloudbreak-egress-internet-allow",
+        "gcp-dev-cloudbreak-ingress-rfc1918-allow"
+      ],
+      "skip_create_image": true
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "scripts/changelog/collect-package-changelogs.sh",
+      "environment_vars": [
+        "IMAGE_UUID={{ user `image_uuid` }}"
+      ],
+      "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
+    },
+    {
+      "type": "file",
+      "source": "/tmp/changlogs-tmp/rpm-package-changelogs.tar.gz",
+      "destination": "rpm-package-changelogs.tar.gz",
+      "direction" : "download"
+    }
+  ]
+}

--- a/scripts/changelog/packer.sh
+++ b/scripts/changelog/packer.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+packer_in_container() {
+  local dockerOpts=""
+  local packerFile="./scripts/changelog/packer.json"
+  PACKER_VERSION="1.4.2"
+
+  if [[ "$GCP_ACCOUNT_FILE" ]]; then
+    dockerOpts="$dockerOpts -v $GCP_ACCOUNT_FILE:$GCP_ACCOUNT_FILE"
+  fi
+
+  TTY_OPTS="--tty"
+  if [[ "$JENKINS_HOME" ]]; then
+    ## dont try to use docker tty on jenkins
+    TTY_OPTS=""
+  fi
+
+  [[ "$TRACE" ]] && set -x
+  ${DRY_RUN:+echo ===} docker run -i $TTY_OPTS --rm \
+    -e CHECKPOINT_DISABLE=1 \
+    -e SOURCE_IMAGE=$SOURCE_IMAGE \
+    -e IMAGE_UUID="$IMAGE_UUID" \
+    -e IMAGE_NAME=$IMAGE_NAME \
+    -e IMAGE_SIZE=$IMAGE_SIZE \
+    -e SUBNET_ID="$SUBNET_ID" \
+    -e VPC_ID="$VPC_ID" \
+    -e IMAGE_OWNER=$IMAGE_OWNER \
+    -e GCP_ACCOUNT_FILE=$GCP_ACCOUNT_FILE \
+    -e ARM_CLIENT_ID=$ARM_CLIENT_ID \
+    -e ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET \
+    -e ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID \
+    -e ARM_TENANT_ID=$ARM_TENANT_ID \
+    -e ARM_GROUP_NAME=$ARM_GROUP_NAME \
+    -e ARM_STORAGE_ACCOUNT=$ARM_STORAGE_ACCOUNT \
+    -e VIRTUAL_NETWORK_RESOURCE_GROUP_NAME=$VIRTUAL_NETWORK_RESOURCE_GROUP_NAME \
+    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+    -e AWS_SNAPSHOT_GROUPS=$AWS_SNAPSHOT_GROUPS \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $PWD:$PWD \
+    -w $PWD \
+    $dockerOpts \
+    hashicorp/packer:$PACKER_VERSION "$@" $packerFile
+}
+
+main() {
+  echo $IMAGE_NAME
+  packer_in_container "$@"
+}
+
+[[ "$0" == "$BASH_SOURCE" ]] && main "$@"


### PR DESCRIPTION
The easiest way to grab precise change logs is directly from images - since we support different OSes (though right now, we should concentrate on CentOS mainly!) and cloud providers, Packer could be a helpful facade here - it should create a VM in the cloud, execute our generator script and then it should terminate and clean up the VM.