### PR TITLE
CDPCP-8354: Upgrade base images for thunderhead-metering-heartbeat-application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ CDP_TELEMETRY_VERSION ?= ""
 CDP_LOGGING_AGENT_VERSION ?= ""
 
 DEFAULT_JUMPGATE_AGENT_RPM_URL := "https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/33961184/jumpgate/3.x/redhat7/yum/tars/jumpgate/jumpgate-agent.rpm"
-DEFAULT_METERING_AGENT_RPM_URL := "https://archive.cloudera.com/cp_clients/thunderhead-metering-heartbeat-application-1.0.0-b8225.x86_64.rpm"
+DEFAULT_METERING_AGENT_RPM_URL := "https://archive.cloudera.com/cp_clients/thunderhead-metering-heartbeat-application-1.0.0-b8780.x86_64.rpm"
 DEFAULT_FREEIPA_PLUGIN_RPM_URL := "https://cloudera-service-delivery-cache.s3.amazonaws.com/cdp-hashed-pwd/workloads/cdp-hashed-pwd-1.0-20200319002729gitc964030.x86_64.rpm"
 DEFAULT_FREEIPA_HEALTH_AGENT_RPM_URL := "https://cloudera-service-delivery-cache.s3.amazonaws.com/freeipa-health-agent/packages/freeipa-health-agent-0.1-20220326020204gitb2ffef7.x86_64.rpm"
 DEFAULT_FREEIPA_LDAP_AGENT_RPM_URL := "https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/35268357/thunderhead/1.x/redhat7/yum/tars/thunderhead/freeipa-ldap-agent-1.0.0-b8901.x86_64.rpm"


### PR DESCRIPTION
update metering agent to use latest build, 1.0.0-b8780.

CDPCP-8354