### PR TITLE
CB-25246: Disabled automatic DNF updates

### DIFF
--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -16,6 +16,8 @@ remove_unused_rhel8_packages:
       - sssd-krb5
       # Not used but adds warnings to register system
       - insights-client
+      # Enforces automatic updates that can end up destabilizing the instance
+      - dnf-automatic
 {% endif %}
 
 


### PR DESCRIPTION
Test builds:
 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4164/ (AWS, should not be affected at all)
 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4165/ (GCP, package should be removed without problems)