### PR TITLE
CB-24609: Disabled redundant SSSD config dir inclusion

### DIFF
--- a/saltstack/final/salt/krb5/init.sls
+++ b/saltstack/final/salt/krb5/init.sls
@@ -4,4 +4,8 @@
 disable_kcm_ccache:
   file.absent:
     - name: /etc/krb5.conf.d/kcm_default_ccache
+
+disable_sssd_conf_dir:
+  file.absent:
+    - name: /etc/krb5.conf.d/enable_sssd_conf_dir
 {% endif %}


### PR DESCRIPTION
Test build: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3583/