### PR TITLE
CB-22661: Provisioning Azure env on mow-int fails - add Central US region to first copy phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,8 @@ endif
 # Azure storage account definitions for the different states
 define AZURE_STORAGE_ACCOUNTS_TEST_PHASE
 West US:cldrwestus,\
-West US 2:cldrwestus2
+West US 2:cldrwestus2,\
+Central US:cldrcentralus
 endef
 
 define AZURE_STORAGE_ACCOUNTS_ALL


### PR DESCRIPTION
we add support for the Central US region.