### PR TITLE
jumpgate-3.0.7 | Fix the RC in CDPAM-4153 and update the jumpgate agent version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ ARCHIVE_CREDENTIALS ?= ":"
 CDP_TELEMETRY_VERSION ?= ""
 CDP_LOGGING_AGENT_VERSION ?= ""
 
-DEFAULT_JUMPGATE_AGENT_RPM_URL := "https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/37118790/jumpgate/3.x/redhat8/yum/jumpgate-agent.rpm"
+DEFAULT_JUMPGATE_AGENT_RPM_URL := https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/41924420/jumpgate/3.x/redhat8/yum/jumpgate-agent.rpm
 DEFAULT_METERING_AGENT_RPM_URL := "https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/41404891/thunderhead/1.x/redhat8/yum/thunderhead-metering-heartbeat-application-1.0.0-b10391.x86_64.rpm"
 DEFAULT_FREEIPA_PLUGIN_RPM_URL := "https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/41404891/thunderhead/1.x/redhat8/yum/cdp-hashed-pwd-1.0-20230524185955gitcd308d4.x86_64.rpm"
 DEFAULT_FREEIPA_HEALTH_AGENT_RPM_URL := "https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/41404891/thunderhead/1.x/redhat8/yum/freeipa-health-agent-0.1-20230524185955gitcd308d4.x86_64.rpm"


### PR DESCRIPTION
The ITs and E2E tests have been run for the following images:

```
AWS: 9dd48cd5-cfd5-41aa-9a10-cde69067d1aa
Azure: c8140b5b-7378-4bfe-9f87-8143cbe3ca3c
GCP: 20fef85e-e0ae-4d1f-aec8-7703422fa272
```

The test URLs:

ITs: 

1. https://quanta.infra.cloudera.com/#/runDetails?gtn=42054045
2. https://quanta.infra.cloudera.com/#/testSetHistory?endTime=1686572217000&startTime=1685017017000&includeUnofficialRuns=true&tags=cli_token%3Dfl8352ugl5

E2E tests:

1. https://quanta.infra.cloudera.com/#/testSetHistory?endTime=1686579223000&startTime=1685024023000&includeUnofficialRuns=true&tags=cli_token%3D7b0kp5q8f2
2. https://quanta.infra.cloudera.com/#/runDetails?gtn=42050761