### PR TITLE
CB-21371 Add the cdpEndpoint parameter

### DIFF
--- a/saltstack/base/salt/ccmv2/cdp/bin/ccmv2/generate-config.sh
+++ b/saltstack/base/salt/ccmv2/cdp/bin/ccmv2/generate-config.sh
@@ -47,6 +47,8 @@ http_proxy = "${HTTP_PROXY_URL}"
 scheme = "https"
 host = "${BACKEND_HOST}:${BACKEND_PORT}"
 trustedBackendCertificatePath = "${TRUSTED_BACKEND_CERT_PATH}"
+
+cdpEndpoint = "${CDP_API_ENDPOINT_URL}"
 EOF
 
 if [ -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
To the config.toml for Jumpgate agent.
The environment variable used `CDP_API_ENDPOINT_URL` originates from the user data script.