### PR TITLE
CB-23922: Replaced xxd with od so CCMv1 based envs won't be broken

### DIFF
--- a/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
@@ -22,7 +22,7 @@ if [ ! -f ${PRIVATE_KEY} ]; then
     else
         IV=436c6f7564657261436c6f7564657261
         cat ${CCM_ENCIPHERED_PRIVATE_KEY_FILE} | openssl enc -aes-128-cbc -d -A -a \
-            -K $(xxd -pu <<< $(echo ${CCM_KEY_ID} | cut -c1-16) | cut -c1-32) \
+            -K $(echo ${CCM_KEY_ID} | cut -c1-16 | tr -d ' \n' | od -An -tx1 -N32 | tr -d ' \n') \
             -iv ${IV} > ${PRIVATE_KEY}
     fi
 else

--- a/scripts/aws-copy.sh
+++ b/scripts/aws-copy.sh
@@ -3,12 +3,20 @@
 set -ex
 
 AMI_ID=$IMAGE_NAME
-IMAGE_NAME=$(aws ec2 describe-images --region $SOURCE_LOCATION --filters "Name=image-id,Values=$AMI_ID" --owners "self" --query 'Images[*].[Name]' --output "text")
+IMAGE_NAME=$(aws ec2 describe-images --region $SOURCE_LOCATION --filters "Name=image-id,Values=$AMI_ID" --query 'Images[*].[Name]' --output "text")
 
 if [ -z "$IMAGE_NAME" ]
 then
   echo "Source image $AMI_ID in region $SOURCE_LOCATION not found, exiting"
   exit 1
+fi
+
+SRC_ACCOUNT=""
+if [[ -z $SOURCE_ACCOUNT ]]; then
+  SRC_ACCOUNT=self
+else
+  SRC_ACCOUNT=$SOURCE_ACCOUNT
+  echo Source account is $SRC_ACCOUNT
 fi
 
 
@@ -160,7 +168,7 @@ do
     continue
   fi
 
-  AMI_IN_REGION=$(aws ec2 describe-images --owners self --filters "Name=name,Values=$IMAGE_NAME" --region $REGION --query "Images[*].[ImageId]" --output "text")
+  AMI_IN_REGION=$(aws ec2 describe-images --owners $SRC_ACCOUNT --filters "Name=name,Values=$IMAGE_NAME" --region $REGION --query "Images[*].[ImageId]" --output "text")
   if [ -n "$AMI_IN_REGION" ]
   then
     log "Image is already copied to region $REGION as $AMI_IN_REGION"

--- a/scripts/img-copy.sh
+++ b/scripts/img-copy.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# This script is a helper meant for copying images to your own account.
+# Currently it supports AWS only and requires the below parameters:
+#
+#  1 Source AWS account (from which the image is being copied)
+#  2 AWS Credentials profile name
+#  3 AMI ID
+#  4 target regions, commma separated
+#
+# To have the proper AWS credentials, you'll need to use gimme-aws-creds along with
+# Okta - this is the company standard, but technically nothing prevents you
+# from setting up a custom ~/.aws/credentials file. Contents the credentials file
+# will also provide you the necessary value for the AWS credentials profile name.
+# Having Docker installed on your machine is also required to run this script.
+#
+# Example use:
+# ./img-copy.sh 1234567890123 default ami-0073e5fb98e2faa3f eu-north-1,eu-west-3
+#
+# This will cause you to end up with a whole lot of log on the standard out, ending
+# with something like this:
+# + echo '2023-11-23 11:00:32+00:00 Image copied to regions: eu-north-1=ami-0b7149651a90989f3,eu-west-3=ami-0fb5aa19986c12ec8'
+# Now you can copy those AMI references into a custom catalog.
+#
+# If you run into the below error message when the script finishes, it means that 
+# your account can't have public AMIs:
+#   "An error occurred (OperationNotPermitted) when calling the ModifyImageAttribute 
+#    operation: You can’t publicly share this image because block public access for
+#    AMIs is enabled for this account. To publicly share the image, you must call 
+#    the DisableImageBlockPublicAccess API."
+# Having public AMIs is a must though, as Cloudbreak needs to access them, so you'll 
+# have to enable this in the account.
+#
+# Note: Regardless of the above error message, the AMI copy should be successful.
+
+if [[ -z $1 ]]; then
+  echo Source AWS account ID must be provided as the first parameter!
+  exit 1
+fi
+
+if [[ -z $2 ]]; then
+  echo AWS Credentials profile must be provided as the second parameter!
+  exit 1
+fi
+
+if [[ -z $3 ]]; then
+  echo Image name must be provided as the third parameter!
+  exit 1
+fi
+
+if [[ -z $4 ]]; then
+  echo Target regions must be provided as the fourth parameter!
+  exit 1
+fi
+
+SCRIPTS_DIR=$(pwd)
+echo Scripts Directory: $SCRIPTS_DIR
+
+CREDS_DIR=$(cd ~/.aws;pwd)
+echo Credentials Directory: $CREDS_DIR
+
+docker run -i --rm \
+ -v $CREDS_DIR:/root/.aws \
+ -v $SCRIPTS_DIR:/scripts \
+ -w /scripts \
+ -e SOURCE_ACCOUNT=$1 \
+ -e AWS_PROFILE=$2 \
+ -e AWS_AMI_REGIONS=$4 \
+ -e IMAGE_NAME=$3 \
+ -e SOURCE_LOCATION=us-west-1 \
+ -e MAKE_PUBLIC_AMIS=yes \
+ -e MAKE_PUBLIC_SNAPSHOTS=yes \
+ -e AWS_AMI_ORG_ARN= \
+ -e AWS_SNAPSHOT_USER= \
+ --entrypoint="/bin/bash" \
+ amazon/aws-cli -c "./aws-copy.sh"


### PR DESCRIPTION
Burning a test image is pointless - the script gets activated during provisioning. Instead, I tested the replacement code using the "black box" methodology - e.g. both code parts, the old and the new should yield the same output in case of the same input. Here are the results:

![Screenshot from 2023-11-27 23-50-29](https://github.com/hortonworks/cloudbreak-images/assets/6706631/9279e720-93ef-4848-b3d6-fcaf90c2502f)

The only observation is that if the input is shorter than 16 chars, the string "0a" is also appended in case of the new implementation. Given past examples and the fact that the implementation cuts down the string from whatever value it has to 16 chars, this should not cause a problem.