### PR TITLE
CB-23061 Move temp files to attached disk to save space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,27 +130,7 @@ ifndef IMAGE_NAME
 @echo IMAGE_NAME was not defined as an environment variable. Generated value: $(IMAGE_NAME)
 endif
 
-ifeq ($(OS),centos7)
-	ifeq ($(CLOUD_PROVIDER),GCP)
-		IMAGE_SIZE ?= 48
-	endif
-	IMAGE_SIZE ?= 36
-else
-# The two legacy versions we still burn for RHEL8
-	ifeq ($(STACK_VERSION),7.2.16)
-		IMAGE_SIZE ?= 64
-	endif
-	ifeq ($(STACK_VERSION),7.2.17)
-		IMAGE_SIZE ?= 64
-	else
-# 7.2.18 and above require much bigger images
-		ifeq ($(CLOUD_PROVIDER),Azure)
-			IMAGE_SIZE ?= 90
-		else
-			IMAGE_SIZE ?= 72
-		endif
-	endif
-endif
+IMAGE_SIZE=$(shell ./scripts/get-image-size.sh $(CLOUD_PROVIDER) $(OS) $(STACK_VERSION))
 
 ifeq ($(MAKE_PUBLIC_SNAPSHOTS),yes)
 	AWS_SNAPSHOT_GROUPS = "all"

--- a/packer.json
+++ b/packer.json
@@ -138,10 +138,12 @@
         "version": "{{user `version`}}",
         "cb-creation-timestamp": "{{timestamp}}",
         "owner": "{{ user `image_owner` }}",
-        "Customer Delivered": "{{user `tag_customer_delivered`}}"
+        "Customer Delivered": "{{user `tag_customer_delivered`}}",
+        "Name": "{{ user `image_name`}}"
       },
       "run_tags": {
-        "owner": "{{ user `image_owner` }}"
+        "owner": "{{ user `image_owner` }}",
+        "Name": "Packer Builder"
       },
       "ami_block_device_mappings": [
         {
@@ -178,10 +180,12 @@
         "version": "{{user `version`}}",
         "cb-creation-timestamp": "{{timestamp}}",
         "owner": "{{ user `image_owner` }}",
-        "Customer Delivered": "{{user `tag_customer_delivered`}}"
+        "Customer Delivered": "{{user `tag_customer_delivered`}}",
+        "Name": "{{ user `image_name`}}"
       },
       "run_tags": {
-        "owner": "{{ user `image_owner` }}"
+        "owner": "{{ user `image_owner` }}",
+        "Name": "Packer Builder"
       },
       "snapshot_users": "{{ user `aws_snapshot_users` }}",
       "snapshot_groups": "{{ user `aws_snapshot_groups` }}",
@@ -192,6 +196,13 @@
           "volume_type": "gp2",
           "delete_on_termination": true,
           "volume_size": "{{user `image_size`}}"
+        },
+        {
+          "device_name": "/dev/sda2",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "50",
+          "no_device": true
         }
       ],
       "launch_block_device_mappings": [
@@ -200,6 +211,12 @@
           "volume_type": "gp2",
           "delete_on_termination": true,
           "volume_size": "{{user `image_size`}}"
+        },
+        {
+          "device_name": "/dev/sda2",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "50"
         }
       ],
       "ami_name": "{{ user `image_name`}}",
@@ -221,10 +238,12 @@
         "version": "{{user `version`}}",
         "cb-creation-timestamp": "{{timestamp}}",
         "owner": "{{ user `image_owner` }}",
-        "Customer Delivered": "{{user `tag_customer_delivered`}}"
+        "Customer Delivered": "{{user `tag_customer_delivered`}}",
+        "Name": "{{ user `image_name`}}"
       },
       "run_tags": {
-        "owner": "{{ user `image_owner` }}"
+        "owner": "{{ user `image_owner` }}",
+        "Name": "Packer Builder"
       },
       "snapshot_users": "{{ user `aws_snapshot_users` }}",
       "snapshot_groups": "{{ user `aws_snapshot_groups` }}",
@@ -265,10 +284,12 @@
         "version": "{{user `version`}}",
         "cb-creation-timestamp": "{{timestamp}}",
         "owner": "{{ user `image_owner` }}",
-        "Customer Delivered": "{{user `tag_customer_delivered`}}"
+        "Customer Delivered": "{{user `tag_customer_delivered`}}",
+        "Name": "{{ user `image_name`}}"
       },
       "run_tags": {
-        "owner": "{{ user `image_owner` }}"
+        "owner": "{{ user `image_owner` }}",
+        "Name": "Packer Builder"
       },
       "ami_block_device_mappings": [
         {
@@ -293,6 +314,7 @@
     {
       "name": "arm-centos7",
       "type": "azure-arm",
+      "communicator": "ssh",
       "client_id": "{{user `client_id`}}",
       "client_secret": "{{user `client_secret`}}",
       "subscription_id": "{{user `subscription_id`}}",
@@ -330,6 +352,7 @@
     {
       "name": "arm-redhat7",
       "type": "azure-arm",
+      "communicator": "ssh",
       "client_id": "{{user `client_id`}}",
       "client_secret": "{{user `client_secret`}}",
       "subscription_id": "{{user `subscription_id`}}",
@@ -367,6 +390,7 @@
     {
       "name": "arm-redhat8",
       "type": "azure-arm",
+      "communicator": "ssh",
       "client_id": "{{user `client_id`}}",
       "client_secret": "{{user `client_secret`}}",
       "subscription_id": "{{user `subscription_id`}}",
@@ -457,6 +481,13 @@
       "image_name": "{{user `image_name`}}",
       "disk_size": "{{user `image_size`}}",
       "state_timeout": "15m",
+      "disk_attachment": [
+        {
+          "volume_size": 50,
+          "volume_type": "pd-standard",
+          "device_name": "tmp"
+        }
+      ],
       "tags": [
         "builder--packer",
         "cb-creation-timestamp--{{timestamp}}",

--- a/saltstack/base/salt/mount/init.sls
+++ b/saltstack/base/salt/mount/init.sls
@@ -1,21 +1,5 @@
-{% set platform = salt['grains.filter_by']({
-    'amazon-ebs': {
-        'required': True
-    },
-    'azure-arm': {
-        'required': False,
-    },
-    'googlecompute': {
-        'required': False,
-    },
-    'default': {
-        'required': False,
-    },
-},
-grain='builder_type'
-)%}
-
-{% if platform.required and pillar['OS'] == 'centos7' %}
+{% if salt['environ.get']('CLOUD_PROVIDER') == "AWS" %}
+{% if pillar['OS'] == 'centos7' %}
 mount-nfs-sequentially-service-file:
   file.managed:
     - user: root
@@ -31,8 +15,33 @@ mount-nfs-sequentially-service-start:
     - reload: True
     - require:
       - file: mount-nfs-sequentially-service-file
+{% elif pillar['OS'] == 'redhat8' %}
+format-additional-disk:
+  cmd.run:
+    - name: mkfs.xfs /dev/nvme1n1
+
+create-additional-disk-mount-point:
+  file.directory:
+    - name: /mnt/tmp/
+
+mount-additional-disk:
+  cmd.run:
+    - name: mount /dev/nvme1n1 /mnt/tmp/
+{% endif %}
+{% elif salt['environ.get']('CLOUD_PROVIDER') == "GCP" and pillar['OS'] == 'redhat8' %}
+format-additional-disk:
+  cmd.run:
+    - name: mkfs.xfs /dev/sdb
+
+create-additional-disk-mount-point:
+  file.directory:
+    - name: /mnt/tmp/
+
+mount-additional-disk:
+  cmd.run:
+    - name: mount /dev/sdb /mnt/tmp/
 {% else %}
-nop-for-mount-workaround-on-other-platforms:
+nop-for-mount-workaround:
   test.nop:
-    - name: "NOP - Mount workaround only needed on AWS"
+    - name: "NOP - Mount workaround not needed for {{ salt['environ.get']('CLOUD_PROVIDER') }} {{ pillar['OS'] }}"
 {% endif %}

--- a/saltstack/final/salt/cis-controls/scripts/cis_control.sh
+++ b/saltstack/final/salt/cis-controls/scripts/cis_control.sh
@@ -4,6 +4,8 @@ set -ex -o pipefail -o errexit
 # Remediating the system to align with the CIS L1 baseline using an SSG Ansible playbook
 # The ansible playbook is available at https://github.com/AutomateCompliance/AnsibleCompliancePlaybooks/blob/main/rhel8-playbook-cis_server_l1.yml
 
+ANSIBLE_PATH=/mnt/tmp/ansible
+
 # The list of tags of ansible tasks from the above-mentioned playbook that would break functionality, so we are skipping temporarily
 SKIP_TAGS="package_firewalld_installed,service_firewalld_enabled,package_openldap-clients_removed"
 EXTRA_VARS="sshd_idle_timeout_value=180"
@@ -19,17 +21,19 @@ if [ "${CLOUD_PROVIDER}" == "Azure" ]; then
 fi
 
 #Install and download what we need for the hardening
-python3 -m pip install --user ansible
+python3 -m virtualenv $ANSIBLE_PATH
+source $ANSIBLE_PATH/bin/activate
+python3 -m pip install ansible
 yum install -y git
-git clone https://github.com/AutomateCompliance/AnsibleCompliancePlaybooks.git /tmp/ansible-compliance-playbooks
+git clone https://github.com/AutomateCompliance/AnsibleCompliancePlaybooks.git $ANSIBLE_PATH/ansible-compliance-playbooks
 
 #Generate missing host keys as they are needed by the playbook
 ssh-keygen -A
 
 #Apply the SSG Ansible playbook
-~/.local/bin/ansible-playbook -i localhost, -c local /tmp/ansible-compliance-playbooks/rhel8-playbook-cis_server_l1.yml --skip-tags $SKIP_TAGS --extra-vars "$EXTRA_VARS" | tee /tmp/cis_log.txt
+ansible-playbook -i localhost, -c local $ANSIBLE_PATH/ansible-compliance-playbooks/rhel8-playbook-cis_server_l1.yml --skip-tags $SKIP_TAGS --extra-vars "$EXTRA_VARS" | tee /tmp/cis_log.txt
 chmod 644 /tmp/cis_log.txt
 
-#Cleanup
-rm -rf /tmp/ansible-compliance-playbooks
-python3 -m pip uninstall -y ansible
+#Clean up python stuff
+deactivate
+rm -rf $ANSIBLE_PATH

--- a/saltstack/final/salt/cleanup/init.sls
+++ b/saltstack/final/salt/cleanup/init.sls
@@ -13,3 +13,8 @@ include:
   - {{ slspath }}.cloud-init
 {% endif %}
   - {{ slspath }}.user
+  - {{ slspath }}.mount
+
+storage_usage:
+  cmd.run:
+    - name: lsblk; df -h

--- a/saltstack/final/salt/cleanup/mount.sls
+++ b/saltstack/final/salt/cleanup/mount.sls
@@ -1,0 +1,7 @@
+umount-additional-disk:
+  cmd.run:
+    - name: umount /mnt/tmp/
+    - onlyif: mountpoint /mnt/tmp/
+
+/mnt/tmp:
+  file.absent

--- a/saltstack/hortonworks/salt/pre-warm/tmp/install_cdh.sh
+++ b/saltstack/hortonworks/salt/pre-warm/tmp/install_cdh.sh
@@ -13,34 +13,34 @@ check_prerequisites() {
   : ${PARCELS_ROOT:? required}
   : ${PARCELS_NAME:? required}
   : ${PARCEL_REPO:=/opt/cloudera/parcel-repo}
+  : ${PARCEL_ARCHIVE_PATH:=/mnt/tmp}
 }
 
 verify_parcel_checksum() {
   local SHA_TYPE=$1
 
   echo "Downloading sha file from $STACK_BASEURL/${PARCELS_NAME}.$SHA_TYPE"
-   curl -s -S "${STACK_BASEURL}/${PARCELS_NAME}.${SHA_TYPE}" -o "$PARCEL_REPO/$PARCELS_NAME.$SHA_TYPE"
-   cp "$PARCEL_REPO/$PARCELS_NAME.$SHA_TYPE" "$PARCEL_REPO/$PARCELS_NAME.sha"
-   sed "s/$/  ${PARCELS_NAME}/" "$PARCEL_REPO/$PARCELS_NAME.$SHA_TYPE" |
-     tee "$PARCEL_REPO/$PARCELS_NAME.shacheck" > /dev/null
+   curl -s -S "${STACK_BASEURL}/${PARCELS_NAME}.${SHA_TYPE}" -o "$PARCEL_ARCHIVE_PATH/$PARCELS_NAME.$SHA_TYPE"
+   cp "$PARCEL_ARCHIVE_PATH/$PARCELS_NAME.$SHA_TYPE" "$PARCEL_ARCHIVE_PATH/$PARCELS_NAME.sha"
+   sed "s/$/  ${PARCELS_NAME}/" "$PARCEL_ARCHIVE_PATH/$PARCELS_NAME.$SHA_TYPE" |
+     tee "$PARCEL_ARCHIVE_PATH/$PARCELS_NAME.shacheck" > /dev/null
 
   echo "Verifying parcel checksum"
   COMMAND="${SHA_TYPE}sum"
-  if ! eval "cd $PARCEL_REPO && $COMMAND -c \"$PARCELS_NAME.shacheck\""; then
+  if ! eval "cd $PARCEL_ARCHIVE_PATH && $COMMAND -c \"$PARCELS_NAME.shacheck\""; then
     echo "Checksum verification failed"
     exit 1
   fi
-   rm "$PARCEL_REPO/$PARCELS_NAME.shacheck"
 }
 
 
 download_cdh_parcel() {
   id -u cloudera-scm &>/dev/null ||useradd -r cloudera-scm
-  mkdir -p ${PARCELS_ROOT} ${PARCEL_REPO} /opt/cloudera/parcel-cache
+  mkdir -p ${PARCELS_ROOT} ${PARCEL_REPO} /opt/cloudera/parcel-cache ${PARCEL_ARCHIVE_PATH}
   cd ${PARCELS_ROOT}
 
   echo "Downloading parcel from  ${STACK_BASEURL}/${PARCELS_NAME}"
-  curl --progress-bar -C - -s -S --create-dirs ${STACK_BASEURL}/${PARCELS_NAME} -o ${PARCEL_REPO}/${PARCELS_NAME}
+  curl --progress-bar -C - -s -S --create-dirs ${STACK_BASEURL}/${PARCELS_NAME} -o ${PARCEL_ARCHIVE_PATH}/${PARCELS_NAME}
   # C5 uses SHA-1 and C6 uses SHA-256
   if  curl -sLf "${STACK_BASEURL}/${PARCELS_NAME}.sha1" -o /dev/null; then
     verify_parcel_checksum "sha1"
@@ -54,7 +54,7 @@ download_cdh_parcel() {
 
 extract_cdh_parcel() {
   echo "Preextracting parcels..."
-  tar zxf "$PARCEL_REPO/$PARCELS_NAME" -C "${PARCELS_ROOT}"
+  tar zxf "$PARCEL_ARCHIVE_PATH/$PARCELS_NAME" -C "${PARCELS_ROOT}"
   # Example: CDH-6.2.0-1.cdh6.2.0.p0.967373
   PARCEL_FOLDER="${PARCELS_NAME%-*}"
   # Example: SPARK2, CDH, etc.
@@ -65,12 +65,12 @@ extract_cdh_parcel() {
   touch ${PARCELS_ROOT}/${PARCEL_PRODUCT}/.dont_delete
   echo "Done extracting"
 
-  parcels=("$PARCEL_REPO"/*.parcel)
-  for parcel in "${parcels[@]}"; do
-    mktorrent -l 19 -v -p -a "" -o "${parcel}.torrent" "${parcel}"
-    touch "${parcel}".skiphash
-    rm -f "${parcel}"
-    touch "${parcel}"
+  parcels=("$PARCEL_ARCHIVE_PATH"/*.parcel)
+  for tmp_parcel in "${parcels[@]}"; do
+    parcel="$PARCEL_REPO/$(basename "$tmp_parcel")"
+    mktorrent -l 19 -v -p -a "" -o "${parcel}.torrent" "${tmp_parcel}"
+    touch "${parcel}" "${parcel}.skiphash"
+    rm -f "${tmp_parcel}"
     ln "${parcel}" "/opt/cloudera/parcel-cache/$(basename "$parcel")"
   done
 

--- a/scripts/get-image-size.sh
+++ b/scripts/get-image-size.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+source scripts/utils.sh
+
+CLOUD_PROVIDER=$1
+OS=$2
+STACK_VERSION=$3
+
+if [ "$OS" == "centos7" ]; then
+  if [ "$CLOUD_PROVIDER" == "GCP" ]; then
+    IMAGE_SIZE=48
+  else
+    IMAGE_SIZE=36
+  fi
+else
+  compare_version $STACK_VERSION 7.2.18
+  COMP_RESULT=$?
+  if [[ "$CLOUD_PROVIDER" == "Azure" ]]; then
+    IMAGE_SIZE=64
+  elif [[ $COMP_RESULT -lt 2 ]]; then
+    # stack version >= 7.2.18
+    IMAGE_SIZE=52
+  else
+    IMAGE_SIZE=48
+  fi
+fi
+
+echo $IMAGE_SIZE

--- a/scripts/get-salt-version.sh
+++ b/scripts/get-salt-version.sh
@@ -1,31 +1,6 @@
 #!/bin/bash
 
-compare_version () {
-  if [[ $1 == $2 ]]; then
-    return 0
-  fi
-  local IFS=.
-  local i version1=($1) version2=($2)
-  # Fill empty fields in version1 with zeros
-  for ((i=${#version1[@]}; i<${#version2[@]}; i++))
-  do
-    version1[i]=0
-  done
-  for ((i=0; i<${#version1[@]}; i++))
-  do
-    # Fill empty fields in version2 with zeros
-    if [[ -z ${version2[i]} ]]; then
-      version2[i]=0
-    fi
-    if ((10#${version1[i]} > 10#${version2[i]})); then
-      return 1
-    fi
-    if ((10#${version1[i]} < 10#${version2[i]})); then
-      return 2
-    fi
-  done
-  return 0
-}
+source scripts/utils.sh
 
 BASE_NAME=$1
 STACK_VERSION=$2

--- a/scripts/packer-command.sh
+++ b/scripts/packer-command.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -ex -o pipefail -o errexit
+
+BUILD_ARGS="$@"
+
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+if [ "$(version "$PACKER_VERSION")" -ge "$(version "1.10.0")" ]; then
+  # from v1.10.0 Packer is not bundled with plugins
+  if [ "$CLOUD_PROVIDER" == "AWS" ] || [ "$CLOUD_PROVIDER" == "AWS_GOV" ]; then
+    PLUGIN="github.com/hashicorp/amazon"
+  elif [ "$CLOUD_PROVIDER" == "Azure" ]; then
+    PLUGIN="github.com/hashicorp/azure"
+  elif [ "$CLOUD_PROVIDER" == "GCP" ]; then
+    PLUGIN="github.com/hashicorp/googlecompute"
+  fi
+
+  if [ -n "$PLUGIN" ]; then
+    packer plugins install $PLUGIN
+  fi
+fi
+
+packer $BUILD_ARGS

--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -4,7 +4,7 @@ set -ex -o pipefail -o errexit
 packer_in_container() {
   local dockerOpts=""
   local packerFile="packer.json"
-  : "${PACKER_VERSION:="1.4.2"}"
+  : "${PACKER_VERSION:="1.10.2"}"
   echo "Using Packer version $PACKER_VERSION"
 
   if [[ "$GCP_ACCOUNT_FILE" ]]; then
@@ -230,11 +230,14 @@ packer_in_container() {
     -e CLOUD_PROVIDER="$CLOUD_PROVIDER" \
     -e SSH_PUBLIC_KEY="$SSH_PUBLIC_KEY" \
     -e FIPS_MODE="$FIPS_MODE" \
+    -e PACKER_VERSION="$PACKER_VERSION" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $PWD:$PWD \
     -w $PWD \
+    --entrypoint /bin/bash \
     $dockerOpts \
-    hashicorp/packer:$PACKER_VERSION "$@" $packerFile
+    hashicorp/packer:$PACKER_VERSION \
+    -c "./scripts/packer-command.sh $* $packerFile"
 }
 
 main() {

--- a/scripts/salt-final.sh
+++ b/scripts/salt-final.sh
@@ -18,7 +18,7 @@ function copy_resources {
 function highstate {
   local saltenv=${1}
   copy_resources ${saltenv}
-  ${SALT_PATH}/bin/salt-call --no-color --local state.highstate saltenv=${saltenv} --retcode-passthrough -l info --log-file=/tmp/salt-build-${saltenv}.log --log-file-level=info --config-dir=/tmp/saltstack/config
+  ${SALT_PATH}/bin/salt-call --no-color --local state.highstate saltenv=${saltenv} -l info --log-file=/tmp/salt-build-${saltenv}.log --log-file-level=info --config-dir=/tmp/saltstack/config
 }
 
 echo "Running validation and cleanup"

--- a/scripts/salt-setup.sh
+++ b/scripts/salt-setup.sh
@@ -45,7 +45,7 @@ function apply_rhel8_salt_patch {
 function highstate {
   local saltenv=${1}
   copy_resources ${saltenv}
-  ${SALT_PATH}/bin/salt-call --no-color --local state.highstate saltenv=${saltenv} --retcode-passthrough -l info --log-file=/tmp/salt-build-${saltenv}.log --log-file-level=info --config-dir=/tmp/saltstack/config
+  ${SALT_PATH}/bin/salt-call --no-color --local state.highstate saltenv=${saltenv} -l info --log-file=/tmp/salt-build-${saltenv}.log --log-file-level=info --config-dir=/tmp/saltstack/config
 }
 
 function apply_optional_states {
@@ -55,7 +55,7 @@ function apply_optional_states {
   then
     local saltenv="optional"
     copy_resources ${saltenv}
-    ${SALT_PATH}/bin/salt-call --no-color --local state.sls ${OPTIONAL_STATES} saltenv=${saltenv} pillarenv=${saltenv} --retcode-passthrough -l info --log-file=/tmp/salt-build-${saltenv}.log --config-dir=/tmp/saltstack/config
+    ${SALT_PATH}/bin/salt-call --no-color --local state.sls ${OPTIONAL_STATES} saltenv=${saltenv} pillarenv=${saltenv} -l info --log-file=/tmp/salt-build-${saltenv}.log --config-dir=/tmp/saltstack/config
   fi
 }
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+compare_version () {
+  if [[ $1 == $2 ]]; then
+    return 0
+  fi
+  local IFS=.
+  local i version1=($1) version2=($2)
+  # Fill empty fields in version1 with zeros
+  for ((i=${#version1[@]}; i<${#version2[@]}; i++))
+  do
+    version1[i]=0
+  done
+  for ((i=0; i<${#version1[@]}; i++))
+  do
+    # Fill empty fields in version2 with zeros
+    if [[ -z ${version2[i]} ]]; then
+      version2[i]=0
+    fi
+    if ((10#${version1[i]} > 10#${version2[i]})); then
+      return 1
+    fi
+    if ((10#${version1[i]} < 10#${version2[i]})); then
+      return 2
+    fi
+  done
+  return 0
+}


### PR DESCRIPTION
Temp files moved:
 - Parcels (empty files were left in place to make CM happy)
 - Ansible stuff needed for cis hardening

Storage requirements changed for RHEL8:
 - Azure needs to 64GB, used to require 90GB for 7.2.18 (LVMs of the source image can not be shrinked so this is the minimum)
 - CDH version 7.2.18+ needs 52GB, used to require 72GB
 - Older runtimes need 48GB, used to require 64GB

Other improvements:
 - Upgrade to latest Packer
 - Move image size calculation to separate script
 - Show storage usage at the end of image burning
 - Remove --retcode-passthrough from salt highstates to fail on error

Test images

- Centos7 7.2.17
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4004/
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4005/
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4027/
- RHEL8 7.2.18
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4029/
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3994/
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4008/
- RHEL8 7.3.0
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4028/
- GOV
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3997/
