### PR TITLE
CB-19579 CB-19578 Lock users for 15min after 3 failed login

### DIFF
--- a/saltstack/base/salt/prerequisites/authconfig.sls
+++ b/saltstack/base/salt/prerequisites/authconfig.sls
@@ -1,0 +1,30 @@
+{% if grains['os_family'] == 'RedHat' %}
+{% if grains['osmajorrelease'] | int == 7 %}
+set_faillock_args:
+  file.replace:
+    - name: /etc/sysconfig/authconfig
+    - pattern: "^FAILLOCKARGS=.*"
+    - repl: 'FAILLOCKARGS="audit deny=3 unlock_time=900"'
+    - append_if_not_found: True
+
+enable_faillock:
+  file.replace:
+    - name: /etc/sysconfig/authconfig
+    - pattern: "^USEFAILLOCK=.*"
+    - repl: 'USEFAILLOCK=yes'
+    - append_if_not_found: True
+{% endif %}
+{% if grains['osmajorrelease'] | int == 8 %}
+/etc/security/faillock.conf:
+  file.managed:
+    - user: root
+    - group: root
+    - source:
+      - salt://{{ slspath }}/etc/security/faillock.conf
+    - mode: 644
+
+enable-faillock:
+  cmd.run:
+    - name: authselect enable-feature with-faillock
+{% endif %}
+{% endif %}

--- a/saltstack/base/salt/prerequisites/etc/security/faillock.conf
+++ b/saltstack/base/salt/prerequisites/etc/security/faillock.conf
@@ -1,0 +1,3 @@
+audit
+deny=3
+unlock_time=900

--- a/saltstack/base/salt/prerequisites/init.sls
+++ b/saltstack/base/salt/prerequisites/init.sls
@@ -22,6 +22,7 @@ include:
 {% if pillar['OS'].startswith('ubuntu') %}
   - {{ slspath }}.disable-unattended-upgrades
 {% endif %}
+  - {{ slspath }}.authconfig
 
 /usr/bin/:
   file.recurse:

--- a/saltstack/final/salt/cis-controls/etc/pam.d/password-auth
+++ b/saltstack/final/salt/cis-controls/etc/pam.d/password-auth
@@ -1,10 +1,10 @@
 auth        required      pam_env.so
-auth        required      pam_faillock.so preauth silent audit deny=5 unlock_time=900
+auth        required      pam_faillock.so preauth silent audit deny=3 unlock_time=900
 auth        required      pam_faildelay.so delay=2000000
 auth        [default=1 ignore=ignore success=ok] pam_succeed_if.so uid >= 1000 quiet
 auth        [default=1 ignore=ignore success=ok] pam_localuser.so
 auth        sufficient    pam_unix.so nullok try_first_pass
-auth        [default=die] pam_faillock.so authfail audit deny=5 unlock_time=900
+auth        [default=die] pam_faillock.so authfail audit deny=3 unlock_time=900
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient    pam_sss.so forward_pass
 auth        required      pam_deny.so

--- a/saltstack/final/salt/cis-controls/etc/pam.d/system-auth
+++ b/saltstack/final/salt/cis-controls/etc/pam.d/system-auth
@@ -1,11 +1,11 @@
 auth        required      pam_env.so
-auth        required      pam_faillock.so preauth silent audit deny=5 unlock_time=900
+auth        required      pam_faillock.so preauth silent audit deny=3 unlock_time=900
 auth        required      pam_faildelay.so delay=2000000
 auth        sufficient    pam_fprintd.so
 auth        [default=1 ignore=ignore success=ok] pam_succeed_if.so uid >= 1000 quiet
 auth        [default=1 ignore=ignore success=ok] pam_localuser.so
 auth        sufficient    pam_unix.so nullok try_first_pass
-auth        [default=die] pam_faillock.so authfail audit deny=5 unlock_time=900
+auth        [default=die] pam_faillock.so authfail audit deny=3 unlock_time=900
 auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
 auth        sufficient    pam_sss.so forward_pass
 auth        required      pam_deny.so


### PR DESCRIPTION
Modified CIS configs to match the requirements. These (CIS configs) are centos7 only.
RH7 based changes: Adjusted authconfig configuration as during freeipa server or client installation the pam configuration is overridden based on authconfig.
RH8 based changes: RH8 switched to authselect from authconfig. Faillock parameters are in a different config, and it's enabled with a command