### PR TITLE
CB-22263 Bump ycloud base image version

### DIFF
--- a/docker/centos7.9/Dockerfile
+++ b/docker/centos7.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-sandbox.infra.cloudera.com/ycloud-base/base-centos7.9:0.1.0.0-120
+FROM docker-sandbox.infra.cloudera.com/ycloud-base/base-centos7.9:0.1.0.0-135
 
 ARG SALT_VERSION
 ARG SALT_PATH

--- a/saltstack/base/pillar/prerequisites/init.sls
+++ b/saltstack/base/pillar/prerequisites/init.sls
@@ -1,5 +1,5 @@
 os_user: {{ salt['environ.get']('OS_USER') }}
-subtype: {% if salt['grains.get']('virtual') == 'bhyve' or salt['grains.get']('virtual_subtype') == 'Docker' %}Docker{% else %}''{% endif %}
+subtype: {% if salt['file.directory_exists']('/yarn-private') %}Docker{% else %}''{% endif %}
 
 # https://tedops.github.io/how-to-find-default-active-ethernet-interface.html
 network_interface: {{ salt['network.default_route']('inet')[0]['interface'] }}

--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -251,7 +251,7 @@ systemd-link:
     - unless: cat /usr/lib/systemd/system/postgresql-10.service | grep postgresql.service
 
 
-{% if salt['file.directory_exists']('/yarn-private') %}  # systemctl reenable does not work on ycloud so we create the symlink manually
+{% if pillar['subtype'] == 'Docker' %}  # systemctl reenable does not work on ycloud so we create the symlink manually
 create-postgres-service-link:
   cmd.run:
     - name: ln -sf /usr/lib/systemd/system/postgresql-10.service /usr/lib/systemd/system/postgresql.service && systemctl disable postgresql-10 && systemctl enable postgresql
@@ -302,9 +302,10 @@ log-postgres-service-status:
 configure-listen-address:
   cmd.run:
     - name: su postgres -c '/opt/salt/scripts/conf_pgsql_listen_address.sh' && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/pgsql_listen_address_configured
+    - env:
+      - SUBTYPE: {{ pillar['subtype'] }}
     - require:
       - file: /opt/salt/scripts/conf_pgsql_listen_address.sh
-
 {% if pillar['subtype'] != 'Docker' %}
       - service: start-postgresql
 {% endif %}

--- a/saltstack/base/salt/postgresql/scripts/conf_pgsql_listen_address.sh
+++ b/saltstack/base/salt/postgresql/scripts/conf_pgsql_listen_address.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if grep -q :/docker/ /proc/1/cgroup; then
+if [ "$SUBTYPE" == "Docker" ]; then
     # inside docker container
     CONFIG_FILE=$(find /etc/postgresql /var/lib/pgsql -type f -name postgresql.conf 2>/dev/null | head -1)
 else

--- a/saltstack/base/salt/prerequisites/corkscrew.sls
+++ b/saltstack/base/salt/prerequisites/corkscrew.sls
@@ -1,3 +1,5 @@
+{%if pillar['subtype'] != 'Docker' %}
+
 clone_corkscrew:
   git.latest:
     - name: https://github.com/bryanpkc/corkscrew.git
@@ -16,3 +18,12 @@ cleanup_corkscrew:
 create_corkscrew_softlink:
   cmd.run:
     - name: ln -s /usr/local/bin/corkscrew /usr/bin/corkscrew
+
+{% else %}
+
+install_corkscrew:
+  pkg.installed:
+    - sources:
+      - corkscrew: http://ftp.altlinux.org/pub/distributions/ALTLinux/Sisyphus/x86_64/RPMS.classic/corkscrew-2.0-alt1.qa1.x86_64.rpm
+
+{% endif %}

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -16,6 +16,6 @@ base:
     - ccmv2
     - custom
     - mount
-{% if not salt['file.directory_exists']('/yarn-private') %}
+{% if pillar['subtype'] != 'Docker' %}
     - chrony
 {% endif %}

--- a/saltstack/final/salt/cis-controls/init.sls
+++ b/saltstack/final/salt/cis-controls/init.sls
@@ -7,7 +7,7 @@
 #### CIS: Disable unused filesystems
 #https://jira.cloudera.com/browse/CB-8897
 
-{% if pillar['OS'] == 'centos7' %}
+{% if pillar['OS'] == 'centos7' and pillar['subtype'] != 'Docker' %}
 
 {% set filesystems_to_disable = ['cramfs', 'freevxfs', 'jffs2', 'hfs', 'hfsplus', 'squashfs'] %}
 {% if salt['environ.get']('CLOUD_PROVIDER') != 'Azure' %}


### PR DESCRIPTION
Additional fixes to make ycloud image burning work:
 - Disable CIS for ycloud (sysctl commands were failing and we do not need CIS internally)
 - Revert corkscrew building on ycloud, because cloning its repo is disabled on dev machines
 - Change subtype detection from virtualization to yarn-private directory check
 - Unify subtype checks