### PR TITLE
CB-25364 Only disable postgresql for rhel8

### DIFF
--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -324,10 +324,10 @@ stop-postgresql:
   service.dead:
 {% if  pillar['OS'] == 'redhat8' %}
     - name: postgresql-{{ pg_default_version }}
+    - enable: False
 {% else %}
     - name: postgresql
 {% endif %}
-    - enable: False
 {% endif %}
 
 set-postgres-nologin-shell:


### PR DESCRIPTION
On centos7 the default postgresql service is needed for CB, but this alias is not resolved when the service is disabled

```
[root@ip-10-84-214-151 cloudbreak]# systemctl list-unit-files |grep postg
postgresql-10.service                         disabled
postgresql-11.service                         disabled
postgresql-14.service                         disabled
[root@ip-10-84-214-151 cloudbreak]# systemctl enable postgresql-10
Created symlink from /etc/systemd/system/postgresql.service to /usr/lib/systemd/system/postgresql-10.service.
Created symlink from /etc/systemd/system/multi-user.target.wants/postgresql-10.service to /usr/lib/systemd/system/postgresql-10.service.
[root@ip-10-84-214-151 cloudbreak]# systemctl list-unit-files |grep postg
postgresql-10.service                         enabled
postgresql-11.service                         disabled
postgresql-14.service                         disabled
postgresql.service                            enabled
```

centos7 test run: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4158/consoleFull
```
    arm-centos7:           ID: stop-postgresql
    arm-centos7:     Function: service.dead
    arm-centos7:         Name: postgresql
    arm-centos7:       Result: True
    arm-centos7:      Comment: Service postgresql was killed
```

rhel8 test run: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4159/consoleFull
```
    arm-redhat8:           ID: stop-postgresql
    arm-redhat8:     Function: service.dead
    arm-redhat8:         Name: postgresql-14
    arm-redhat8:       Result: True
    arm-redhat8:      Comment: Service postgresql-14 has been disabled, and is dead
```