### PR TITLE
CDPAM-3971 | Update jumpgate agent version to support CDPAM-1835

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ ARCHIVE_CREDENTIALS ?= ":"
 CDP_TELEMETRY_VERSION ?= ""
 CDP_LOGGING_AGENT_VERSION ?= ""
 
-DEFAULT_JUMPGATE_AGENT_RPM_URL := "https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/37118790/jumpgate/3.x/redhat8/yum/jumpgate-agent.rpm"
+DEFAULT_JUMPGATE_AGENT_RPM_URL := "https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/38343515/jumpgate/3.x/redhat8/yum/jumpgate-agent.rpm"
 DEFAULT_METERING_AGENT_RPM_URL := "https://archive.cloudera.com/cp_clients/thunderhead-metering-heartbeat-application-1.0.0-b8780.x86_64.rpm"
 DEFAULT_FREEIPA_PLUGIN_RPM_URL := "https://cloudera-service-delivery-cache.s3.amazonaws.com/cdp-hashed-pwd/workloads/cdp-hashed-pwd-1.0-20200319002729gitc964030.x86_64.rpm"
 DEFAULT_FREEIPA_HEALTH_AGENT_RPM_URL := "https://cloudera-service-delivery-cache.s3.amazonaws.com/freeipa-health-agent/packages/freeipa-health-agent-0.1-20230125124737git1961633.x86_64.rpm"


### PR DESCRIPTION
This PR updates the Jumpgate agent version from 3.0.3 to 3.0.4 for our new release.

Changes are tested with CCM test runs and CCM e2e test runs with custom images. Below are the image IDs:

```
AWS: be143b3e-a16e-43c3-9064-be0b610b26dd

AWS_GOV: 5665fcb5-93bd-4d6e-a43c-b8a708ae11fd

Azure: 4208cf32-9584-491a-a8df-f3255c945526

GCP: 3438bced-6df7-4c88-8a14-2833ecd75d69

```
