### PR TITLE
CB-20929 Fix missing JAVA_HOME env variable and python version condition

### DIFF
--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -9,7 +9,7 @@ set_java_home_user:
 set_java_home_systemd:
   file.replace:
     - name: /etc/systemd/system.conf
-    - pattern: (DefaultEnvironment=.*)
+    - pattern: \#*(DefaultEnvironment=.*)
     - repl: \1 JAVA_HOME={{ pillar['JAVA_HOME'] }}
 {% endif %}
 

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -110,7 +110,7 @@ function install_python_pip() {
     fi
 
   # For images with Runtime 7.2.15 and below we only support RHEL7 and CentOS7 with Python 2.7 and 3.6
-  elif [ $(version $STACK_VERSION) -le $(version "7.2.16") ]; then
+  elif [ $(version $STACK_VERSION) -le $(version "7.2.15") ]; then
     if [ "${OS}" == "redhat7" ] ; then
       echo "Updating Python 2.7..."
       yum update -y python


### PR DESCRIPTION
The append of JAVA_HOME variable to systemd's default environment variables should result in a line without being a comment even it was a commented out line before. Also fix the runtime check for python version condition.