### PR TITLE
CB-21044 Patch FreeIPA constants lib to support hostnames longer than…

### DIFF
--- a/saltstack/base/salt/prerequisites/init.sls
+++ b/saltstack/base/salt/prerequisites/init.sls
@@ -24,6 +24,8 @@ include:
   - {{ slspath }}.disable-unattended-upgrades
 {% endif %}
   - {{ slspath }}.authconfig
+  - {{ slspath }}.ipa
+
 
 /usr/bin/:
   file.recurse:

--- a/saltstack/base/salt/prerequisites/ipa-constants.patch
+++ b/saltstack/base/salt/prerequisites/ipa-constants.patch
@@ -1,0 +1,11 @@
+--- constants.py	2022-06-15 14:39:26.000000000 +0000
++++ constants.py.patched	2023-04-03 14:48:44.798318271 +0000
+@@ -311,7 +311,7 @@
+ 
+ # Maximum hostname length in Linux
+ # It's the max length of uname's nodename and return value of gethostname().
+-MAXHOSTNAMELEN = 64
++MAXHOSTNAMELEN = 253
+ # DNS name is 255 octets, effectively 253 ASCII characters.
+ MAXHOSTFQDNLEN = 253
+ 

--- a/saltstack/base/salt/prerequisites/ipa.sls
+++ b/saltstack/base/salt/prerequisites/ipa.sls
@@ -1,0 +1,6 @@
+{% if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] | int == 8 %}
+patch_ipa_constants_hostname:
+  file.patch:
+    - name: /usr/lib/python3.6/site-packages/ipalib/constants.py
+    - source: salt://{{ slspath }}/ipa-constants.patch
+{% endif %}


### PR DESCRIPTION
… 64 chars

RedHat claims that hostname must be the same as FQDN thus have the limit 64 char for the hostname/FQDN. As we don't set the hostname to FQDN, it's possible the FQDN is longer than 64 char, but this limit would cause failures on client side when `ipa-client-install` is run. This change is introduced in RH8, Centos7 works fine. Commit causing the validation error: https://github.com/freeipa/freeipa/commit/6662e99e173a16059271528e1fa58e37a3028924

The limit on FreeIPA server side is also increased: https://github.com/hortonworks/cloudbreak/commit/18a867c6b47fc6efb39dd50c3f5557f3940f25bb