### PR TITLE
CB-18202: Increase packer version due to the skip create ami feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,7 @@ generate-aws-centos7-changelog:
 ifdef IMAGE_UUID
 ifdef SOURCE_IMAGE
 	$(ENVS) \
+	OS=centos \
 	IMAGE_UUID=$(IMAGE_UUID) \
 	SOURCE_IMAGE=$(SOURCE_IMAGE) \
 	./scripts/changelog/packer.sh build -color=false -only=aws-centos7 -force $(PACKER_OPTS)
@@ -282,6 +283,7 @@ generate-aws-gov-centos7-changelog:
 ifdef IMAGE_UUID
 ifdef SOURCE_IMAGE
 	$(ENVS) \
+	OS=centos \
 	IMAGE_UUID=$(IMAGE_UUID) \
 	SOURCE_IMAGE=$(SOURCE_IMAGE) \
 	./scripts/changelog/packer.sh build -color=false -only=aws-gov-centos7 -force $(PACKER_OPTS)
@@ -326,6 +328,7 @@ generate-gc-centos7-changelog:
 ifdef IMAGE_UUID
 ifdef SOURCE_IMAGE
 	$(ENVS) \
+	OS=centos \
 	IMAGE_UUID=$(IMAGE_UUID) \
 	SOURCE_IMAGE=$(SOURCE_IMAGE) \
 	./scripts/changelog/packer.sh build -color=false -only=gc-centos7 -force $(PACKER_OPTS)
@@ -378,6 +381,7 @@ generate-azure-centos7-changelog:
 ifdef IMAGE_UUID
 ifdef SOURCE_IMAGE
 	$(ENVS) \
+	OS=centos \
 	IMAGE_UUID=$(IMAGE_UUID) \
 	SOURCE_IMAGE=$(SOURCE_IMAGE) \
 	BUILD_RESOURCE_GROUP_NAME=$(BUILD_RESOURCE_GROUP_NAME) \

--- a/scripts/changelog/collect-package-changelogs.sh
+++ b/scripts/changelog/collect-package-changelogs.sh
@@ -8,7 +8,7 @@ if [ -z "${IMAGE_UUID}" ] ; then
   exit 1
 fi
 
-BASE_PATH="/tmp/changlogs-tmp"
+BASE_PATH="/tmp/changelogs-tmp"
 RPM_PACKAGE_LIST_PATH="${BASE_PATH}/rpm-packages.txt"
 RPM_PACKAGE_TAR_FILE_NAME="rpm-package-changelogs.tar.gz"
 RPM_PACKAGE_TAR_FILE_PATH="${BASE_PATH}/${RPM_PACKAGE_TAR_FILE_NAME}"
@@ -27,6 +27,7 @@ function execute() {
   echo "Compressing the entire directory that contains generated files into ${RPM_PACKAGE_TAR_FILE_PATH} file..."
   cd $BASE_PATH
   tar -zcf $RPM_PACKAGE_TAR_FILE_NAME $CHANGELOG_DIRECTORY_NAME
+  chmod 777 $BASE_PATH -R
 }
 
 function clean_up() {
@@ -34,7 +35,7 @@ function clean_up() {
 } 
 
 function collect_rpm_packages() {
-   mkdir -p $BASE_PATH
+  mkdir -p $BASE_PATH
   rpm -qa | sort | while read line ; do
     name=$(rpm -q --queryformat '%{NAME}' "$line")
     if ! contains "$name" "${FILTERED_RPM_PACKAGES[@]}" ; then
@@ -68,9 +69,9 @@ function contains() {
   return 1
 }
 
-echo "Trying to collect changelogs regarding to the installed packages on ${SALT_INSTALL_OS}"
+echo "Trying to collect changelogs regarding to the installed packages on ${OS}"
 
-case ${SALT_INSTALL_OS} in
+case ${OS} in
   centos|redhat|amazon)
     execute
     ;;
@@ -79,7 +80,7 @@ case ${SALT_INSTALL_OS} in
     exit 1
     ;;
   *)
-    echo "Unsupported platform:" $SALT_INSTALL_OS
+    echo "Unsupported platform:" $OS
     exit 1
     ;;
 esac

--- a/scripts/changelog/packer.json
+++ b/scripts/changelog/packer.json
@@ -1,5 +1,6 @@
 {
   "variables": {
+    "os": "{{ env `OS` }}",
     "source_image": "{{ env `SOURCE_IMAGE` }}",
     "image_uuid": "{{ env `IMAGE_UUID` }}",
     "image_name": "{{ env `IMAGE_NAME` }}",
@@ -24,7 +25,7 @@
       "ssh_pty": true,
       "source_ami": "{{ user `source_image` }}",
       "instance_type": "t3.2xlarge",
-      "ssh_username": "centos",
+      "ssh_username": "cloudbreak",
       "ena_support": true,
       "skip_region_validation": true,
       "tags": {
@@ -63,7 +64,7 @@
       "ssh_pty": true,
       "source_ami": "{{ user `source_image` }}",
       "instance_type": "t3.2xlarge",
-      "ssh_username": "centos",
+      "ssh_username": "cloudbreak",
       "ena_support": true,
       "skip_region_validation": true,
       "tags": {
@@ -110,7 +111,7 @@
       "ssh_pty": "true",
       "username": "cloudbreak",
       "os_type": "Linux",
-      "ssh_username": "centos",
+      "ssh_username": "cloudbreak",
       "ssh_password": "S3cr3t",
       "location": "westus",
       "vm_size": "Standard_D4",
@@ -124,7 +125,8 @@
         "cb-creation-timestamp": "{{timestamp}}",
         "owner": "{{ user `image_owner` }}"
       },
-      "skip_create_image": true
+      "skip_create_image": true,
+      "communicator": "ssh"
     },
     {
       "name": "gc-centos7",
@@ -135,7 +137,7 @@
       "zone": "us-west2-a",
       "project_id": "gcp-cdp-cb-images",
       "network_project_id": "gcp-eng-network-enterprise",
-      "ssh_username": "centos",
+      "ssh_username": "cloudbreak",
       "ssh_pty": "true",
       "machine_type": "n1-standard-2",
       "preemptible": false,
@@ -162,13 +164,14 @@
       "type": "shell",
       "script": "scripts/changelog/collect-package-changelogs.sh",
       "environment_vars": [
+        "OS={{ user `os` }}",
         "IMAGE_UUID={{ user `image_uuid` }}"
       ],
-      "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}"
+      "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }};"
     },
     {
       "type": "file",
-      "source": "/tmp/changlogs-tmp/rpm-package-changelogs.tar.gz",
+      "source": "/tmp/changelogs-tmp/rpm-package-changelogs.tar.gz",
       "destination": "rpm-package-changelogs.tar.gz",
       "direction" : "download"
     }

--- a/scripts/changelog/packer.sh
+++ b/scripts/changelog/packer.sh
@@ -3,7 +3,7 @@
 packer_in_container() {
   local dockerOpts=""
   local packerFile="./scripts/changelog/packer.json"
-  PACKER_VERSION="1.4.2"
+  PACKER_VERSION="1.8.3"
 
   if [[ "$GCP_ACCOUNT_FILE" ]]; then
     dockerOpts="$dockerOpts -v $GCP_ACCOUNT_FILE:$GCP_ACCOUNT_FILE"
@@ -18,6 +18,7 @@ packer_in_container() {
   [[ "$TRACE" ]] && set -x
   ${DRY_RUN:+echo ===} docker run -i $TTY_OPTS --rm \
     -e CHECKPOINT_DISABLE=1 \
+    -e OS=$OS \
     -e SOURCE_IMAGE=$SOURCE_IMAGE \
     -e IMAGE_UUID="$IMAGE_UUID" \
     -e IMAGE_NAME=$IMAGE_NAME \


### PR DESCRIPTION
Now we use packer version 1.4.2 that cannot support the skip create ami feature, so we should increase the version number >= 1.7.0 where this feature was provided at the first time. The latest version will be tried to used.