### PR TITLE
CB-23918: Lock in RHEL 8.8 as 8.9 can caused problems for JDK 8

### DIFF
--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -1,4 +1,8 @@
-{% if pillar['subtype'] != 'Docker' %}
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' %}
+update-packages:
+  cmd.run:
+    - name: dnf update -y --releasever=8.8 --nobest
+{% elif pillar['subtype'] != 'Docker' %}
 update-packages:
   pkg.uptodate:
     - refresh: True


### PR DESCRIPTION
Successful validation: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-awsgov/362/