### PR TITLE
BUG-95449 - Image not found for Azure in region Southeast Asia

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ North Central US:cldrnorthcentralus,\
 East US 2:cldreastus2,\
 Japan East:cldrjapaneast,\
 Japan West:cldrjapanwest,\
-South East Asia:cldrsoutheastasia,\
+Southeast Asia:cldrsoutheastasia,\
 West US:cldrwestus,\
 West Europe:cldrwesteurope,\
 Brazil South:cldrbrazilsouth,\


### PR DESCRIPTION
Azure SDK contains the correct entry, matching the Azure CLI now, so it could be re-renamed to its original form.

    public static final Region ASIA_SOUTHEAST = new Region("southeastasia", "Southeast Asia");