### PR TITLE
CB-18380: Bumped Python version to 3.8, made some cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,7 @@ ifeq ($(OS),centos7)
 	ifeq ($(CLOUD_PROVIDER),GCP)
 		IMAGE_SIZE ?= 48
 	endif
-	ifeq ($(CLOUD_PROVIDER),Azure)
-		IMAGE_SIZE ?= 32
-	endif
-	IMAGE_SIZE ?= 30
+	IMAGE_SIZE ?= 32
 else
 	IMAGE_SIZE ?= 64
 endif

--- a/packer.json
+++ b/packer.json
@@ -1,5 +1,6 @@
 {
   "variables": {
+    "base_name": "{{ env `BASE_NAME` }}",
     "mock": "{{ env `MOCK` }}",
     "description": "{{ env `DESCRIPTION` }}",
     "gcp_account_file": "{{env `GCP_ACCOUNT_FILE`}}",
@@ -431,6 +432,7 @@
       "type": "shell",
       "script": "scripts/salt-install.sh",
       "environment_vars": [
+        "IMAGE_BASE_NAME={{ user `base_name` }}",
         "SALT_INSTALL_OS={{ user `salt_install_os` }}",
         "SALT_INSTALL_REPO={{user `salt_install_repo` }}",
         "SALT_VERSION={{user `salt_version`}}",
@@ -455,6 +457,7 @@
       "expect_disconnect": true,
       "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }} ",
       "environment_vars": [
+        "IMAGE_BASE_NAME={{ user `base_name` }}",
         "CUSTOM_IMAGE_TYPE={{user `custom_image_type`}}",
         "OS_USER={{ user `os_user` }}",
         "CLUSTERMANAGER_VERSION={{user `clustermanager_version`}}",

--- a/saltstack/base/salt/postgresql/scripts/conf_pgconfig_path.sh
+++ b/saltstack/base/salt/postgresql/scripts/conf_pgconfig_path.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+echo "Updating /etc/environment to include PostgreSQL binaries on the path..."    
+cat /etc/environment
+echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/pgsql-11/bin' >>/etc/environment
+cat /etc/environment

--- a/saltstack/base/salt/python3/init.sls
+++ b/saltstack/base/salt/python3/init.sls
@@ -1,0 +1,7 @@
+{% if grains['init'] == 'systemd' -%}
+set_python3_path_systemd:
+  file.replace:
+    - name: /etc/systemd/system.conf
+    - pattern: \#+DefaultEnvironment=.*
+    - repl: DefaultEnvironment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin
+{% endif %}

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -5,6 +5,7 @@ base:
     - cloud-init
 {% endif %}
     - nginx
+    - python3
     - salt-bootstrap
     - salt
     - postgresql

--- a/saltstack/freeipa/salt/ipaconsistency/init.sls
+++ b/saltstack/freeipa/salt/ipaconsistency/init.sls
@@ -1,5 +1,23 @@
+# CentOS 7 / RHEL 7 / RHEL 8 + Python 3.6
 /usr/local/lib/python3.6/site-packages/checkipaconsistency/main.py:
   file.managed:
     - name: /usr/local/lib/python3.6/site-packages/checkipaconsistency/main.py
     - source: salt://{{ slspath }}/scripts/main.py
     - mode: 644
+    - onlyif: ls -la /usr/local/lib/python3.6/site-packages/
+
+# RHEL 8 + Python 3.8
+/usr/local/lib/python3.8/site-packages/checkipaconsistency/main.py:
+  file.managed:
+    - name: /usr/local/lib/python3.8/site-packages/checkipaconsistency/main.py
+    - source: salt://{{ slspath }}/scripts/main.py
+    - mode: 644
+    - onlyif: ls -la /usr/local/lib/python3.8/site-packages/
+
+# CentOS 7 + Python 3.8
+/opt/rh/rh-python38/root/usr/local/lib/python3.8/site-packages/checkipaconsistency/main.py:
+  file.managed:
+    - name: /opt/rh/rh-python38/root/usr/local/lib/python3.8/site-packages/checkipaconsistency/main.py
+    - source: salt://{{ slspath }}/scripts/main.py
+    - mode: 644
+    - onlyif: ls -la /opt/rh/rh-python38/root/usr/local/lib/python3.8/site-packages/

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -9,8 +9,8 @@ set_java_home_user:
 set_java_home_systemd:
   file.replace:
     - name: /etc/systemd/system.conf
-    - pattern: \#+DefaultEnvironment=.*
-    - repl: DefaultEnvironment=JAVA_HOME={{ pillar['JAVA_HOME'] }}
+    - pattern: (DefaultEnvironment=.*)
+    - repl: \1 JAVA_HOME={{ pillar['JAVA_HOME'] }}
 {% endif %}
 
 {% if grains['os_family'] == 'RedHat' %}

--- a/saltstack/hortonworks/salt/pre-warm/tmp/pre_warm_parcels.py
+++ b/saltstack/hortonworks/salt/pre-warm/tmp/pre_warm_parcels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import os
 import json
@@ -9,10 +9,10 @@ import time
 import functools
 import hashlib
 
-print "PRE_WARM_PARCELS: " + os.environ.get("PRE_WARM_PARCELS", "[]")
-print "\n-------------\n"
-print "PRE_WARM_CSD: " + os.environ.get("PRE_WARM_CSD", "[]")
-print "\n-------------\n"
+print("PRE_WARM_PARCELS: " + os.environ.get("PRE_WARM_PARCELS", "[]"))
+print("\n-------------\n")
+print("PRE_WARM_CSD: " + os.environ.get("PRE_WARM_CSD", "[]"))
+print("\n-------------\n")
 
 if os.environ.get("PRE_WARM_PARCELS", "[]"):
     PRE_WARM_PARCELS = json.loads(os.environ.get("PRE_WARM_PARCELS", "[]"))
@@ -24,7 +24,6 @@ if os.environ.get("PRE_WARM_PARCELS", "[]"):
     PARCEL_REPO = "/opt/cloudera/parcel-repo"
     PARCEL_CACHE = "/opt/cloudera/parcel-cache"
 
-
 # PRE_WARM_PARCELS = json.loads(os.environ.get("PRE_WARM_PARCELS", "[]"))
 # PRE_WARM_CSD = json.loads(os.environ.get("PRE_WARM_CSD", "[]"))
 # PARCELS_ROOT = os.environ.get("PARCELS_ROOT", "/home/workstation/dev/cloudera/cloudbreak-images/test-folder/proot")
@@ -33,7 +32,18 @@ if os.environ.get("PRE_WARM_PARCELS", "[]"):
 # CREATE_USERS = False
 # PARCEL_REPO = "/home/workstation/dev/cloudera/cloudbreak-images/test-folder/prepo"
 # PARCEL_CACHE = "/home/workstation/dev/cloudera/cloudbreak-images/test-folder/pcache"
-    
+
+try:
+    isinstance("", basestring)
+    # Definition for Python 2.x
+    def isstr(s):
+        return isinstance(s, basestring)
+except NameError:
+    # Definition for Python 3.x
+    def isstr(s):
+        return isinstance(s, str)
+
+
     def retry(num_attempts=3, sleeptime_in_seconds=1):
         def decorator(func):
             @functools.wraps(func)
@@ -45,7 +55,7 @@ if os.environ.get("PRE_WARM_PARCELS", "[]"):
                         if i == num_attempts - 1:
                             raise
                         else:
-                            print 'Failed with error {0}, trying again'.format(e)
+                            print('Failed with error {0}, trying again'.format(e))
                             time.sleep(sleeptime_in_seconds)
 
             return wrapper
@@ -85,7 +95,7 @@ if os.environ.get("PRE_WARM_PARCELS", "[]"):
             try:
                 checksum_url = url + "." + ext
                 download(checksum_url, dest + ".sha")
-                print "Downloaded checksum file:", dest + ".sha"
+                print("Downloaded checksum file:", dest + ".sha")
                 return ext
             except:
                 pass
@@ -120,13 +130,13 @@ if os.environ.get("PRE_WARM_PARCELS", "[]"):
                 sha_hash.update(byte_block)
 
         if check_if_string_in_file(parcel_dest + ".sha", sha_hash.hexdigest()):
-            print "Hash verification passed for {0}".format(parcel_dest)
+            print("Hash verification passed for {0}".format(parcel_dest))
         else:
             raise Exception("Hash verification failed for {0}".format(parcel_dest))
 
 
     def place_parcel(parcel_path):
-        print "Place parcel: {0}".format(parcel_path)
+        print("Place parcel: {0}".format(parcel_path))
         base_folder, parcel_meta = read_parcel_meta(parcel_path)
         subprocess.check_call("echo Decompress " + parcel_path + ";df -h", shell=True)
 
@@ -145,9 +155,9 @@ if os.environ.get("PRE_WARM_PARCELS", "[]"):
             subprocess.check_call("echo Download " + parcel_file_name + ";df -h", shell=True)
             parcel_url = normalize_url(parcel_repository) + "/" + parcel_file_name
             parcel_dest = os.path.join(PARCEL_REPO, parcel_file_name)
-            print "Downloading parcel {0}, please wait ...".format(parcel_url)
+            print("Downloading parcel {0}, please wait ...".format(parcel_url))
             download(parcel_url, parcel_dest)
-            print "Downloaded parcel:", parcel_url
+            print("Downloaded parcel:", parcel_url)
             hash_method = download_parcel_checksum(parcel_url, parcel_dest)
             verify_checksum(hash_method, parcel_dest)
             place_parcel(parcel_dest)
@@ -156,12 +166,12 @@ if os.environ.get("PRE_WARM_PARCELS", "[]"):
     def place_csds():
         for csd_url in PRE_WARM_CSD:
             subprocess.check_call("echo Download " + csd_url + ";df -h", shell=True)
-            if isinstance(csd_url, basestring):
+            if isstr(csd_url):
                 download(csd_url, os.path.join(CSD_ROOT, csd_url.split("/")[-1]))
-                print "Downloaded CSD:", csd_url
+                print("Downloaded CSD:" + csd_url)
             elif isinstance(csd_url, list):
                 download(csd_url[0], os.path.join(CSD_ROOT, csd_url[1]))
-                print "Downloaded CSD:", csd_url[0]
+                print("Downloaded CSD:" + csd_url[0])
 
 
     def create_users():

--- a/scripts/generate-delta-package-list.sh
+++ b/scripts/generate-delta-package-list.sh
@@ -158,10 +158,6 @@ function add_rpm_package_to_csv_list() {
 function add_python_package_to_csv_list() {
   local package=$1
   declare -A DETAIL_MAP=()
-  PIPCALL="pip"
-  if [ "${OS}" == "redhat8" ] ; then
-    PIPCALL="python3 -m pip"
-  fi
   while IFS= read -r line ; do
     IFS=':' read -r key value <<< "$line"
     key=$(echo ${key} | sed -e 's/^[ \t]*//')
@@ -331,19 +327,13 @@ function contains() {
 echo "Trying to collect installed packages on ${SALT_INSTALL_OS}"
 
 case ${SALT_INSTALL_OS} in
-  centos|redhat)
+
+  centos)
+    export PATH=$PATH:/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin
     execute
     ;;
-  debian|ubuntu)
-    echo "Platform does not support this functionality"
-    exit 0
-    ;;
-  amazon)
+  redhat)
     execute
-    ;;
-  suse)
-    echo "Platform does not support this functionality"
-    exit 0
     ;;
   *)
     echo "Unsupported platform:" $SALT_INSTALL_OS

--- a/scripts/get-salt-version.sh
+++ b/scripts/get-salt-version.sh
@@ -34,15 +34,15 @@ SALT_VERSION=3001.8
 
 if [[ $BASE_NAME == "cb" ]]; then
   if [[ ! -z "$STACK_VERSION" ]]; then
-    compare_version $STACK_VERSION 7.2.15
+    compare_version $STACK_VERSION 7.2.6
     COMP_RESULT=$?
-    # Stack version < 7.2.15 - Lowered this from 7.2.16, because we'll need Python 3.8 on older images too
+    # Stack version < 7.2.6 - Lowered this from 7.2.16, because we'll need Python 3.8 on older images too
     if [[ $COMP_RESULT == 2 ]]; then
       SALT_VERSION=3000.8
     fi
   # Missing STACK_VERSION and BASE_NAME=cb -> base image
   else
-    SALT_VERSION=3000.8
+    SALT_VERSION=3001.8
   fi
 fi
 

--- a/scripts/rhel8_salt_fix.patch
+++ b/scripts/rhel8_salt_fix.patch
@@ -1,4 +1,4 @@
---- /opt/salt_3001.8/lib/python3.6/site-packages/salt/modules/network.py	2022-10-14 08:51:36.756992334 +0000
+--- /opt/salt_3001.8/lib/python3.8/site-packages/salt/modules/network.py	2022-10-14 08:51:36.756992334 +0000
 +++ network.py	2022-10-14 08:53:53.778305601 +0000
 @@ -537,7 +537,17 @@
  

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -8,56 +8,29 @@ set -ex -o pipefail -o errexit
 function install_salt_with_pip3() {
 
   echo "Installing salt with version: $SALT_VERSION"
-  pip3 install --upgrade pip
-  pip3 install virtualenv
+  python3 -m pip install --upgrade pip
+  python3 -m pip install virtualenv
   python3 -m pip install checkipaconsistency==2.7.10
   python3 -m pip install 'PyYAML>=5.1' --ignore-installed
-  
+
+  # OS specific required packages go here
+  if [ "${OS}" == "redhat8" ] ; then
+    python3 -m pip install distro
+  elif [ "${OS}" == "redhat7" ] ; then
+    echo "No OS specific packages required for RedHat 7"
+  elif [ "${OS}" == "centos7" ] ; then
+    echo "No OS specific packages required for CentOS 7"
+  fi
+
+  # Anything installed after this point will end up Salt's venv
   mkdir ${SALT_PATH}
   python3 -m virtualenv ${SALT_PATH}
   source ${SALT_PATH}/bin/activate
+  python3 -m pip install --upgrade pip
 
-  pip3 install --upgrade pip
-  pip3 install pbr
-  pip3 install -r /tmp/salt_requirements.txt
-}
-
-function install_with_apt() {
-  export DEBIAN_FRONTEND=noninteractive
-  apt-get update
-  apt-get install -y apt-transport-https python-pip python-dev build-essential
-  install_salt_with_pip3
-  # apt-mark hold salt zeromq zeromq-devel
-  install_python_apt_into_virtualenv
-  create_temp_minion_config
-  if [ "${OS_TYPE}" == "ubuntu14" ]; then
-    install_nvme-cli
-  fi
-}
-
-function install_python_apt_into_virtualenv() {
-  source ${SALT_PATH}/bin/activate
-  if ! [ -x "$(command -v git)" ]; then
-    echo 'git is not installed.'
-    apt install -y git
-  fi
-
-  # first install build requirements / dependencies
-  if [ "${OS_TYPE}" == "ubuntu18" ] || [ "${OS_TYPE}" == "ubuntu16" ]; then
-    sed -i 's/^# deb-src/deb-src/g' /etc/apt/sources.list
-    apt-get update
-  fi
-  apt-get -y build-dep python-apt
-
-  pip install git+https://git.launchpad.net/python-apt@${PYTHON_APT_VERSION}
-
-  deactivate
-}
-
-function install_nvme-cli () {
-  add-apt-repository -y ppa:sbates
-  apt-get update -y
-  apt-get install -y nvme-cli
+  # Some packages can't be installed via salt_requirements.txt (don't ask why)
+  python3 -m pip install pbr
+  python3 -m pip install -r /tmp/salt_requirements.txt
 }
 
 function install_with_yum() {
@@ -75,98 +48,94 @@ function install_with_yum() {
     fi
   fi
 
-  if [ "${OS_TYPE}" == "redhat8" ] ; then  
-    yum update -y python3
-  else
-    yum update -y python
-  fi
-
   yum install -y yum-utils yum-plugin-versionlock
   yum clean metadata
   enable_epel_repository
   yum groupinstall -y 'Development Tools'
-  if [ "${OS_TYPE}" == "redhat6" ] ; then
-    cp /tmp/repos/${SALT_REPO_FILE} /etc/yum.repos.d/${SALT_REPO_FILE}
-    cp /tmp/repos/saltstack-gpg-key.pub /etc/pki/rpm-gpg/saltstack-gpg-key.pub
-    yum install -y zeromq zeromq-devel
-  fi
+  
   install_python_pip
+  
+  ### Do we need this section at all? Probably not...
   if [ ! -z $(grep "^exclude=" /etc/yum.conf) ]; then
     sed -i 's/^exclude=.*$/& salt/g' /etc/yum.conf
   else
     echo "exclude=salt" >> /etc/yum.conf
   fi
+  ###
+
   install_salt_with_pip3
+  
   create_temp_minion_config
 }
 
 function enable_epel_repository() {
   if [ "${OS}" == "redhat8" ] ; then
     dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-  elif [ "${OS}" == "amazonlinux2" ] || [ "${OS}" == "redhat7" ] ; then
+  elif [ "${OS}" == "redhat7" ] ; then
     curl https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -o epel-release-latest-7.noarch.rpm && yum install --nogpgcheck -y ./epel-release-latest-7.noarch.rpm
-  elif [ "${OS}" == "amazonlinux" ] ; then
-    yum-config-manager --enable epel
-  elif [ "${OS_TYPE}" == "redhat6" ] ; then
-    curl https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm -o epel-release-latest-6.noarch.rpm && yum install -y ./epel-release-latest-6.noarch.rpm
-  else
+  elif [ "${OS}" == "centos7" ] ; then
     yum install -y epel-release
   fi
 }
 
 function install_python_pip() {
+  
   yum install -y openldap-devel
-  if [ "${OS_TYPE}" == "redhat8" ] ; then
-    echo "Installing python3-devel (the rest should be already installed in case of RHEL8)"
-    yum install -y python3-devel
-  elif [ "${OS_TYPE}" == "amazonlinux" ]; then
-    yum install -y python27-devel python27-pip
-  elif [ "${OS_TYPE}" == "redhat7" ] || [ "${OS_TYPE}" == "amazonlinux2" ] ; then
-    echo "Installing python36 with deps"
-    if [ "${OS}" == "redhat7" ] ; then
+  
+  # For now, FreeIPA images have to be left with Python 3.6 and 2.7
+  if [ "${IMAGE_BASE_NAME}" == "freeipa" ] ; then
+    if [ "${OS}" == "redhat8" ] ; then
+      echo "Installing python3-devel (the rest should be already installed in case of RHEL8)..."
+      yum update -y python3
+      yum install -y python3-devel
+
+    elif [ "${OS}" == "redhat7" ] ; then
+      echo "Updating Python 2.7..."
+      yum update -y python
+      echo "Installing Python 3.6 with dependencies..."
       yum-config-manager --enable rhscl
       yum -y install rh-python36
       # pip workaround
       echo "source scl_source enable rh-python36; python3.6 -m pip \$@" > /usr/bin/pip
       chmod +x /usr/bin/pip
-    else
+
+    elif [ "${OS}" == "centos7" ] ; then
+      yum -y install centos-release-scl
+      echo "Updating Python 2.7..."
+      yum update -y python
+      echo "Installing Python 3.6 with dependencies..."
       yum install -y python36 python36-pip python36-devel python36-setuptools
-      make_pip3_default_pip
     fi
+  # For Runtime images we need Python 3.8, but sadly the package
+  # names depend on the OS
   else
-    yum install -y python-pip python-devel
-  fi
-}
+    if [ "${OS}" == "redhat8" ] ; then
+      echo "Upgrading Python 3.6 to Python 3.8..."
+      yum remove -y python3
+      yum install -y python38
+      yum install -y python38-devel python38-libs python38-cffi python38-lxml python38-psycopg2
+      alternatives --set python /usr/bin/python3.8
 
-function make_pip3_default_pip() {
-  FILE=/bin/pip
-  if [ -f "$FILE" ]; then
-      mv /bin/pip /bin/pip2
-  fi
-  cp /bin/pip3 /bin/pip
-  if [ -f "$FILE" ]; then
-      cp /bin/pip3.6 /bin/pip
-  fi
-}
+    elif [ "${OS}" == "redhat7" ] ; then
+      echo "Installing Python 3.8 with dependencies..."
+      yum-config-manager --enable rhscl
+      yum -y install rh-python38
+      # pip workaround
+      echo "source scl_source enable rh-python38; python3.8 -m pip \$@" > /usr/bin/pip
+      chmod +x /usr/bin/pip
 
-function install_with_zypper() {
-  cp /tmp/repos/sles12sp3/* /etc/zypp/repos.d/
-  while [[ $(pgrep -f -c zypper) != 0 ]]; do
-    echo "Zypper is running, waiting 5 sec to continue"
-    sleep 5
-  done
-  zypper --gpg-auto-import-keys refresh
-  if [[ -n "${SLES_REGISTRATION_CODE}" ]] && ! SUSEConnect -s | grep -q \"Registered\"; then
-    echo "SLES_REGISTRATION_CODE="$SLES_REGISTRATION_CODE
-    SUSEConnect --regcode $SLES_REGISTRATION_CODE
+    elif [ "${OS}" == "centos7" ] ; then
+      echo "Installing Python 3.8 with dependencies..."
+      yum -y install centos-release-scl
+      yum -y install openssl-devel libffi-devel bzip2-devel rh-python38-python-pip rh-python38-python-libs rh-python38-python-devel rh-python38-python-cffi rh-python38-python-lxml rh-python38-python-psycopg2
+
+      # We need this because the rh-python38-* packages apparently use a non-standard location... duh!
+      echo "Updating /etc/environment for Python 3.8..."
+      PATH=$PATH:/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin
+      echo "PATH=$PATH" >>/etc/environment
+      cat /etc/environment
+    fi
   fi
-  if ! SUSEConnect -s | grep -q \"sle-sdk\"; then
-    SUSEConnect -p sle-sdk/12.3/x86_64
-  fi
-  zypper install -y python-simplejson python-pip zypp-plugin-python gcc gcc-c++ make python-devel
-  zypper addlock salt zeromq zeromq-devel
-  install_salt_with_pip3
-  create_temp_minion_config
 }
 
 function create_temp_minion_config() {
@@ -184,20 +153,6 @@ case ${SALT_INSTALL_OS} in
   centos|redhat)
     echo "Install with yum"
     install_with_yum
-    ;;
-  debian|ubuntu)
-    echo "Install with apt"
-    install_with_apt
-    ;;
-  amazon)
-    echo "Install for Amazon linux"
-    echo "Return code: $?"
-    echo "Install with yum"
-    install_with_yum
-    ;;
-  suse)
-    echo "Install with zypper"
-    install_with_zypper
     ;;
   *)
   echo "Unsupported platform:" $1

--- a/scripts/salt-setup.sh
+++ b/scripts/salt-setup.sh
@@ -32,7 +32,11 @@ EOF
 
 function apply_rhel8_salt_patch {
   if [ "${OS}" == "redhat8" ] ; then
-    patch -t -u /opt/salt_3001.8/lib/python3.6/site-packages/salt/modules/network.py -i /tmp/rhel8_salt_fix.patch
+    if [ "${IMAGE_BASE_NAME}" == "freeipa" ] ; then
+      patch -t -u /opt/salt_3001.8/lib/python3.6/site-packages/salt/modules/network.py -i /tmp/rhel8_salt_fix.patch
+    else
+      patch -t -u /opt/salt_3001.8/lib/python3.8/site-packages/salt/modules/network.py -i /tmp/rhel8_salt_fix.patch
+    fi
   fi
 }
 

--- a/scripts/sparseimage/packer.json
+++ b/scripts/sparseimage/packer.json
@@ -14,7 +14,7 @@
         "root_volume_size": "90",
         "instance_size" : "m4.xlarge",
         "aws_ami_base_snapshot" : "{{env `SOURCE_AMI_SNAPSHOT`}}",
-        "aws_ami_base_snapshot_size" : "30",
+        "aws_ami_base_snapshot_size" : "32",
         "aws_snapshot_groups": "{{ env `AWS_SNAPSHOT_GROUPS` }}",
         "aws_ami_groups": "{{ env `AWS_AMI_GROUPS` }}",        
         "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",


### PR DESCRIPTION
Supersedes https://github.com/hortonworks/cloudbreak-images/pull/740

- Made sure we install the right Python version for the right OS (CB-18380)
 - Increased AMI base snapshot size (CB-19722)
 - Fixed rh-python38 root path (CB-19812)
 - Fixed psycopg2 installation (CB-19812)
 - Removed a leftover python2 reference (CB-19529)
 - Python3-ified pre_warm_parcels.py (CB-19529)
 - Added code to update Python 3.6 to Python 3.8 (CB-19529)
 - Set Python 3.8 as "python" globally for RHEL 8 as CM currently needs this to work! (CB-20079)
 - Updated path with pg_config for PsycoPG installed by CB (CB-20079)
 - Added postgresql11-devel
 - Increased SaltStack version to 3001.8 across the board for everything including and above 7.2.6
 - Made sure that FreeIPA will be installed with Python 3.6 and 2.7 on RHEL and CentOS respectfully