### PR TITLE
CB-19862 Do not create compute images on GCP for 7.2.17 runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,6 +378,7 @@ build-gc-tar-file:
 	GCP_AMI_REGIONS=$(GCP_AMI_REGIONS) \
 	GCP_STORAGE_BUNDLE=$(GCP_STORAGE_BUNDLE) \
 	GCP_STORAGE_BUNDLE_LOG=$(GCP_STORAGE_BUNDLE_LOG) \
+	STACK_VERSION=$(STACK_VERSION) \
 	./scripts/bundle-gcp-image.sh
 
 build-gc-centos7:

--- a/scripts/bundle-gcp-image.sh
+++ b/scripts/bundle-gcp-image.sh
@@ -45,6 +45,12 @@ main() {
 
 	docker run --rm --name gcloud-create-instance-$IMAGE_NAME --volumes-from gcloud-config-$IMAGE_NAME google/cloud-sdk gcloud compute images export --quiet --destination-uri gs://${GCP_STORAGE_BUNDLE}/${IMAGE_PRE_NAME}${IMAGE_NAME}.tar.gz --image ${IMAGE_NAME} --project ${GCP_PROJECT}
 	docker run --rm --name gcloud-create-instance-public-$IMAGE_NAME --volumes-from gcloud-config-$IMAGE_NAME google/cloud-sdk gsutil -m acl ch -r -u AllUsers:R gs://${GCP_STORAGE_BUNDLE}/${IMAGE_PRE_NAME}${IMAGE_NAME}.tar.gz
+
+	if [[ "$STACK_VERSION" == "7.2.17" ]]; then
+	  echo "Removing compute image"
+	  docker run --rm --name gcloud-remove-compute-image-$IMAGE_NAME --volumes-from gcloud-config-$IMAGE_NAME google/cloud-sdk gcloud compute images delete --quiet $IMAGE_NAME
+  fi
+
 	exit 0
 }
 


### PR DESCRIPTION
Skip creating compute images on GCP as we are only using their tar.gz counterpart.