### PR TITLE
CB-22295 Generate java package versions for base images

### DIFF
--- a/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/cleanup/tmp/generate-package-versions.sh
@@ -100,7 +100,7 @@ elif [[ "$CUSTOM_IMAGE_TYPE" == "hortonworks" ]]; then
 		exit 1
 	fi
 
-	if [ $(version $STACK_VERSION) -lt $(version "7.2.15") ]; then
+	if [ -n "$STACK_VERSION" ] && [ $(version $STACK_VERSION) -lt $(version "7.2.15") ]; then
 		echo "Skip java versions as CB should not allow to force java version before 7.2.15"
 	else
 		DEFAULT_JAVA_MAJOR_VERSION=$(java -version 2>&1 | grep -oP "version [^0-9]?(1\.)?\K\d+" || true)


### PR DESCRIPTION
Image burn with these changes: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1405/

Image catalog entry:
```
{
  "created": 1687349567,
  "published": 1687351907,
  "date": "2023-06-21",
  "description": "Official Cloudbreak image",
  "images": {
    "azure": {
      "West US": "https://cldrwestus.blob.core.windows.net/images/cb-cdh--1687349559.vhd"
    }
  },
  "os": "centos7",
  "os_type": "redhat7",
  "uuid": "ffcd862b-b973-4052-8dc9-3015f0da1582",
  "package-versions": {
    "blackbox-exporter": "0.19.0",
    "cdp-logging-agent": "0.3.6",
    "cdp-minifi-agent": "1.22.07",
    "cdp-prometheus": "2.36.2",
    "cdp-request-signer": "0.2.4",
    "cdp-telemetry": "0.4.31",
    "cloudbreak_images": "2604e8d1835fcc34b4bd05206242034c8858652f",
    "inverting-proxy-agent": "3.0.7-b1",
    "inverting-proxy-agent_gbn": "41924420",
    "java": "8",
    "java11": "11.0.19",
    "java17": "17.0.2",
    "java8": "1.8.0_372",
    "metering_agent": "1.0.0",
    "node-exporter": "1.3.1",
    "psql": "10",
    "psql10": "10.23",
    "psql11": "11.20",
    "psql14": "14.8",
    "python27": "2.7.5-92.el7_9",
    "python36": "3.6.8-18.el7",
    "python38": "3.8.13-1.el7",
    "salt": "3001.8",
    "salt-bootstrap": "0.13.6-2022-05-20T08:57:17"
  }
}
```