### PR TITLE
CB-25364 Disable postgres

### DIFF
--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -327,6 +327,7 @@ stop-postgresql:
 {% else %}
     - name: postgresql
 {% endif %}
+    - enable: False
 {% endif %}
 
 set-postgres-nologin-shell:


### PR DESCRIPTION
```
[cloudbreak@ip-10-83-196-130 ~]$ systemctl status postgresql-14
● postgresql-14.service - PostgreSQL 14 database server
   Loaded: loaded (/usr/lib/systemd/system/postgresql-14.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
     Docs: https://www.postgresql.org/docs/14/static/

```