### PR TITLE
CB-25087 Add sosreport to image

### DIFF
--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -48,6 +48,9 @@ packages_install:
     {% if pillar['OS'] == 'redhat8' and pillar['subtype'] == 'Docker' %}
       - NetworkManager
     {% endif %}
+    {% if pillar['OS'] == 'redhat8' %}
+      - sos
+    {% endif %}
   {% endif %}
       - nvme-cli
       - openssl


### PR DESCRIPTION
https://access.redhat.com/solutions/3592

test image burn: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3826/console

```Installed Packages
Name         : sos
Version      : 4.6.0
Release      : 5.el8
Architecture : noarch
Size         : 2.9 M
Source       : sos-4.6.0-5.el8.src.rpm
Repository   : @System
From repo    : ubi-8.8-baseos-cldr
Summary      : A set of tools to gather troubleshooting information from a system
URL          : https://github.com/sosreport/sos
License      : GPL-2.0-or-later
Description  : Sos is a set of tools that gathers information about system
             : hardware and configuration. The information can then be used for
             : diagnostic purposes and debugging. Sos is commonly used to help
             : support technicians and developers.
```
From the test FreeIPA