### PR TITLE
CB-22215: Fixed cdp-logging-agent and cdp-telemetry URLs for CentOS 7

### DIFF
--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -56,7 +56,11 @@ packer_in_container() {
     
     ## The RPM_URL is overwritten due to FIPS compatibility
     ## It will be deleted after the proper rpm will be available via the base url
-    CDP_TELEMETRY_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/39697508/cdp-infra-tools/1.x/redhat8/yum/cdp_telemetry-0.4.36.x86_64.rpm"
+    if [[ "$CLOUD_PROVIDER" == "AWS_GOV" ]]; then
+      CDP_TELEMETRY_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/39697508/cdp-infra-tools/1.x/redhat8/yum/cdp_telemetry-0.4.36.x86_64.rpm"
+    else
+      CDP_TELEMETRY_RPM_URL="https://archive.cloudera.com/cdp-infra-tools/latest/redhat7/yum/cdp_telemetry-0.4.31.x86_64.rpm"
+    fi
   fi
   if [[ "$INCLUDE_FLUENT" == "Yes" && -z "$CDP_LOGGING_AGENT_RPM_URL" ]]; then
     CDP_LOGGING_AGENT_BASE_URL="https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-logging-agent/"
@@ -70,7 +74,7 @@ packer_in_container() {
     if [[ "$CLOUD_PROVIDER" == "AWS_GOV" ]]; then
       CDP_LOGGING_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/39697508/cdp-infra-tools/1.x/redhat8/yum/cdp_logging_agent-0.3.7.x86_64.rpm"
     else
-      CDP_LOGGING_AGENT_RPM_URL="https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-logging-agent/0.2.16/cdp_logging_agent-0.2.16.x86_64.rpm"
+      CDP_LOGGING_AGENT_RPM_URL="https://archive.cloudera.com/cdp-infra-tools/latest/redhat7/yum/cdp_logging_agent-0.3.6.x86_64.rpm"
     fi
   fi
 


### PR DESCRIPTION
Added these hardcoded URLs till we figure out how to differentiate between OSes and versions properly and clean up all the mess!