### PR TITLE
CB-19582 CB-19583 Configure SSH/user session timeout for all systems

### DIFF
--- a/saltstack/base/salt/prerequisites/etc/profile.d/timeout.sh
+++ b/saltstack/base/salt/prerequisites/etc/profile.d/timeout.sh
@@ -1,0 +1,3 @@
+# Ensure default user shell timeout is 900 seconds
+readonly TMOUT=900
+export TMOUT

--- a/saltstack/base/salt/prerequisites/init.sls
+++ b/saltstack/base/salt/prerequisites/init.sls
@@ -16,6 +16,7 @@ include:
   - {{ slspath }}.user
   - {{ slspath }}.firewall
   - {{ slspath }}.umask
+  - {{ slspath }}.timeout
   - {{ slspath }}.jinja
   - {{ slspath }}.corkscrew
   - {{ slspath }}.storage

--- a/saltstack/base/salt/prerequisites/timeout.sls
+++ b/saltstack/base/salt/prerequisites/timeout.sls
@@ -1,0 +1,7 @@
+/etc/profile.d/timeout.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - source:
+      - salt://{{ slspath }}/etc/profile.d/timeout.sh
+    - mode: 755

--- a/saltstack/final/salt/cis-controls/init.sls
+++ b/saltstack/final/salt/cis-controls/init.sls
@@ -641,10 +641,6 @@ Umask027:
 Umask077:
   cmd.run:
     - name: "for TEMPLATE in 'bashrc' 'profile'; do sed -i 's|umask 022|umask 077|g' /etc/${TEMPLATE}; done"
-#Ensure default user shell timeout is 900 seconds or less
-TMOUT_profile:
-  cmd.run:
-    - name: printf "readonly TMOUT=900 ; export TMOUT" >> /etc/profile
 
 #### CIS: Ensure access to the su command is restricted
 #https://jira.cloudera.com/browse/CB-8929


### PR DESCRIPTION
Currently the timeout was added only for Centos 7. Refactored the related states:
- it's applied to all OS
- matches the structure of how we configure profile