### PR TITLE
CB-20961: Multiple Python3 versions on the same image, depending on image type and RT version

### DIFF
--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -322,8 +322,8 @@ psycopg2-centos7-py36:
 psycopg2-rhel8-py38:
   pip.installed:
     - name: psycopg2==2.9.3
-    - bin_env: /usr/local/bin/pip3
-    - onlyif: ls -la /usr/local/lib/python3.8/site-packages/
+    - bin_env: /usr/local/bin/pip3.8
+    - onlyif: ls -la /usr/lib64/python3.8/site-packages
 
 # CentOS 7 + Python 3.8
 psycopg2-centos7-py38:

--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -315,7 +315,7 @@ set-path-pgsql11-bin:
 psycopg2-centos7-py36:
   pip.installed:
     - name: psycopg2==2.9.3
-    - bin_env: /usr/local/lib/python3.6/bin/pip3
+    - bin_env: /usr/local/bin/pip3
     - onlyif: ls -la /usr/local/lib/python3.6/site-packages/
 
 # RHEL 8 + Python 3.8
@@ -329,5 +329,5 @@ psycopg2-rhel8-py38:
 psycopg2-centos7-py38:
   pip.installed:
     - name: psycopg2==2.9.3
-    - bin_env: /opt/rh/rh-python38/root/usr/local/bin/pip3
-    - onlyif: ls -la /opt/rh/rh-python38/root/usr/local/lib/python3.8/site-packages/
+    - bin_env: /opt/rh/rh-python38/root/usr/bin/pip3
+    - onlyif: ls -la /opt/rh/rh-python38/root/usr/lib/python3.8/site-packages/

--- a/saltstack/base/salt/python3/init.sls
+++ b/saltstack/base/salt/python3/init.sls
@@ -6,3 +6,22 @@ set_python3_path_systemd:
     - repl: DefaultEnvironment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/rh/rh-python38/root/usr/local/bin:/opt/rh/rh-python38/root/usr/bin
     - onlyif: ls -la /opt/rh/rh-python38/root/usr/local/
 {% endif %}
+
+# Install distro globally
+
+# CentOS 7 / RHEL 7 / RHEL 8 + Python 3.6
+distro-centos7-py36:
+  pip.installed:
+    - name: distro
+    - bin_env: /usr/local/bin/pip3
+    - onlyif: ls -la /usr/local/lib/python3.6/site-packages/
+
+# RHEL 8 + Python 3.8
+# For RHEL 8 this is installed in salt-install.sh, because it is required for Salt
+
+# CentOS 7 + Python 3.8
+distro-centos7-py38:
+  pip.installed:
+    - name: distro
+    - bin_env: /opt/rh/rh-python38/root/usr/bin/pip3
+    - onlyif: ls -la /opt/rh/rh-python38/root/usr/lib/python3.8/site-packages/

--- a/scripts/salt-setup.sh
+++ b/scripts/salt-setup.sh
@@ -32,9 +32,10 @@ EOF
 
 function apply_rhel8_salt_patch {
   if [ "${OS}" == "redhat8" ] ; then
-    if [ "${IMAGE_BASE_NAME}" == "freeipa" ] ; then
+    if [ -f "/opt/salt_3001.8/lib/python3.6/site-packages/salt/modules/network.py" ]; then
       patch -t -u /opt/salt_3001.8/lib/python3.6/site-packages/salt/modules/network.py -i /tmp/rhel8_salt_fix.patch
-    else
+    fi
+    if [ -f "/opt/salt_3001.8/lib/python3.8/site-packages/salt/modules/network.py" ]; then
       patch -t -u /opt/salt_3001.8/lib/python3.8/site-packages/salt/modules/network.py -i /tmp/rhel8_salt_fix.patch
     fi
   fi


### PR DESCRIPTION
This should also solve **CB-21011** and **CB-21199**.

**Original requirement from Slack:**

7.2.16.2 (and all subsequent 7.2.16.x service packs) CentOS7 images:
Python 2 present on the Cloudbreak images
Python 3 present on the Cloudbreak images, Py 3.6 remains the default for “python3”, but Py3.8 is also present (for Hue)

7.2.17 (and all subsequent 7.2.17 service packs:) CentOS7 images:
Python 2 present on the Cloudbreak images
Python 3 present on the Cloudbreak images, Py 3.6 remains the default for “python3", but Py3.8 is also present (for Hue)

7.2.17 (and all subsequent 7.2.17 service packs:) RHEL8 images:
Python 2 present on the Cloudbreak images
Python 3 present on the Cloudbreak images, Py 3.8 becomes the default for “python3”, but Py3.6 is also present (for legacy apps, including pyspark2)

**Also, additional info:**

7.2.16.2 (and all subsequent 7.2.16.x service packs) RHEL8 images:
Python 3 present on the Cloudbreak images, Py 3.6 remains the default for “python3”, but Py3.8 is also present (for Hue)

Base RHEL8 images:
Python 3 present on the Cloudbreak images, Py 3.6 remains the default for “python3”, but Py3.8 is also present (for Hue)

Base CentOS images:
Python 2 present on the Cloudbreak images
Python 3 present on the Cloudbreak images, Py 3.6 remains the default for “python3", but Py3.8 is also present (for Hue)