### PR TITLE
CB-24163, CB-24164, CB-24165, CB-24166, CB-24175: LUKS volume creation

### DIFF
--- a/saltstack/base/salt/luks/bin/create-luks-volume.sh
+++ b/saltstack/base/salt/luks/bin/create-luks-volume.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+export LUKS_VOLUME_NAME="cdp-luks"
+export MOUNT_POINT="/mnt/$LUKS_VOLUME_NAME"
+export LUKS_DIR="/etc/$LUKS_VOLUME_NAME"
+export LUKS_BACKING_FILE="$LUKS_DIR/$LUKS_VOLUME_NAME"
+export PASSPHRASE_TMPFS="/mnt/cdp-luks_passphrase_tmpfs"
+export PASSPHRASE_PLAINTEXT="$PASSPHRASE_TMPFS/passphrase"
+export PASSPHRASE_CIPHERTEXT="$LUKS_DIR/passphrase_ciphertext"
+export LUKS_LOG_DIR="/var/log/$LUKS_VOLUME_NAME"
+export LUKS_BACKUP_DIR="$LUKS_DIR/backup"
+export LUKS_MAPPER_DEVICE="/dev/mapper/$LUKS_VOLUME_NAME"
+export ENCRYPTION_KEY_FILE="$LUKS_DIR/passphrase_encryption_key"
+export LUKS_BACKING_FILE_DEFAULT_SIZE="100MiB"
+
+setup_backing_file() {
+  if [[ -e "$LUKS_BACKING_FILE" && $(stat -c "%a" "$LUKS_BACKING_FILE" | tr -d '\n') == 600 ]]; then
+    # Set the backing file to the specified size if it exists
+    truncate -s "$LUKS_BACKING_FILE_DEFAULT_SIZE" "$LUKS_BACKING_FILE"
+  else
+    # Create the backing file if it doesn't exist
+    dd if=/dev/zero of="$LUKS_BACKING_FILE" bs="$LUKS_BACKING_FILE_DEFAULT_SIZE" count=1
+    chmod 600 "$LUKS_BACKING_FILE"
+  fi
+}
+
+setup_tmpfs_for_plaintext_passphrase() {
+  if ! mountpoint "$PASSPHRASE_TMPFS"; then
+    # Create the tmpfs for the plaintext passphrase
+    mount -t tmpfs -o size=1k,mode=700 tmpfs "$PASSPHRASE_TMPFS"
+  fi
+}
+
+generate_passphrase() {
+  if [[ -e "$PASSPHRASE_PLAINTEXT" ]]; then
+    echo "Plaintext passphrase already exists... Exiting LUKS volume creation with failed exit code!"
+    exit 1
+  else
+    aws kms generate-random \
+        --number-of-bytes 64 \
+        --output text \
+        --query Plaintext \
+      | base64 --decode \
+      > "$PASSPHRASE_PLAINTEXT"
+      chmod 600 "$PASSPHRASE_PLAINTEXT"
+  fi
+}
+
+encrypt_passphrase_ciphertext() {
+  INSTANCE_ID="$(TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 10") && \
+                                  curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)"
+  METADATA_LOG_FILE="$LUKS_LOG_DIR/passphrase_encryption_md-$(date +"%F-%T").json"
+  # Encrypt the plaintext passphrase and store the ciphertext
+  if ! /usr/local/bin/aws-encryption-cli \
+         --encrypt \
+         --input "$PASSPHRASE_PLAINTEXT" \
+         --output "$PASSPHRASE_CIPHERTEXT" \
+         --wrapping-keys provider=aws-kms key="$(cat "$ENCRYPTION_KEY_FILE")" \
+         --metadata-output "$METADATA_LOG_FILE" \
+         --encryption-context INSTANCE_ID="$INSTANCE_ID"; then
+    echo "Failed to encrypt plaintext passphrase... Exiting LUKS volume creation with failed exit code!"
+    exit 2
+  fi
+  chmod 600 "$PASSPHRASE_CIPHERTEXT"
+  chmod 600 "$METADATA_LOG_FILE"
+}
+
+setup_loop_device() {
+  # Create the loop device
+  LOOP_DEVICE=$(losetup --find --show "$LUKS_BACKING_FILE")
+  if [[ $(losetup -j "$LUKS_BACKING_FILE" | cut -d ':' -f1 | tr -d '\n') != "$LOOP_DEVICE" ]]; then
+    echo "Failed to set up the loop device correctly... Exiting LUKS volume creation with failed exit code!"
+    exit 3
+  fi
+}
+
+create_luks_volume() {
+  # Create the LUKS volume
+  if ! echo "YES" | cryptsetup luksFormat "$LOOP_DEVICE" \
+                     --key-file "$PASSPHRASE_PLAINTEXT" \
+                     --type luks2 \
+                     --hash "sha3-512" \
+                     --cipher "aes-xts-plain64" \
+                     --use-random \
+                     --iter-time 2000 \
+                     --pbkdf "pbkdf2" \
+                     --debug; then
+    echo "Failed to create the LUKS volume... Exiting LUKS volume creation with failed exit code!"
+    exit 4
+  fi
+}
+
+open_luks_volume() {
+  # Open the LUKS volume
+  if ! cryptsetup open "$LOOP_DEVICE" "$LUKS_VOLUME_NAME" \
+           --key-file "$PASSPHRASE_PLAINTEXT" \
+           --type luks2 \
+           --debug; then
+    echo "Failed to open the LUKS volume... Exiting LUKS volume creation with failed exit code!"
+    exit 5
+  fi
+}
+
+create_fs_on_luks_volume() {
+  # Create the file system on the LUKS volume
+  if ! mkfs.xfs "$LUKS_MAPPER_DEVICE"; then
+    echo "Failed to create the file system on the LUKS volume... Exiting LUKS volume creation with failed exit code!"
+    exit 6
+  fi
+}
+
+backup_luks_header() {
+  # Create backup of LUKS volume header
+  if ! cryptsetup luksHeaderBackup "$LOOP_DEVICE" \
+                    --header-backup-file "$LUKS_BACKUP_DIR/luks_header_backup-$(date +"%F-%T")" \
+                    --debug; then
+    echo "Failed to create backup of the header of the LUKS volume... Without backup, if the header gets corrupted, the entire volume will become undecryptable!"
+  fi
+}
+
+mount_luks_volume() {
+  if ! mountpoint -q "$MOUNT_POINT"; then
+    # Mount the LUKS volume
+    mount "$LUKS_MAPPER_DEVICE" "$MOUNT_POINT"
+    chmod 700 "$MOUNT_POINT"
+  else
+    echo "Failed to mount the LUKS volume, as the path is already a mount point... Exiting LUKS volume creation with failed exit code!"
+    exit 7
+  fi
+}
+
+main() {
+  if mountpoint "$MOUNT_POINT"; then
+    echo "Volume already mounted at mount point... Exiting LUKS volume creation!"
+    exit
+  fi
+
+  setup_backing_file
+  setup_tmpfs_for_plaintext_passphrase
+  generate_passphrase
+  encrypt_passphrase_ciphertext
+  setup_loop_device
+  create_luks_volume
+  open_luks_volume
+  create_fs_on_luks_volume
+  backup_luks_header
+  mount_luks_volume
+
+  # If everything went fine up to this point, we can enable the reopen service,
+  # the guards in the unit file will stop it from actually executing the reopen script
+  systemctl enable cdp-reopen-luks-volume.service
+}
+
+main

--- a/saltstack/base/salt/luks/bin/reopen-luks-volume.sh
+++ b/saltstack/base/salt/luks/bin/reopen-luks-volume.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+export LUKS_VOLUME_NAME="cdp-luks"
+export MOUNT_POINT="/mnt/$LUKS_VOLUME_NAME"
+export LUKS_DIR="/etc/$LUKS_VOLUME_NAME"
+export LUKS_BACKING_FILE="$LUKS_DIR/$LUKS_VOLUME_NAME"
+export PASSPHRASE_TMPFS="/mnt/cdp-luks_passphrase_tmpfs"
+export PASSPHRASE_PLAINTEXT="$PASSPHRASE_TMPFS/passphrase"
+export PASSPHRASE_CIPHERTEXT="$LUKS_DIR/passphrase_ciphertext"
+export LUKS_LOG_DIR="/var/log/$LUKS_VOLUME_NAME"
+export LUKS_MAPPER_DEVICE="/dev/mapper/$LUKS_VOLUME_NAME"
+export ENCRYPTION_KEY_FILE="$LUKS_DIR/passphrase_encryption_key"
+
+recreate_loop_device() {
+  if [[ $(losetup -j "$LUKS_BACKING_FILE" | wc -l | tr -d '\n') == 0 ]]; then
+    # Recreate the loop device
+    LOOP_DEVICE=$(losetup --find --show "$LUKS_BACKING_FILE")
+
+    if [[ $(losetup -j "$LUKS_BACKING_FILE" | cut -d ':' -f1 | tr -d '\n') != "$LOOP_DEVICE" ]]; then
+      echo "Failed to set up loop device correctly... Exiting LUKS volume reopen script with failed exit code!"
+      exit 1
+    fi
+  else
+    LOOP_DEVICE=$(losetup -j "$LUKS_BACKING_FILE" | cut -d ':' -f1 | tr -d '\n')
+  fi
+}
+
+setup_tmpfs_for_plaintext_passphrase() {
+  if ! mountpoint "$PASSPHRASE_TMPFS"; then
+    # Create the tmpfs for the plaintext passphrase
+    mount -t tmpfs -o size=1k,mode=700 tmpfs "$PASSPHRASE_TMPFS"
+  fi
+}
+
+decrypt_passphrase_ciphertext() {
+  if [[ ! -s "$PASSPHRASE_PLAINTEXT" ]]; then
+    INSTANCE_ID="$(TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 10") && \
+                                curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)"
+    METADATA_LOG_FILE="$LUKS_LOG_DIR/passphrase_decryption_md-$(date +"%F-%T").json"
+    # Decrypt the ciphertext passphrase
+    if ! /usr/local/bin/aws-encryption-cli \
+           --decrypt \
+           --input "$PASSPHRASE_CIPHERTEXT" \
+           --output "$PASSPHRASE_PLAINTEXT" \
+           --wrapping-keys provider=aws-kms key="$(cat "$ENCRYPTION_KEY_FILE")" \
+           --metadata-output "$METADATA_LOG_FILE" \
+           --encryption-context INSTANCE_ID="$INSTANCE_ID"; then
+      echo "Failed to decrypt the plaintext ciphertext... Exiting LUKS volume reopen script with failed exit code!"
+      exit 2
+    fi
+    chmod 600 "$PASSPHRASE_PLAINTEXT"
+    chmod 600 "$METADATA_LOG_FILE"
+  fi
+}
+
+reopen_luks_volume() {
+  if ! cryptsetup status "$LUKS_VOLUME_NAME"; then
+    # Reopen the LUKS volume
+    if ! cryptsetup open "$LOOP_DEVICE" "$LUKS_VOLUME_NAME" \
+             --key-file "$PASSPHRASE_PLAINTEXT" \
+             --type luks2 \
+             --debug; then
+      echo "Failed to reopen the LUKS volume... Exiting LUKS volume reopen script with failed exit code!"
+      exit 3
+    fi
+  fi
+}
+
+remount_luks_volume() {
+  if ! mountpoint "$MOUNT_POINT"; then
+    # Remount the LUKS volume
+    mount "$LUKS_MAPPER_DEVICE" "$MOUNT_POINT"
+    chmod 700 "$MOUNT_POINT"
+  else
+    echo "Did not mount the LUKS volume, as the path is already a mount point... Exiting LUKS volume reopen script with failed exit code!"
+    exit 4
+  fi
+}
+
+main() {
+  recreate_loop_device
+  setup_tmpfs_for_plaintext_passphrase
+  decrypt_passphrase_ciphertext
+  reopen_luks_volume
+  remount_luks_volume
+}
+
+main

--- a/saltstack/base/salt/luks/etc/systemd/system/cdp-reopen-luks-volume.service
+++ b/saltstack/base/salt/luks/etc/systemd/system/cdp-reopen-luks-volume.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=CDP-LUKS volume reopen script service
+ConditionPathIsMountPoint=!/mnt/cdp-luks
+ConditionFileNotEmpty=/etc/cdp-luks/passphrase_encryption_key
+ConditionFileNotEmpty=/etc/cdp-luks/passphrase_ciphertext
+#TODO Add a Before directive here for services, which will have secrets stored in the LUKS volume
+#Note: Adding a Before directive for a service should only be absolutely necessary,
+#      if otherwise it would start before or in parallel with this service
+#      (for example, if it also starts when network-online.target is reached)
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=600
+StartLimitBurst=5
+
+[Service]
+Type=oneshot
+ExecStart=/etc/cdp-luks/bin/reopen-luks-volume.sh
+RemainAfterExit=yes
+Restart=on-failure
+TimeoutSec=30
+
+[Install]
+WantedBy=network-online.target

--- a/saltstack/base/salt/luks/init.sls
+++ b/saltstack/base/salt/luks/init.sls
@@ -1,0 +1,71 @@
+/etc/cdp-luks:
+  file.directory:
+    - name: /etc/cdp-luks
+    - user: root
+    - group: root
+    - mode: 700
+
+/etc/cdp-luks/bin:
+  file.directory:
+    - name: /etc/cdp-luks/bin
+    - user: root
+    - group: root
+    - mode: 700
+
+/etc/cdp-luks/backup:
+  file.directory:
+    - name: /etc/cdp-luks/backup
+    - user: root
+    - group: root
+    - mode: 700
+
+/mnt/cdp-luks:
+  file.directory:
+    - name: /mnt/cdp-luks
+    - user: root
+    - group: root
+    - mode: 700
+
+/mnt/cdp-luks_passphrase_tmpfs:
+  file.directory:
+    - name: /mnt/cdp-luks_passphrase_tmpfs
+    - user: root
+    - group: root
+    - mode: 700
+
+/var/log/cdp-luks:
+  file.directory:
+    - name: /var/log/cdp-luks
+    - user: root
+    - group: root
+    - mode: 700
+
+/etc/cdp-luks/bin/create-luks-volume.sh:
+  file.managed:
+    - name: /etc/cdp-luks/bin/create-luks-volume.sh
+    - source: salt://{{ slspath }}/bin/create-luks-volume.sh
+    - user: root
+    - group: root
+    - mode: 700
+
+/etc/cdp-luks/bin/reopen-luks-volume.sh:
+  file.managed:
+    - name: /etc/cdp-luks/bin/reopen-luks-volume.sh
+    - source: salt://{{ slspath }}/bin/reopen-luks-volume.sh
+    - user: root
+    - group: root
+    - mode: 700
+
+/etc/systemd/system/cdp-reopen-luks-volume.service:
+  file.managed:
+    - name: /etc/systemd/system/cdp-reopen-luks-volume.service
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - source: salt://{{ slspath }}/etc/systemd/system/cdp-reopen-luks-volume.service
+
+install_aws_encryption_sdk_cli:
+  pip.installed:
+    - name: aws-encryption-sdk-cli
+    - bin_env: /usr/local/bin/pip3.8

--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -54,6 +54,9 @@ packages_install:
       - sos
     {% endif %}
   {% endif %}
+  {% if salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' %}
+      - cryptsetup
+  {% endif %}
       - nvme-cli
       - openssl
       - autossh

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -16,6 +16,9 @@ base:
     - ccmv2
     - custom
     - mount
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' %}
+    - luks
+{% endif %}
 {% if pillar['subtype'] != 'Docker' or pillar['OS'] == 'redhat8' %}
     - chrony
 {% endif %}

--- a/saltstack/freeipa/salt/ipaconsistency/init.sls
+++ b/saltstack/freeipa/salt/ipaconsistency/init.sls
@@ -12,7 +12,7 @@
     - name: /usr/local/lib/python3.8/site-packages/checkipaconsistency/main.py
     - source: salt://{{ slspath }}/scripts/main.py
     - mode: 644
-    - onlyif: ls -la /usr/local/lib/python3.8/site-packages/
+    - onlyif: ls -la /usr/local/lib/python3.8/site-packages/ && ! ls -la /usr/local/lib/python3.6/site-packages/
 
 # CentOS 7 + Python 3.8
 /opt/rh/rh-python38/root/usr/local/lib/python3.8/site-packages/checkipaconsistency/main.py:

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -255,10 +255,11 @@ function install_python_pip() {
   # FreeIPA images:
   #  CentOS7: Python 2.7 + Python 3.6
   #  RHEL7  : Python 2.7 + Python 3.6
-  #  RHEL8  : Python 3.6
+  #  RHEL8  : Python 3.6 + Python 3.8
   if [ "${IMAGE_BASE_NAME}" == "freeipa" ] ; then
     if [ "${OS}" == "redhat8" ] ; then
       redhat8_update_python36
+      redhat8_install_python38
     elif [ "${OS}" == "redhat7" ] ; then
       redhat7_update_python27
       redhat7_install_python36


### PR DESCRIPTION
On first boot (started by user-data-helper.sh):
1. Generate passphrase
2. Encrypt passphrase and store ciphertext
3. Create backing file
4. Create loop device on the backing file
5. Create LUKS volume on the loop device
6. Open LUKS volume
7. Create file system inside the LUKS volume
8. Mount LUKS volume

On subsequent boots (done by reopen-luks-volume.service):
1. Recreate loop device on the backing file
2. Decrypt passphrase ciphertext
3. Reopen LUKS volume
4. Remount LUKS volume

Dependencies added:
- cryptsetup
- aws-encryption-sdk-cli
- Python 3.8 to RHEL8 freeipa images (needed for aws-encryption-sdk-cli)