### PR TITLE
CB-22117 CIS: Enable SELinux permissive mode

### DIFF
--- a/saltstack/base/salt/prerequisites/selinux.sls
+++ b/saltstack/base/salt/prerequisites/selinux.sls
@@ -1,40 +1,19 @@
 {% if grains['os_family'] == 'RedHat' %}
 
-{% if pillar['OS'] == 'redhat8' %}  
 install_selinux_module_dependecies:
   pkg.installed:
     - pkgs:
       - policycoreutils
+{% if pillar['OS'] == 'redhat8' %}
       - policycoreutils-python-utils
 {% else %}
-install_selinux_module_dependecies:
-  pkg.installed:
-    - pkgs:
-      - policycoreutils
       - policycoreutils-python
 {% endif %}
 
-selinux.setenforce:
-  module.run:
-    - mode: Disabled
+selinux_permissive:
+  selinux.mode:
+    - name: permissive
     - require:
       - pkg: install_selinux_module_dependecies
 
-disable_selinux_type:
-  file.replace:
-    - name: /etc/sysconfig/selinux
-    - pattern: "^SELINUXTYPE.*"
-    - repl: "#SELINUXTYPE="
-    - append_if_not_found: False
-    - require:
-      - pkg: install_selinux_module_dependecies
-
-disable_selinux:
-  file.replace:
-    - name: /etc/sysconfig/selinux
-    - pattern: "^SELINUX.*"
-    - repl: "SELINUX=Disabled"
-    - append_if_not_found: True
-    - require:
-      - pkg: install_selinux_module_dependecies
 {% endif %}


### PR DESCRIPTION
Validated images:

1. http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-azure/2538/
2. http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-azure/2537/

SELinux status:
```
[root@azure-test-d88c2b91-idbroker0 cloudbreak]# sestatus
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             targeted
Current mode:                   permissive
Mode from config file:          permissive
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Max kernel policy version:      31
[root@azure-test-d88c2b91-idbroker0 cloudbreak]# grep "SELinux is preventing" /var/log/messages
[root@azure-test-d88c2b91-idbroker0 cloudbreak]# 
```