### PR TITLE
CB-24956 Fix cloudera-scm uid/gid on RHEL8

### DIFF
--- a/saltstack/base/salt/prerequisites/user_uid.sls
+++ b/saltstack/base/salt/prerequisites/user_uid.sls
@@ -1,28 +1,26 @@
+{% set ids = {
+  'cloudera_scm_user': '992',
+  'cloudera_scm_group': '988',
+} %}
+
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'Azure' %}
+
+{% set ids = {
+  'cloudera_scm_user': '991',
+  'cloudera_scm_group': '987',
+} %}
+
 {% if pillar['OS'] == 'redhat8' %}
-  {% 
-    set ids = {
-      'cloudera_scm_user': '10001',
-      'cloudera_scm_group': '10001',
-    } 
-  %}
-{% else %}
-{% set ids = salt['grains.filter_by']({
-    'amazon-ebs': {
-        'cloudera_scm_user': '992',
-        'cloudera_scm_group': '988',
-    },
-    'azure-arm': {
-        'cloudera_scm_user': '991',
-        'cloudera_scm_group': '987',
-    },
-    'googlecompute': {
-        'cloudera_scm_user': '992',
-        'cloudera_scm_group': '988',
-    },
-},
-grain='builder_type',
-default='amazon-ebs'
-)%}
+# sssd has the needed uid/gid for cloudera-scm so it has to be modified
+
+change_sssd_ids:
+  cmd.run:
+    - name: |
+        usermod -u 10001 sssd
+        groupmod -g 10001 sssd
+        find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h sssd {} \;
+        find / -not -path "/proc/*" -group {{ ids.cloudera_scm_group }}  -exec chgrp -h sssd {} \;
+{% endif %}
 {% endif %}
 
 create_cloudera_scm_group:


### PR DESCRIPTION
On Azure RHEL8 the cloudera-scm uid and gid collides with sssd, so as a fix this was modified to 10001, but that caused permission issues when upgrading from centos7 to rhel8. The actual fix is to change the sssd uid and gid to free them up for cloudera-scm.

RHEL8 7.2.17 runs:
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/171/
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/164/
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/174/