### PR TITLE
CB-18806 Add back http_proxy to cloudbreak image proxy config

### DIFF
--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -182,7 +182,8 @@ setup_proxy() {
     fi
     PROXY_ENV_FILE=/etc/cdp/proxy.env
     mkdir -p /etc/cdp
-    echo https_proxy=$PROXY_URL > $PROXY_ENV_FILE
+    echo http_proxy=$PROXY_URL > $PROXY_ENV_FILE
+    echo https_proxy=$PROXY_URL >> $PROXY_ENV_FILE
     if  [[ ! -z ${PROXY_NO_PROXY_HOSTS} ]]; then
       echo no_proxy=${PROXY_NO_PROXY_HOSTS} >> $PROXY_ENV_FILE
     fi


### PR DESCRIPTION
Some customers complained that they are not able to use the configured proxy for http web targets.
This change will somewhat reflect the state at 2022-01-10 The http_proxy was used only, then it was switched to https_proxy at 2022-07-26.

Now this commit unifies these two changes.