### PR TITLE
Bump-up new version of jumpgate agent to 3.0.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ CDP_TELEMETRY_VERSION ?= ""
 CDP_LOGGING_AGENT_VERSION ?= ""
 
 # This one is OS-independent (right?)
-DEFAULT_JUMPGATE_AGENT_RPM_URL := https://archive.cloudera.com/ccm/3.0.7/jumpgate-agent.rpm
+DEFAULT_JUMPGATE_AGENT_RPM_URL := https://archive.cloudera.com/ccm/3.0.8/jumpgate-agent.rpm
 
 # This one is OS-independent (v2.0 is a rewrite done in GoLang)
 DEFAULT_METERING_AGENT_RPM_URL := "https://archive.cloudera.com/cp_clients/thunderhead-metering-heartbeat-application-2.0.0-b12639.x86_64.rpm"

--- a/docker/redhat8/Dockerfile
+++ b/docker/redhat8/Dockerfile
@@ -107,7 +107,7 @@ ENV CDP_TELEMETRY_RPM_URL="https://archive.cloudera.com/cdp-infra-tools/1.3.2/re
 ENV CDP_LOGGING_AGENT_RPM_URL="https://archive.cloudera.com/cdp-infra-tools/1.3.2/redhat8/yum/cdp_logging_agent-1.3.2_b1.rpm"
 ENV FREEIPA_PLUGIN_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/49070467/thunderhead/1.x/redhat8/yum/cdp-hashed-pwd-1.0-20240109061814git4230396.el8.x86_64.rpm"
 ENV FREEIPA_LDAP_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/49050621/thunderhead/1.x/redhat8/yum/freeipa-ldap-agent-1.0.0-b12325.x86_64.rpm"
-ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.0.7/jumpgate-agent.rpm"
+ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.0.8/jumpgate-agent.rpm"
 
 #we build logic on the existance of this directory, please DO NOT REMOVE
 RUN mkdir /yarn-private


### PR DESCRIPTION
**AWS based image tested using** 
CentOS
```
{
        "created": 1713976483,
        "published": 1713980461,
        "date": "2024-04-24",
        "description": "Official Cloudbreak image",
        "images": {
          "aws": {
            "us-west-1": "ami-07bfde7b8e8b6507a"
          }
        },
        "os": "centos7",
        "os_type": "redhat7",
        "uuid": "0eadafc6-315d-4599-80ed-6130f1dd15b1",
        "package-versions": {
          "blackbox-exporter": "0.19.0",
          "cdp-logging-agent": "1.3.2_b1",
          "cdp-minifi-agent": "1.22.07",
          "cdp-prometheus": "2.36.2",
          "cdp-request-signer": "0.2.4",
          "cdp-telemetry": "1.3.2_b1",
          "cloudbreak_images": "9eb34da0142d90da75f9cd949010b850f4861fe2",
          "freeipa-health-agent": "0.1-20240306130845git17cc467",
          "freeipa-ldap-agent": "1.0.0-b12478",
          "freeipa-plugin": "1.0-20240306130845git17cc467.el7",
          "imds": "v2",
          "inverting-proxy-agent": "3.4.0-b48",
          "inverting-proxy-agent_gbn": "52222811",
          "node-exporter": "1.3.1",
          "python27": "2.7.5-94.el7_9",
          "python36": "3.6.8-21.el7_9",
          "salt": "3001.8",
          "salt-bootstrap": "0.13.6-2022-05-20T08:57:17",
          "source-image": "ami-098f55b4287a885ba"
        },
        "tags": {
          "hardening": "cis_server_l1"
        }
      }
```
Rhel8
```
{
        "created": 1713955427,
        "published": 1713958021,
        "date": "2024-04-24",
        "description": "Official Cloudbreak image",
        "images": {
          "aws": {
            "us-west-1": "ami-006e6d75b00c6c4c9"
          }
        },
        "os": "redhat8",
        "os_type": "redhat8",
        "uuid": "5f185044-195b-417e-8d4a-eb67f03e2e4d",
        "package-versions": {
          "blackbox-exporter": "0.19.0",
          "cdp-logging-agent": "1.3.2_b1",
          "cdp-minifi-agent": "1.22.07",
          "cdp-prometheus": "2.36.2",
          "cdp-request-signer": "0.2.4",
          "cdp-telemetry": "1.3.2_b1",
          "cloudbreak_images": "caa9151eea4476a532a18755acf67c16f1673c3f",
          "freeipa-health-agent": "0.1-20240306130845git17cc467",
          "freeipa-ldap-agent": "1.0.0-b12478",
          "freeipa-plugin": "1.0-20240306130845git17cc467.el8",
          "imds": "v2",
          "inverting-proxy-agent": "3.4.0-b48",
          "inverting-proxy-agent_gbn": "52222811",
          "node-exporter": "1.3.1",
          "python36": "3.6.8-38.module+el8.5.0+12207+5c5719bc",
          "python38": "3.8.16-1.module+el8.8.0+18967+20d359ae.1",
          "salt": "3001.8",
          "salt-bootstrap": "0.13.6-2022-05-20T08:57:17",
          "source-image": "ami-039ce2eddc1949546"
        },
        "tags": {
          "fips-mode": "disabled",
          "hardening": "cis_server_l1"
        }
      }
```

**Azure based image tested using**
CentOS
```
{
        "created": 1713982784,
        "published": 1713984593,
        "date": "2024-04-24",
        "description": "Official Cloudbreak image",
        "images": {
          "azure": {
            "West US": "https://cldrwestus.blob.core.windows.net/images/freeipa-cdh--1713982649.vhd"
          }
        },
        "os": "centos7",
        "os_type": "redhat7",
        "uuid": "cca0e0d6-2d92-4c59-940d-f9e5863db695",
        "package-versions": {
          "blackbox-exporter": "0.19.0",
          "cdp-logging-agent": "1.3.2_b1",
          "cdp-minifi-agent": "1.22.07",
          "cdp-prometheus": "2.36.2",
          "cdp-request-signer": "0.2.4",
          "cdp-telemetry": "1.3.2_b1",
          "cloudbreak_images": "4e2dc20e52448c592df2ea385e978c282a8dd577",
          "freeipa-health-agent": "0.1-20240306130845git17cc467",
          "freeipa-ldap-agent": "1.0.0-b12478",
          "freeipa-plugin": "1.0-20240306130845git17cc467.el7",
          "inverting-proxy-agent": "3.4.0-b48",
          "inverting-proxy-agent_gbn": "52222811",
          "node-exporter": "1.3.1",
          "python27": "2.7.5-94.el7_9",
          "python36": "3.6.8-21.el7_9",
          "salt": "3001.8",
          "salt-bootstrap": "0.13.6-2022-05-20T08:57:17",
          "source-image": "openlogic:centos:7.6:7.6.201909120"
        },
        "tags": {
          "hardening": "cis_server_l1"
        }
      }
```
Rhel8
```
{
        "created": 1713962878,
        "published": 1713965078,
        "date": "2024-04-24",
        "description": "Official Cloudbreak image",
        "images": {
          "azure": {
            "West US": "https://cldrwestus.blob.core.windows.net/images/freeipa-cdh--1713962754.vhd"
          }
        },
        "os": "redhat8",
        "os_type": "redhat8",
        "uuid": "a992a3fa-b124-45a1-afed-75ecc297c0b4",
        "package-versions": {
          "blackbox-exporter": "0.19.0",
          "cdp-logging-agent": "1.3.2_b1",
          "cdp-minifi-agent": "1.22.07",
          "cdp-prometheus": "2.36.2",
          "cdp-request-signer": "0.2.4",
          "cdp-telemetry": "1.3.2_b1",
          "cloudbreak_images": "6bb2ec13ca0eb68766bc944e8cc5be57f519df14",
          "freeipa-health-agent": "0.1-20240306130845git17cc467",
          "freeipa-ldap-agent": "1.0.0-b12478",
          "freeipa-plugin": "1.0-20240306130845git17cc467.el8",
          "inverting-proxy-agent": "3.4.0-b48",
          "inverting-proxy-agent_gbn": "52222811",
          "node-exporter": "1.3.1",
          "python36": "3.6.8-38.module+el8.5.0+12207+5c5719bc",
          "python38": "3.8.16-1.module+el8.8.0+18967+20d359ae.1",
          "salt": "3001.8",
          "salt-bootstrap": "0.13.6-2022-05-20T08:57:17",
          "source-image": "redhat:rhel-byos:rhel-lvm88:8.8.2023102310"
        },
        "tags": {
          "fips-mode": "disabled",
          "hardening": "cis_server_l1"
        }
      }
```

**GCP image tested using**
CentOS
```
{
  "created": 1713988662,
  "published": 1713990651,
  "date": "2024-04-24",
  "description": "Official Cloudbreak image",
  "images": {
    "gcp": {
      "default": "cloudera-freeipa-images/freeipa-cdh--1713988645.tar.gz"
    }
  },
  "os": "centos7",
  "os_type": "redhat7",
  "uuid": "0485f6cf-3673-4766-a023-4eb458bf03e5",
  "package-versions": {
    "blackbox-exporter": "0.19.0",
    "cdp-logging-agent": "1.3.2_b1",
    "cdp-minifi-agent": "1.22.07",
    "cdp-prometheus": "2.36.2",
    "cdp-request-signer": "0.2.4",
    "cdp-telemetry": "1.3.2_b1",
    "cloudbreak_images": "c856e96e9c5bd5f7e0340ebbe24d0034f6872678",
    "freeipa-health-agent": "0.1-20240306130845git17cc467",
    "freeipa-ldap-agent": "1.0.0-b12478",
    "freeipa-plugin": "1.0-20240306130845git17cc467.el7",
    "inverting-proxy-agent": "3.4.0-b48",
    "inverting-proxy-agent_gbn": "52222811",
    "node-exporter": "1.3.1",
    "python27": "2.7.5-94.el7_9",
    "python36": "3.6.8-21.el7_9",
    "salt": "3001.8",
    "salt-bootstrap": "0.13.6-2022-05-20T08:57:17",
    "source-image": "centos-7-v20200811"
  },
  "tags": {
    "hardening": "cis_server_l1"
  }
}
```
Rhel8
```
{
        "created": 1713971161,
        "published": 1713973745,
        "date": "2024-04-24",
        "description": "Official Cloudbreak image",
        "images": {
          "gcp": {
            "default": "cloudera-freeipa-images/freeipa-cdh--1713971146.tar.gz"
          }
        },
        "os": "redhat8",
        "os_type": "redhat8",
        "uuid": "3fdd1660-b854-4d32-a57f-ea5d649921ff",
        "package-versions": {
          "blackbox-exporter": "0.19.0",
          "cdp-logging-agent": "1.3.2_b1",
          "cdp-minifi-agent": "1.22.07",
          "cdp-prometheus": "2.36.2",
          "cdp-request-signer": "0.2.4",
          "cdp-telemetry": "1.3.2_b1",
          "cloudbreak_images": "b6ab3bb014d70a8587b8ecafb98e2dfeaef66960",
          "freeipa-health-agent": "0.1-20240306130845git17cc467",
          "freeipa-ldap-agent": "1.0.0-b12478",
          "freeipa-plugin": "1.0-20240306130845git17cc467.el8",
          "inverting-proxy-agent": "3.4.0-b48",
          "inverting-proxy-agent_gbn": "52222811",
          "node-exporter": "1.3.1",
          "python36": "3.6.8-38.module+el8.5.0+12207+5c5719bc",
          "python38": "3.8.16-1.module+el8.8.0+18967+20d359ae.1",
          "salt": "3001.8",
          "salt-bootstrap": "0.13.6-2022-05-20T08:57:17",
          "source-image": "rhel-8-byos-v20230615"
        },
        "tags": {
          "fips-mode": "disabled",
          "hardening": "cis_server_l1"
        }
      }
```