### PR TITLE
Revert "CB-18661 avoid the "ssl" directive is deprecated warning mess…

### DIFF
--- a/README.image-content.md
+++ b/README.image-content.md
@@ -15,11 +15,11 @@ This section provides information about the packages of specified images to be i
 
 ## Source of base images
 
-|Cloud Provider | OS | Source                     |
-|--------------| ---- |----------------------------|
-|AWS           | CentOS 7 | `ami-098f55b4287a885ba`    |
-|Azure         | CentOS 7 | `OpenLogic - CentOS - 7.6` |
-|Gcp           | CentOS 7 | `centos-7-v20200811`       |
+ Cloud Provider | OS | Source
+ ---- | ---- | ----
+ AWS | CentOS 7 | `ami-098f55b4287a885ba`
+ Azure | CentOS 7 |  `OpenLogic - CentOS - 7.6`
+ Gcp | CentOS 7 |  `centos-7-v20200811`
 
 ## Salt requirements
 - requests
@@ -80,6 +80,8 @@ This section provides information about the packages of specified images to be i
 - policycoreutils-python (RedHat)
 - cloud-init
 - fluentd
+- consul-template
+- consul
 - node-exporter
 - jmx-exporter
 - prometheus

--- a/saltstack/base/salt/nginx/etc/nginx/nginx.conf
+++ b/saltstack/base/salt/nginx/etc/nginx/nginx.conf
@@ -49,8 +49,8 @@ http {
 
     server_tokens off;
 
-    upstream clouderamanager {
-        server 127.0.0.1:7183;
+    upstream ambari {
+        server 127.0.0.1:8080;
     }
 
     upstream saltboot {
@@ -59,6 +59,30 @@ http {
 
     upstream saltapi {
         server 127.0.0.1:3080;
+    }
+
+    upstream prometheus {
+        server 127.0.0.1:9090;
+    }
+
+    upstream consul {
+        server 127.0.0.1:8500;
+    }
+
+    server {
+        listen 1080;
+
+        allow  10.0.0.0/8;
+        allow  172.16.0.0/12;
+        allow  192.168.0.0/16;
+
+        location ~ /exporter/(.*) {
+            proxy_pass         http://127.0.0.1:$1;
+            proxy_redirect     off;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Forwarded-Host $server_name;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
     }
 
     include /etc/nginx/sites-enabled/*.conf;

--- a/saltstack/base/salt/nginx/etc/nginx/ssl.conf
+++ b/saltstack/base/salt/nginx/etc/nginx/ssl.conf
@@ -1,13 +1,65 @@
+{% if pillar['CUSTOM_IMAGE_TYPE'] != 'freeipa' %}
 server {
     add_header x-response-nginx true always;
-    listen       9443 ssl;
+    listen       443;
+    ssl on;
+    ssl_certificate      /etc/certs/cluster.pem;
+    ssl_certificate_key  /etc/certs/cluster-key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    rewrite ^([^/]*/ambari)$ $1/ permanent;
+    # e.g.: https://172.22.107.133/img/white-logo.png -> https://172.22.107.133/ambari/img/white-logo.png
+    if ($http_referer ~ .*/ambari/.*) {
+        rewrite ^([/](?!ambari/).*$) /ambari$1;
+    }
+    if ($cookie_AMBARISESSIONID ~ .+) {
+        rewrite ^([/](?!ambari/).*$) /ambari$1;
+    }
+    location / {
+        rewrite ^(/)$  https://$host/ambari;
+    }
+    location ~ .*/ambari/(.*) {
+        proxy_pass         http://ambari/$1$is_args$args;
+          proxy_redirect     off;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
 
+}
+{% endif %}
+#curl --verbose --key ./key.pem --cert ./cert.pem -k --user "user:password" -H "Accept: application/json" https://104.155.27.67:9443/saltboot/health
+server {
+    add_header x-response-nginx true always;
+    listen       9443;
+    ssl on;
     ssl_certificate      /etc/certs/cluster.pem;
     ssl_certificate_key  /etc/certs/cluster-key.pem;
     ssl_client_certificate /etc/certs/cb-client.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_verify_client on;
-
+{% if pillar['CUSTOM_IMAGE_TYPE'] != 'freeipa' %}
+    location / {
+        proxy_pass         http://ambari;
+          proxy_redirect     off;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+    location /prometheus {
+        proxy_pass         http://prometheus;
+          proxy_redirect     off;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+    location /consul/v1 {
+        proxy_pass         http://consul/v1;
+          proxy_redirect     off;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+{% endif %}
     location /saltboot {
         proxy_pass         http://saltboot;
           proxy_redirect     off;

--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -44,7 +44,7 @@ setup_tmp_ssh() {
 
 format_disks() {
   lazy_format_disks
-  cd /hadoopfs/fs1 && mkdir logs logs/kerberos
+  cd /hadoopfs/fs1 && mkdir logs logs/ambari-server logs/ambari-agent logs/consul-watch logs/kerberos
 }
 
 lazy_format_disks() {

--- a/scripts/hardcoded-packages.csv
+++ b/scripts/hardcoded-packages.csv
@@ -1,5 +1,7 @@
 certm;0.1.3;Hardcoded;UNKNOWN;keyki;https://github.com/keyki/certm/releases/download/v0.1.3/certm_0.1.3_Linux_x86_64.tgz;CertM is a simple tool to generate TLS certificates and keys.
 cert-tool;0.0.1;Hardcoded;UNKNOWN;Evan Hazlett;https://github.com/ehazlett/certm/releases/download/v0.0.1/cert-tool_linux_amd64;CertM is a simple tool to generate TLS certificates and keys.
+consul;0.7.3;Hardcoded;UNKNOWN;Hashicorp;https://releases.hashicorp.com/consul/0.7.3/consul_0.7.3_linux_amd64.zip;Automate service-based networking in the cloud.
+consul_template;0.16.0;Hardcoded;UNKNOWN;Hashicorp;https://releases.hashicorp.com/consul-template/0.16.0/consul-template_0.16.0_linux_amd64.zip;Automate service-based networking in the cloud.
 jmx_prometheus_javaagent;0.2.0;Hardcoded;Apache License 2.0;Prometheus;https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.2.0/jmx_prometheus_javaagent-0.2.0.jar;JMX to Prometheus exporter: a collector that can configurably scrape and expose mBeans of a JMX target.
 jq;1.5-r5;Hardcoded;MIT license, CC-BY-3.0 license;Stephen Dolan;http://stedolan.github.io/jq/download/linux64/jq;jq is a lightweight and flexible command-line JSON processor.
 node_exporter;0.12.0;Hardcoded;Apache License 2.0;Prometheus;https://github.com/prometheus/node_exporter/releases/download/0.12.0/node_exporter-0.12.0.linux-amd64.tar.gz;Prometheus exporter for hardware and OS metrics exposed by *NIX kernels, written in Go with pluggable metric collectors.


### PR DESCRIPTION
…age, and delete the dead code and free up the port 1080."

This reverts commit 941c3f3fcf7147c6d182c43e395e877c1ee0d294. Image validators started failing after this commit got merged:
- http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-gcp/1174/
- http://ci-cloudbreak.eng.hortonworks.com/view/e2e-test/job/api-e2e-imagevalidator-aws/2466/
- http://ci-cloudbreak.eng.hortonworks.com/view/e2e-test/job/api-e2e-imagevalidator-azure/2247/