### PR TITLE
Burn image with Salt version 3006.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,12 @@ AWS_MAX_ATTEMPTS ?= 300
 PACKAGE_VERSIONS ?= ""
 SALT_VERSION ?= $(shell ./scripts/get-salt-version.sh $(BASE_NAME) $(STACK_VERSION))
 SALT_PATH ?= /opt/salt_$(SALT_VERSION)
-PYZMQ_VERSION ?= 19.0
+SALT_NEWER_PYZMQ = $(shell echo "$(SALT_VERSION)>=3006.4" | bc)
+ifeq ($(SALT_NEWER_PYZMQ),1)
+	PYZMQ_VERSION ?= 25.0.2
+else
+	PYZMQ_VERSION ?= 19.0
+endif
 PYTHON_APT_VERSION ?= 1.1.0_beta1ubuntu0.16.04.1
 
 # This block remains here for backward compatibility reasons when the IMAGE_NAME is not defined as an env variable

--- a/saltstack/base/salt/salt/etc/salt/master.d/custom.conf
+++ b/saltstack/base/salt/salt/etc/salt/master.d/custom.conf
@@ -18,3 +18,12 @@ rest_cherrypy:
 
 hash_type: sha256
 fips_mode: True
+netapi_enable_clients:
+  - local
+  - local_async
+  - local_batch
+  - local_subset
+  - runner
+  - runner_async
+  - wheel
+  - ssh

--- a/scripts/get-salt-version.sh
+++ b/scripts/get-salt-version.sh
@@ -33,19 +33,22 @@ STACK_VERSION=$2
 SALT_VERSION=3001.8
 
 if [[ $BASE_NAME == "cb" ]]; then
-  if [[ ! -z "$STACK_VERSION" ]]; then
+  if [[ ! -z "$STACK_VERSION" ]]; then # prewarm image
     compare_version $STACK_VERSION 7.2.6
     COMP_RESULT=$?
     # Stack version < 7.2.6 - Lowered this from 7.2.16, because we'll need Python 3.8 on older images too
     if [[ $COMP_RESULT == 2 ]]; then
       SALT_VERSION=3000.8
     fi
-  # Missing STACK_VERSION and BASE_NAME=cb -> base image
-  else
-    SALT_VERSION=3001.8
+    compare_version $STACK_VERSION 7.2.18
+    COMP_RESULT=$?
+    # Stack version >= 7.2.18
+    if [[ $COMP_RESULT -lt 2 ]]; then
+      SALT_VERSION=3006.4
+    fi
+  else # base image
+    SALT_VERSION=3006.4
   fi
 fi
 
 echo $SALT_VERSION
-
-


### PR DESCRIPTION
AWS 7.2.18: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-aws/3241/
Azure 7.2.18: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-azure/2973/
GCP 7.2.18: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-gcp/1788/
AWS base: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-aws/3245/
AWS 7.2.16: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-aws/3250/