### PR TITLE
CB-22127: Temporary fix for the broken cdp-logging-agent (v2)

### DIFF
--- a/saltstack/base/salt/telemetry/centos/init.sls
+++ b/saltstack/base/salt/telemetry/centos/init.sls
@@ -1,7 +1,7 @@
 {% set include_cdp_telemetry = salt['environ.get']('INCLUDE_CDP_TELEMETRY') %}
 {% set include_fluent = salt['environ.get']('INCLUDE_FLUENT') %}
-{% set cdp_telemetry_rpm_repo_url = salt['environ.get']('CDP_TELEMETRY_RPM_URL') %}
-{% set cdp_logging_agent_rpm_repo_url = salt['environ.get']('CDP_LOGGING_AGENT_RPM_URL') %}
+{% set cdp_telemetry_rpm_url = salt['environ.get']('CDP_TELEMETRY_RPM_URL') %}
+{% set cdp_logging_agent_rpm_url = salt['environ.get']('CDP_LOGGING_AGENT_RPM_URL') %}
 {% set use_telemetry_archive = salt['environ.get']('USE_TELEMETRY_ARCHIVE') %}
 {% set archive_base_url = salt['environ.get']('ARCHIVE_BASE_URL') %}
 {% set archive_credentials = salt['environ.get']('ARCHIVE_CREDENTIALS') %}
@@ -16,15 +16,15 @@
     - mode: 700
 
 {% if include_cdp_telemetry == "Yes" %}
-{% if use_telemetry_archive == "Yes" %}
+{% if cdp_telemetry_rpm_url %}
+install_cdp_telemetry_rpm:
+  cmd.run:
+    - name: "rpm -i {{ cdp_telemetry_rpm_url }}"
+{% elif use_telemetry_archive == "Yes" %}
 ## regarding cdp-telemetry, see more at internal repo: thunderhead/cdp-telemetry-cli
 install_cdp_telemetry_rpm_from_archive:
   cmd.run:
-   - name: "/cdp/telemetry/install-package.sh cdp_telemetry {{ archive_base_url }} {{ archive_credentials }} {{ cdp_telemetry_rpm_repo_url }}"
-{% elif cdp_telemetry_rpm_repo_url %}
-install_cdp_telemetry_rpm:
-  cmd.run:
-    - name: "rpm -i {{ cdp_telemetry_rpm_repo_url }}"
+   - name: "/cdp/telemetry/install-package.sh cdp_telemetry {{ archive_base_url }} {{ archive_credentials }} {{ cdp_telemetry_rpm_url }}"
 {% endif %}
 {% endif %}
 
@@ -33,14 +33,14 @@ install_cdp_telemetry_rpm:
 install_lsb_core_for_fluent:
   cmd.run:
     - name: yum install -y redhat-lsb-core
-{% if use_telemetry_archive == "Yes" %}
-install_cdp_logging_rpm_from_archive:
-  cmd.run:
-   - name: "/cdp/telemetry/install-package.sh cdp_logging_agent {{ archive_base_url }} {{ archive_credentials }} {{ cdp_logging_agent_rpm_repo_url }}"
-{% elif cdp_logging_agent_rpm_repo_url %}
+{% if cdp_logging_agent_rpm_url %}
 install_cdp_logging_rpm_from_repo_url:
   cmd.run:
-    - name: rpm -i {{ cdp_logging_agent_rpm_repo_url }}
+    - name: rpm -i {{ cdp_logging_agent_rpm_url }}
+{% elif use_telemetry_archive == "Yes" %}
+install_cdp_logging_rpm_from_archive:
+  cmd.run:
+   - name: "/cdp/telemetry/install-package.sh cdp_logging_agent {{ archive_base_url }} {{ archive_credentials }} {{ cdp_logging_agent_rpm_url }}"
 {% endif %}
 {% endif %}
 

--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -69,6 +69,8 @@ packer_in_container() {
     ## It will be deleted after the proper rpm will be available via the base url
     if [[ "$CLOUD_PROVIDER" == "AWS_GOV" ]]; then
       CDP_LOGGING_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/39697508/cdp-infra-tools/1.x/redhat8/yum/cdp_logging_agent-0.3.7.x86_64.rpm"
+    else
+      CDP_LOGGING_AGENT_RPM_URL="https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-logging-agent/0.2.16/cdp_logging_agent-0.2.16.x86_64.rpm"
     fi
   fi
 


### PR DESCRIPTION
For CentOS 7 the new version is optional, so disabled it. For RHEL 8 w/ FIPS, it's mandatory, so it's still a blocker bug and a new RPM will be needed. Had to re-write this due to the weird RPM selection logic...