### PR TITLE
CB-21660 CDP_API_ENDPOINT_URL needs a default empty value because of …

### DIFF
--- a/saltstack/base/salt/ccmv2/cdp/bin/ccmv2/generate-config.sh
+++ b/saltstack/base/salt/ccmv2/cdp/bin/ccmv2/generate-config.sh
@@ -48,7 +48,7 @@ scheme = "https"
 host = "${BACKEND_HOST}:${BACKEND_PORT}"
 trustedBackendCertificatePath = "${TRUSTED_BACKEND_CERT_PATH}"
 
-cdpEndpoint = "${CDP_API_ENDPOINT_URL}"
+cdpEndpoint = "${CDP_API_ENDPOINT_URL:=}"
 EOF
 
 if [ -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
…`set -u` on the top