### PR TITLE
CB-21747 Adds support to burn RHEL8 FreeIPA images for commercial clouds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER
 		else ifeq ($(OS),redhat8)
 			AZURE_IMAGE_PUBLISHER ?= RedHat
 			AZURE_IMAGE_OFFER ?= RHEL
-			AZURE_IMAGE_SKU ?= 8
+			AZURE_IMAGE_SKU ?= 8-LVM
 		else ifeq ($(OS),centos7)
 			AZURE_IMAGE_PUBLISHER ?= OpenLogic
 			AZURE_IMAGE_OFFER ?= CentOS

--- a/packer.json
+++ b/packer.json
@@ -421,7 +421,7 @@
       "type": "googlecompute",
       "disable_default_service_account" : true,
       "account_file": "{{user `gcp_account_file`}}",
-      "source_image": "rhel-8-v20221206",
+      "source_image": "rhel-8-v20230411",
       "zone": "us-west2-a",
       "project_id": "gcp-cdp-cb-images",
       "network_project_id": "gcp-eng-network-enterprise",

--- a/saltstack/base/salt/prerequisites/authconfig.sls
+++ b/saltstack/base/salt/prerequisites/authconfig.sls
@@ -23,6 +23,10 @@ enable_faillock:
       - salt://{{ slspath }}/etc/security/faillock.conf
     - mode: 644
 
+select-profile:
+  cmd.run:
+    - name: authselect select sssd --force
+
 enable-faillock:
   cmd.run:
     - name: authselect enable-feature with-faillock

--- a/saltstack/base/salt/prerequisites/disable_ipv6.sls
+++ b/saltstack/base/salt/prerequisites/disable_ipv6.sls
@@ -22,6 +22,11 @@ net.ipv6.conf.{{ pillar['network_interface'] }}.disable_ipv6:
     - repl: "NETWORKING_IPV6=\"no\""
     - append_if_not_found: True
 
+
+create_missing_ifcfg_file:
+  cmd.run:
+    - name: touch /etc/sysconfig/network-scripts/ifcfg-{{ pillar['network_interface'] }}
+
 /etc/sysconfig/network-scripts/ifcfg-{{ pillar['network_interface'] }}:
   file.replace:
     - name: /etc/sysconfig/network-scripts/ifcfg-{{ pillar['network_interface'] }}

--- a/saltstack/base/salt/prerequisites/user_uid.sls
+++ b/saltstack/base/salt/prerequisites/user_uid.sls
@@ -1,3 +1,11 @@
+{% if pillar['OS'] == 'redhat8' %}
+  {% 
+    set ids = {
+      'cloudera_scm_user': '10001',
+      'cloudera_scm_group': '10001',
+    } 
+  %}
+{% else %}
 {% set ids = salt['grains.filter_by']({
     'amazon-ebs': {
         'cloudera_scm_user': '992',
@@ -15,6 +23,7 @@
 grain='builder_type',
 default='amazon-ebs'
 )%}
+{% endif %}
 
 create_cloudera_scm_group:
   group.present:

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -137,13 +137,16 @@ function redhat7_install_python38() {
 
 function redhat8_update_python36() {
   echo "Installing python3-devel (the rest should be already installed in case of RHEL8)..."
-  yum update -y python3
+  yum update -y python3 || yum update -y python36
   yum install -y python3-devel
   
   echo PYTHON36=$(yum list installed | grep ^python36\\.x86_64 | grep -oi " [^\s]* " | xargs) >> /tmp/python_install.properties
 
   # CM agent needs this to work
   alternatives --set python /usr/bin/python3
+
+  # Required dependency for IdM
+  pip3 install pyasn1-modules
 }
 
 function redhat8_install_python38() {


### PR DESCRIPTION
* Update Azure and GCP base images
* Force select sssd auth profile
* Create missing ifcfg files
* Update cloudera scm user and group ids to avoid conflict
* Update python36 in case of python3 fails
* Install pyasn1-modules for IdM