### PR TITLE
CB-19141: Burn image with Salt version 3005.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ AWS_MAX_ATTEMPTS ?= 300
 PACKAGE_VERSIONS ?= ""
 SALT_VERSION ?= $(shell ./scripts/get-salt-version.sh $(BASE_NAME) $(STACK_VERSION))
 SALT_PATH ?= /opt/salt_$(SALT_VERSION)
-PYZMQ_VERSION ?= 19.0
+PYZMQ_VERSION ?= 20.0
 PYTHON_APT_VERSION ?= 1.1.0_beta1ubuntu0.16.04.1
 
 # This block remains here for backward compatibility reasons when the IMAGE_NAME is not defined as an env variable

--- a/scripts/get-salt-version.sh
+++ b/scripts/get-salt-version.sh
@@ -30,7 +30,7 @@ compare_version () {
 BASE_NAME=$1
 STACK_VERSION=$2
 
-SALT_VERSION=3001.8
+SALT_VERSION=3005.1
 
 if [[ $BASE_NAME == "cb" ]]; then
   if [[ ! -z "$STACK_VERSION" ]]; then


### PR DESCRIPTION
We need to use a newer salt version than the one we are using now. It can be the latest 3005.1