### PR TITLE
CDPAM-3882 | Make jumpgate agent certificate and key parameters options for CCMv2

### DIFF
--- a/saltstack/base/salt/prerequisites/usr/bin/ccmv2-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/ccmv2-helper.sh
@@ -16,7 +16,7 @@ setup_ccmv2() {
   touch "$AGENT_KEY_PATH"
   touch "$AGENT_CERT_PATH"
 
-  if [[ ! -z "$CCM_V2_AGENT_CERTIFICATE" &&  -z $CCM_V2_AGENT_ENCIPHERED_KEY ]]; then
+  if [[ ! -z "$CCM_V2_AGENT_CERTIFICATE" &&  ! -z $CCM_V2_AGENT_ENCIPHERED_KEY ]]; then
     CCM_V2_AGENT_KEY_HEX=$(xxd -pu -l 16 <<< $CCM_V2_AGENT_KEY_ID)
     echo ${CCM_V2_AGENT_ENCIPHERED_KEY} | openssl enc -aes-128-cbc -d -A -a -K ${CCM_V2_AGENT_KEY_HEX} -iv ${LEGACY_IV} > ${AGENT_KEY_PATH}
     chmod 400 "$AGENT_KEY_PATH"

--- a/saltstack/base/salt/prerequisites/usr/bin/ccmv2-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/ccmv2-helper.sh
@@ -1,8 +1,6 @@
 setup_ccmv2() {
   : ${CCM_V2_INVERTING_PROXY_CERTIFICATE:? required}
   : ${CCM_V2_INVERTING_PROXY_HOST:? required}
-  : ${CCM_V2_AGENT_CERTIFICATE:? required}
-  : ${CCM_V2_AGENT_ENCIPHERED_KEY:? required}
   : ${CCM_V2_AGENT_KEY_ID:? required}
   : ${CCM_V2_AGENT_BACKEND_ID_PREFIX:? required}
 
@@ -14,14 +12,18 @@ setup_ccmv2() {
 
   LEGACY_IV=436c6f7564657261436c6f7564657261
   AGENT_KEY_PATH=/etc/ccmv2/ccmv2-key.enc
-
-  CCM_V2_AGENT_KEY_HEX=$(xxd -pu -l 16 <<< $CCM_V2_AGENT_KEY_ID)
-  echo ${CCM_V2_AGENT_ENCIPHERED_KEY} | openssl enc -aes-128-cbc -d -A -a -K ${CCM_V2_AGENT_KEY_HEX} -iv ${LEGACY_IV} > ${AGENT_KEY_PATH}
-  chmod 400 "$AGENT_KEY_PATH"
-
   AGENT_CERT_PATH=/etc/ccmv2/ccmv2-cert.enc
-  echo "$CCM_V2_AGENT_CERTIFICATE" | base64 --decode > "$AGENT_CERT_PATH"
-  chmod 400 "$AGENT_CERT_PATH"
+  touch "$AGENT_KEY_PATH"
+  touch "$AGENT_CERT_PATH"
+
+  if [[ ! -z "$CCM_V2_AGENT_CERTIFICATE" &&  -z $CCM_V2_AGENT_ENCIPHERED_KEY ]]; then
+    CCM_V2_AGENT_KEY_HEX=$(xxd -pu -l 16 <<< $CCM_V2_AGENT_KEY_ID)
+    echo ${CCM_V2_AGENT_ENCIPHERED_KEY} | openssl enc -aes-128-cbc -d -A -a -K ${CCM_V2_AGENT_KEY_HEX} -iv ${LEGACY_IV} > ${AGENT_KEY_PATH}
+    chmod 400 "$AGENT_KEY_PATH"
+
+    echo "$CCM_V2_AGENT_CERTIFICATE" | base64 --decode > "$AGENT_CERT_PATH"
+    chmod 400 "$AGENT_CERT_PATH"
+  fi
 
   TRUSTED_BACKEND_CERT_PATH="/etc/jumpgate/cluster.pem"
 


### PR DESCRIPTION
This PR makes the required changes to make Jumpgate-agent certificate and key parameters optional as we would not be generating those in CCMv2 service when FIPS is enabled. Changes are tested with below scenarios:

Testing:

- Create an environment with only a new freeipa image (which is burned with changes from this CDPAM-3883 branch) and no CCMv2 side changes (without one-way TLS)
- Create an environment with only a new freeipa image and no CCMv2 side changes (with one-way TLS)
- Create an environment with a new freeipa image and new CCMv2 docker image (without one-way TLS and fips enabled)
- Create an environment with a new freeipa image and new CCMv2 docker image (with one-way TLS and fips enabled)
- Create an environment with a new freeipa image and new CCMv2 docker image (without one-way TLS and fips disabled)
- Create an environment with a new freeipa image and new CCMv2 docker image (with one-way TLS and fips disabled)