### PR TITLE
CB-23120 Fix /etc/pam.d/su sugroup

### DIFF
--- a/saltstack/final/salt/cis-controls/common.sls
+++ b/saltstack/final/salt/cis-controls/common.sls
@@ -108,8 +108,10 @@ sugroup_group:
 update_pam.d_su:
   file.replace:
     - name: /etc/pam.d/su
-    - pattern: '^auth\s*required\s*pam_wheel\.so.*'
-    - repl: 'auth required pam_wheel.so use_uid group=sugroup'
+    - pattern: |
+        ^#?auth\s*required\s*pam_wheel\.so.*
+    - repl: |
+        auth required pam_wheel.so use_uid group=sugroup
     - append_if_not_found: True
 
 #Ensure SSH LoginGraceTime is set to one minute or less - sshd_config


### PR DESCRIPTION
### RHEL8
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2216
```
[root@ip-10-112-2-38 cloudbreak]# cat /etc/pam.d/su
#%PAM-1.0
auth		required	pam_env.so
auth		sufficient	pam_rootok.so
# Uncomment the following line to implicitly trust users in the "wheel" group.
#auth		sufficient	pam_wheel.so trust use_uid
# Uncomment the following line to require a user to be in the "wheel" group.
auth required pam_wheel.so use_uid group=sugroup
auth		substack	system-auth
auth		include		postlogin
account		sufficient	pam_succeed_if.so uid = 0 use_uid quiet
account		include		system-auth
password	include		system-auth
session		include		system-auth
session		include		postlogin
session		optional	pam_xauth.so
```
### Centos7
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2217
```
[root@ip-10-112-0-33 cloudbreak]# cat /etc/pam.d/su
#%PAM-1.0
auth		sufficient	pam_rootok.so
# Uncomment the following line to implicitly trust users in the "wheel" group.
#auth		sufficient	pam_wheel.so trust use_uid
# Uncomment the following line to require a user to be in the "wheel" group.
auth required pam_wheel.so use_uid group=sugroup
auth		substack	system-auth
auth		include		postlogin
account		sufficient	pam_succeed_if.so uid = 0 use_uid quiet
account		include		system-auth
password	include		system-auth
session		include		system-auth
session		include		postlogin
session		optional	pam_xauth.so
```