### PR TITLE
CB-23468: Added new version of telemetry and logging agent RPMs

### DIFF
--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -58,9 +58,9 @@ packer_in_container() {
     ## The RPM_URL is overwritten due to FIPS/redhat8 compatibility
     ## It will be deleted after the proper rpm will be available via the base url
     if [[ "$OS" == "redhat8" ]]; then
-      CDP_TELEMETRY_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/44198886/cdp-infra-tools/1.x/redhat8/yum/cdp_telemetry-0.4.36.x86_64.rpm"
+      CDP_TELEMETRY_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/45882890/cdp-infra-tools/0.x/redhat8/yum/cdp_telemetry-0.4.36.x86_64.rpm"
     else
-      CDP_TELEMETRY_RPM_URL="https://archive.cloudera.com/cdp-infra-tools/latest/redhat7/yum/cdp_telemetry-0.4.31.x86_64.rpm"
+      CDP_TELEMETRY_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/45882890/cdp-infra-tools/0.x/redhat7/yum/cdp_telemetry-0.4.36.x86_64.rpm"
     fi
   fi
   if [[ "$INCLUDE_FLUENT" == "Yes" && -z "$CDP_LOGGING_AGENT_RPM_URL" ]]; then
@@ -73,9 +73,9 @@ packer_in_container() {
     ## The RPM_URL is overwritten due to FIPS/redhat8 compatibility
     ## It will be deleted after the proper rpm will be available via the base url
     if [[ "$OS" == "redhat8" ]]; then
-      CDP_LOGGING_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/44198886/cdp-infra-tools/1.x/redhat8/yum/cdp_logging_agent-0.3.7.x86_64.rpm"
+      CDP_LOGGING_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/45882890/cdp-infra-tools/0.x/redhat8/yum/cdp_logging_agent-0.3.7.x86_64.rpm"
     else
-      CDP_LOGGING_AGENT_RPM_URL="https://archive.cloudera.com/cdp-infra-tools/latest/redhat7/yum/cdp_logging_agent-0.3.6.x86_64.rpm"
+      CDP_LOGGING_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/45882890/cdp-infra-tools/0.x/redhat7/yum/cdp_logging_agent-0.3.7.x86_64.rpm"
     fi
   fi
 


### PR DESCRIPTION
Test builds:

CentOS 7: /cloudbreak-multi-packer-image-builder-salt-v3/2528/
RHEL 8: /job/cloudbreak-multi-packer-image-builder-salt-v3/2529/
