### PR TITLE
CB-24059 Update default Postgres versions

### DIFF
--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -38,7 +38,9 @@ install-postgres:
         dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
         dnf module -y disable postgresql
         dnf clean all
+{% if pillar['subtype'] != 'Docker' %}
         dnf -y install postgresql11-server postgresql11 postgresql11-devel {{ postgres_install_flags }}
+{% endif %}
         dnf -y install postgresql14-server postgresql14 postgresql14-devel {{ postgres_install_flags }}
 {% elif grains['os_family'] == 'RedHat' and grains['osmajorrelease'] | int == 7  %}
 install-postgres:
@@ -110,13 +112,12 @@ install-postgres:
 {% endif %}
 
 {% if pillar['OS'] == 'redhat8' %}
-  {% set pg_default_version = '11' %}
-{% elif grains['os_family'] == 'RedHat' and grains['osmajorrelease'] | int == 7 %}
+  {% set pg_default_version = '14' %}
+{% else %}
   # the override to 11 for runtimes >= 7.2.7 is handled in CB
   {% set pg_default_version = '10' %}
 {% endif %}
 
-{% if pg_default_version %}
 pgsql-ld-conf:
   alternatives.set:
     - path: /usr/pgsql-{{ pg_default_version }}/share/postgresql-{{ pg_default_version }}-libs.conf
@@ -222,17 +223,16 @@ pgsql-vacuumdbman:
     - mode: 755
     - target: /usr/pgsql-{{ pg_default_version }}/bin/initdb
     - force: True
-{% endif %}
 
 {% if pillar['OS'] == 'redhat8' %}
 
 init-pg-database:
   cmd.run:
-    - name: /usr/pgsql-11/bin/postgresql-11-setup initdb
+    - name: /usr/pgsql-{{ pg_default_version }}/bin/postgresql-{{ pg_default_version }}-setup initdb
 
 reenable-postgres:
   cmd.run:
-    - name: systemctl enable --now postgresql-11
+    - name: systemctl enable --now postgresql-{{ pg_default_version }}
 
 {% elif  grains['os_family'] == 'RedHat' and grains['osmajorrelease'] | int == 7 %}
 /var/lib/pgsql/data:
@@ -250,20 +250,23 @@ init-pg11-database:
 
 systemd-link:
   file.replace:
-    - name: /usr/lib/systemd/system/postgresql-10.service
+    - name: /usr/lib/systemd/system/postgresql-{{ pg_default_version }}.service
     - pattern: "\\[Install\\]"
     - repl: "[Install]\nAlias=postgresql.service"
-    - unless: cat /usr/lib/systemd/system/postgresql-10.service | grep postgresql.service
+    - unless: cat /usr/lib/systemd/system/postgresql-{{ pg_default_version }}.service | grep postgresql.service
 
 
 {% if pillar['subtype'] == 'Docker' %}  # systemctl reenable does not work on ycloud so we create the symlink manually
 create-postgres-service-link:
   cmd.run:
-    - name: ln -sf /usr/lib/systemd/system/postgresql-10.service /usr/lib/systemd/system/postgresql.service && systemctl disable postgresql-10 && systemctl enable postgresql
+    - name: |
+        ln -sf /usr/lib/systemd/system/postgresql-{{ pg_default_version }}.service /usr/lib/systemd/system/postgresql.service
+        systemctl disable postgresql-{{ pg_default_version }}
+        systemctl enable postgresql
 {% else %}
 reenable-postgres:
   cmd.run:
-    - name: systemctl reenable postgresql-10.service
+    - name: systemctl reenable postgresql-{{ pg_default_version }}.service
 {% endif %}
 
 {% elif pillar['OS'] == 'debian9' or ( grains['os_family'] == 'Debian' and grains['osmajorrelease'] | int in ( 8, 9, 16, 18 ) )  %}
@@ -285,14 +288,14 @@ init-pg-database:
 start-postgresql:
   service.running:
 {% if  pillar['OS'] == 'redhat8' %}
-    - name: postgresql-11
+    - name: postgresql-{{ pg_default_version }}
 {% else %}
     - name: postgresql
 {% endif %}
 log-postgres-service-status:
   cmd.run:
 {% if  pillar['OS'] == 'redhat8' %}
-    - name: systemctl status postgresql-11.service
+    - name: systemctl status postgresql-{{ pg_default_version }}.service
 {% else %}
     - name: systemctl status postgresql.service
 {% endif %}
@@ -321,23 +324,20 @@ set-postgres-nologin-shell:
     - shell: {{ salt['cmd.run']('which nologin') }}
 
 # Needed for installing psycopg2 in saltstack/base/salt/postgresql/init.sls
-{% if '/usr/pgsql-11/bin' not in salt['environ.get']('PATH') %}
-/opt/salt/scripts/conf_pgconfig_path.sh:
-  file.managed:
-    - makedirs: True
-    - mode: 755
-    - source: salt://postgresql/scripts/conf_pgconfig_path.sh
+{% set pg_default_version_bin = '/usr/pgsql-' ~ pg_default_version ~ '/bin' %}
+{% if pg_default_version_bin not in salt['environ.get']('PATH') %}
+set-etc-environment-path-pgsql{{ pg_default_version }}-bin:
+  file.replace:
+    - name: /etc/environment
+    - pattern: |
+        ^PATH="(.*)"$
+    - repl: |
+        PATH="\1:{{ pg_default_version_bin }}"
 
-add-pgconfig-to-path:
-  cmd.run:
-    - name: /opt/salt/scripts/conf_pgconfig_path.sh
-    - require:
-      - file: /opt/salt/scripts/conf_pgconfig_path.sh
-
-set-path-pgsql11-bin:
+set-path-pgsql{{ pg_default_version }}-bin:
   environ.setenv:
     - name: PATH
-    - value: "{{ salt['environ.get']('PATH') }}:/usr/pgsql-11/bin"
+    - value: "{{ salt['environ.get']('PATH') }}:{{ pg_default_version_bin }}"
     - update_minion: True
 {% endif %}
 

--- a/saltstack/base/salt/postgresql/scripts/conf_pgconfig_path.sh
+++ b/saltstack/base/salt/postgresql/scripts/conf_pgconfig_path.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Updating /etc/environment to include PostgreSQL binaries on the path..."    
-cat /etc/environment
-sed -e '/^PATH/s/"$/:\/usr\/pgsql-11\/bin"/g' -i /etc/environment
-cat /etc/environment


### PR DESCRIPTION
Centos7 http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-aws/3261/ 
	install 10,11,14
	default 10
RHEL8 AWS/GCP/Azure http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-aws/3263/
	install 11,14
	default 14
RHEL8 YARN
	install 14
	default 14

/etc/environment was empty on all providers I have tried so I tried a test run where I first set the file:
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3267
```
    aws-centos7:           ID: set-etc-environment-path-pgsql10-bin
    aws-centos7:     Function: file.replace
    aws-centos7:         Name: /etc/environment
    aws-centos7:       Result: True
    aws-centos7:      Comment: Changes were made
    aws-centos7:      Started: 11:05:22.429850
    aws-centos7:     Duration: 5.158 ms
    aws-centos7:      Changes:
    aws-centos7:               ----------
    aws-centos7:               diff:
    aws-centos7:                   ---
    aws-centos7:                   +++
    aws-centos7:                   @@ -1 +1 @@
    aws-centos7:                   -PATH="/sbin:/bin:/usr/sbin:/usr/bin"
    aws-centos7:                   +PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/pgsql-10/bin"
```