### PR TITLE
CB-18927: Ensure SaltStack uses Python 3.6 during image burning

### DIFF
--- a/saltstack/base/salt/prerequisites/jinja.sls
+++ b/saltstack/base/salt/prerequisites/jinja.sls
@@ -1,3 +1,3 @@
 install_jinja2:
-  cmd.run:
-    - name: pip install jinja2
+  pip.installed:
+    - name: jinja2

--- a/saltstack/base/salt/prerequisites/path.sls
+++ b/saltstack/base/salt/prerequisites/path.sls
@@ -10,6 +10,6 @@ set_path_sbin:
 set_path_local_sbin:
   environ.setenv:
     - name: PATH
-    - value: "{{ salt['environ.get']('PATH') }}:/usr/local/sbin"
+    - value: "{{ salt['environ.get']('PATH') }}:/usr/local/sbin:/usr/local/bin"
     - update_minion: True
 {% endif %}

--- a/saltstack/base/salt/prerequisites/pip.sls
+++ b/saltstack/base/salt/prerequisites/pip.sls
@@ -5,34 +5,9 @@ install_openssl_devel:
       - openssl-devel
 {% endif %}
 
-{% if grains['os'] | upper == 'SUSE' %}
-update_python_pip2:
-  cmd.run:
-    - name: pip2 install --upgrade --index=https://pypi.python.org/simple/ pip==9.0.3
-    - onlyif: pip2 -V
-
-update_python_pip3:
-  cmd.run:
-    - name: pip3 install --upgrade --index=https://pypi.python.org/simple/ pip==9.0.3
-    - onlyif: pip3 -V
-
-{% elif grains['os'] != 'Amazon' and not salt['file.directory_exists']('/yarn-private') %}
-update_python_pip2:
-  cmd.run:
-    - name: pip2 install --upgrade --index=https://pypi.python.org/simple/ pip==8.1.2
-    - onlyif: pip2 -V
-
-update_python_pip3:
-  cmd.run:
-    - name: pip3 install --upgrade --index=https://pypi.python.org/simple/ pip==8.1.2
-    - onlyif: pip3 -V
-
-{% endif %}
-
 install_pyyaml:
-  cmd.run:
-    - name: pip install PyYAML --ignore-installed
-    - unless: pip list | grep -E 'PyYAML'
+  pip.installed:
+    - name: PyYAML
 
 install_jq:
   file.managed:

--- a/saltstack/freeipa/salt/ipaconsistency/init.sls
+++ b/saltstack/freeipa/salt/ipaconsistency/init.sls
@@ -1,6 +1,6 @@
 install_checkipaconsistency:
-  cmd.run:
-    - name: pip install checkipaconsistency==2.7.10
+  pip.installed:
+    - name: checkipaconsistency==2.7.10
 
 /usr/local/lib/python3.6/site-packages/checkipaconsistency/main.py:
   file.managed:

--- a/scripts/generate-delta-package-list.sh
+++ b/scripts/generate-delta-package-list.sh
@@ -73,7 +73,7 @@ function collect_rpm_packages() {
 function collect_python_packages() {
   file=$1
   echo "Collecting installed python packages"
-  pip list --format json | jq -r '.[].name' | sort >> "$file"
+  python3 -m pip list --format json | jq -r '.[].name' | sort >> "$file"
   cat "$file"
   PYTHON_PACKAGE_NUMBER=$(wc -l < "$file")
   echo "Found ${PYTHON_PACKAGE_NUMBER} python related package(s)"
@@ -83,9 +83,9 @@ function collect_python_packages() {
 function collect_virtualenv_python_packages() {
   file=$1
   echo "Collecting installed python packages in virtualenv used by Salt"
-  virtualenv ${SALT_PATH}
+  python3 -m virtualenv ${SALT_PATH}
   source ${SALT_PATH}/bin/activate
-  pip list --format json | jq -r '.[].name' | sort >> "$file"
+  python3 -m pip list --format json | jq -r '.[].name' | sort >> "$file"
   cat "$file"
   PYTHON_PACKAGE_NUMBER=$(wc -l < "$file")
   echo "Found ${PYTHON_PACKAGE_NUMBER} python related package(s) in virtualenv"
@@ -167,7 +167,7 @@ function add_python_package_to_csv_list() {
         DETAIL_MAP[$key]=$value
       fi
     fi
-  done <<< "$(pip show -v "$package")"
+  done <<< "$(python3 -m pip show -v "$package")"
   PYTHON_PACKAGE_DETAIL="${DETAIL_MAP["Name"]}|${DETAIL_MAP["Version"]}|$SOURCE_PYTHON|${DETAIL_MAP["License"]}|${DETAIL_MAP["Author"]}|${DETAIL_MAP["Home-page"]}|${DETAIL_MAP["Summary"]}"
   PYTHON_PACKAGE_DETAIL=$(echo $PYTHON_PACKAGE_DETAIL | sed -e "s/;/,/g")
   PYTHON_PACKAGE_DETAIL=$(echo $PYTHON_PACKAGE_DETAIL | sed -e "s/|/;/g")
@@ -235,7 +235,7 @@ function construct_detailed_packages_csv {
     done < "$PYTHON_PACKAGE_LIST_PATH"
   fi
   if [ -f $VIRTUALENV_PYTHON_PACKAGE_LIST_PATH ] ; then
-    virtualenv ${SALT_PATH}
+    python3 -m virtualenv ${SALT_PATH}
     source ${SALT_PATH}/bin/activate
     while read package; do
       if ! contains "$package" "${PYTHON_PACKAGE_ARRAY[@]}" ; then

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -5,34 +5,26 @@
 
 set -ex -o pipefail -o errexit
 
-function install_salt_with_pip() {
-  echo "Installing salt with version: $SALT_VERSION"
-  pip install --upgrade pip
-  pip install virtualenv
+function install_salt_with_pip3() {
 
-  # fix pip3 not installing virtualenv for root
-  if [ "${OS}" != "redhat7" ] ; then
-    ln -s /usr/local/bin/virtualenv /usr/bin/virtualenv
-  else
-    echo "source scl_source enable rh-python36; python3.6 -m virtualenv \$@" > /usr/bin/virtualenv
-    chmod +x /usr/bin/virtualenv
-  fi
+  echo "Installing salt with version: $SALT_VERSION"
+  pip3 install --upgrade pip
+  pip3 install virtualenv
+
   mkdir ${SALT_PATH}
-  virtualenv ${SALT_PATH}
+  python3 -m virtualenv ${SALT_PATH}
   source ${SALT_PATH}/bin/activate
-  if [ "${OS}" == "redhat7" ] ; then
-    # can't install this via salt_requirements.txt and I dunno why...
-    pip install pbr
-  fi
-  pip install --upgrade pip
-  pip install -r /tmp/salt_requirements.txt
+
+  pip3 install --upgrade pip
+  pip3 install pbr
+  pip3 install -r /tmp/salt_requirements.txt
 }
 
 function install_with_apt() {
   export DEBIAN_FRONTEND=noninteractive
   apt-get update
   apt-get install -y apt-transport-https python-pip python-dev build-essential
-  install_salt_with_pip
+  install_salt_with_pip3
   # apt-mark hold salt zeromq zeromq-devel
   install_python_apt_into_virtualenv
   create_temp_minion_config
@@ -97,7 +89,7 @@ function install_with_yum() {
   else
     echo "exclude=salt" >> /etc/yum.conf
   fi
-  install_salt_with_pip
+  install_salt_with_pip3
   create_temp_minion_config
 }
 
@@ -138,9 +130,9 @@ function make_pip3_default_pip() {
   if [ -f "$FILE" ]; then
       mv /bin/pip /bin/pip2
   fi
-  mv /bin/pip3 /bin/pip
+  cp /bin/pip3 /bin/pip
   if [ -f "$FILE" ]; then
-      mv /bin/pip3.6 /bin/pip
+      cp /bin/pip3.6 /bin/pip
   fi
 }
 
@@ -160,7 +152,7 @@ function install_with_zypper() {
   fi
   zypper install -y python-simplejson python-pip zypp-plugin-python gcc gcc-c++ make python-devel
   zypper addlock salt zeromq zeromq-devel
-  install_salt_with_pip
+  install_salt_with_pip3
   create_temp_minion_config
 }
 


### PR DESCRIPTION
This enables us to burn images with the following combination:
 - Python 3.6 (without SaltStack relying on Python 2.7 in any way)
 - CentOS 7
 - SaltStack 3001.8