### PR TITLE
CB-12687: Copy image to all regions as part of prod promotion

### DIFF
--- a/scripts/check-image-regions.sh
+++ b/scripts/check-image-regions.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+if [ -z "${AWS_AMI_REGIONS}" ] ; then
+  echo "AWS_AMI_REGIONS env variable is mandatory."
+  exit 1
+fi
+
+if [ -z "${AZURE_STORAGE_ACCOUNTS}" ] ; then
+  echo "AZURE_STORAGE_ACCOUNTS env variable is mandatory."
+  exit 1
+fi
+
+if [ -z "${CLOUD_PROVIDER}" ] ; then
+  echo "CLOUD_PROVIDER env variable is mandatory."
+  exit 1
+fi
+
+if [ -z "${IMAGE_REGIONS}" ] ; then
+  echo "IMAGE_REGIONS env variable is mandatory."
+  exit 1
+fi
+
+case "$CLOUD_PROVIDER" in
+  AWS)
+    ALL_REGIONS=$AWS_AMI_REGIONS
+    ;;
+  Azure)
+    ALL_REGIONS=$AZURE_STORAGE_ACCOUNTS
+    ;;
+  *)
+    echo Unexpected CLOUD_PROVIDER
+    exit 1
+esac
+
+ALL_REGIONS_ARRAY=(${ALL_REGIONS//,/ })
+IFS=$'\n' EXPECTED_REGIONS=($(sort <<<"${ALL_REGIONS_ARRAY[*]}")); unset IFS
+IMAGE_REGIONS_ARRAY=(${IMAGE_REGIONS//,/ })
+IFS=$'\n' CURRENT_REGIONS=($(sort <<<"${IMAGE_REGIONS_ARRAY[*]}")); unset IFS
+
+REGIONS_1=${EXPECTED_REGIONS[@]};
+REGIONS_2=${CURRENT_REGIONS[@]};
+if [ "$REGIONS_1" != "$REGIONS_2" ]; then
+  echo "Image does not contain all required regions"
+  DIFF=$(echo ${EXPECTED_REGIONS[@]} ${CURRENT_REGIONS[@]} | tr ' ' '\n' | sort | uniq -u)
+  echo "Missing: $DIFF"
+  exit 1
+else
+  echo "All required regions are found"
+fi


### PR DESCRIPTION
Only prod catalog needs all regions of an image. Before that we should only store the images in a few regions where testing takes place.

We should copy the images only to us-west-2 and eu-central after validation, like it is now. The rest of the copy should happen right before prod promotion. If a complaint arrives that someone needs images in other regions as well for testing/development/etc. and the request is justified (e.g. other regions are slow or something) we'll re-enable early copy for those regions as well.