### PR TITLE
CB-23006 Temporarily disable tmp noexec as CM fails to start REGIONSERVER

### DIFF
--- a/saltstack/final/salt/cis-controls/scripts/cis_control.sh
+++ b/saltstack/final/salt/cis-controls/scripts/cis_control.sh
@@ -12,6 +12,8 @@ fi
 if [ "${CLOUD_PROVIDER}" == "Azure" ]; then
     # Azure needs UDF to execute custom data: https://learn.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init#cloud-init-vm-provisioning-without-a-udf-driver
     SKIP_TAGS+=",kernel_module_udf_disabled"
+    # Temporarily disable tmp noexec as CM fails to start REGIONSERVER. Can be removed when CM side fix is done by OPSAPS-68448
+    SKIP_TAGS+=",mount_option_tmp_noexec"
 fi
 
 #Install and download what we need for the hardening


### PR DESCRIPTION
The workaround can be removed when CM side fix is done by OPSAPS-68448