### PR TITLE
CB-23922: Replaced xxd with od so CCMv1 based envs won't be broken

### DIFF
--- a/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
+++ b/saltstack/base/salt/ccm-client/cdp/bin/reverse-tunnel.sh
@@ -22,7 +22,7 @@ if [ ! -f ${PRIVATE_KEY} ]; then
     else
         IV=436c6f7564657261436c6f7564657261
         cat ${CCM_ENCIPHERED_PRIVATE_KEY_FILE} | openssl enc -aes-128-cbc -d -A -a \
-            -K $(xxd -pu <<< $(echo ${CCM_KEY_ID} | cut -c1-16) | cut -c1-32) \
+            -K $(echo ${CCM_KEY_ID} | cut -c1-16 | tr -d ' \n' | od -An -tx1 -N32 | tr -d ' \n') \
             -iv ${IV} > ${PRIVATE_KEY}
     fi
 else


### PR DESCRIPTION
Burning a test image is pointless - the script gets activated during provisioning. Instead, I tested the replacement code using the "black box" methodology - e.g. both code parts, the old and the new should yield the same output in case of the same input. Here are the results:

![Screenshot from 2023-11-27 23-50-29](https://github.com/hortonworks/cloudbreak-images/assets/6706631/9279e720-93ef-4848-b3d6-fcaf90c2502f)

The only observation is that if the input is shorter than 16 chars, the string "0a" is also appended in case of the new implementation. Given past examples and the fact that the implementation cuts down the string from whatever value it has to 16 chars, this should not cause a problem.