### PR TITLE
CB-24126: Include `AccessDenied` in the errors we retry for while retrieving userdata secrets

### DIFF
--- a/saltstack/base/salt/userdata-secrets/bin/cdp-retrieve-userdata-secrets.sh
+++ b/saltstack/base/salt/userdata-secrets/bin/cdp-retrieve-userdata-secrets.sh
@@ -7,27 +7,42 @@ retry_until_non_placeholder_value() {
   local BASE_FACTOR=2
   local MAX_BACKOFF=20
   local MAX_ATTEMPT=15
+  local ACCESS_DENIED_EXIT_CODE=254
 
   local total_wait_time=0
   local timeout=1
   local attempt=1
+  local non_transient_aws_service_error_count=0
 
+  set +e
   SECRET_STRING="$("$@")"
-  while [[ "$SECRET_STRING" == "PLACEHOLDER" ]]; do
+  local exit_code=$?
+  set -e
+  while [[ "$SECRET_STRING" == "PLACEHOLDER" || "$exit_code" == "$ACCESS_DENIED_EXIT_CODE" ]]; do
     if (( attempt > MAX_ATTEMPT )); then
       echo "Maximum number of retry attempts reached while waiting for userdata secret to update! Total wait time was $total_wait_time seconds. Exiting..."
       exit 1
     fi
+    if [[ "$exit_code" == "$ACCESS_DENIED_EXIT_CODE" ]]; then
+      non_transient_aws_service_error_count=$(( non_transient_aws_service_error_count + 1 ))
+      echo "Getting the userdata secret failed with a non-transient error. See the error returned by aws-cli above! "
+    else
+      echo "Userdata secret still has PLACEHOLDER value."
+    fi
 
-    echo "Userdata secret still has PLACEHOLDER value. Waiting $timeout seconds until the next attempt to retrieve the secret."
+    echo "Waiting $timeout seconds until the next attempt to retrieve the secret."
     sleep $timeout
 
     total_wait_time=$(( total_wait_time + timeout ))
-    attempt=$(( attempt + 1))
+    attempt=$(( attempt + 1 ))
     timeout=$(( timeout * BASE_FACTOR > MAX_BACKOFF ? MAX_BACKOFF : timeout * BASE_FACTOR ))
 
+    set +e
     SECRET_STRING="$("$@")"
+    exit_code=$?
+    set -e
   done
+  echo "Total number of non-transient AWS errors: $non_transient_aws_service_error_count."
   echo "Userdata secret's value was retrieved after waiting $total_wait_time seconds."
 }
 
@@ -45,6 +60,11 @@ aws_with_retry_params() {
 # Intermittent issues like throttling of AWS APIs are handled by the built in retry mechanism of the aws cli.
 # Waiting for CB to update the secret's value to the actual secrets is handled by the `retry_until_non_placeholder_value` function.
 main() {
+  if [[ -z "$USERDATA_SECRET_ID" ]]; then
+    echo "USERDATA_SECRET_ID is empty. Cannot retrieve userdata secrets!"
+    exit 1
+  fi
+
   if [[ "$CLOUD_PLATFORM" == "AWS" ]]; then
     echo "Retrieving userdata secrets..."
     retry_until_non_placeholder_value \
@@ -64,7 +84,7 @@ main() {
     echo "Successfully deleted secret associated with this instance!"
   else
     echo "Userdata secret retrieval not implemented for CLOUD_PLATFORM $CLOUD_PLATFORM."
-    exit 1
+    exit 2
   fi
 }
 


### PR DESCRIPTION
Previously, when an instance would try to retrieve its userdata secret and the secret's resource policy hasn't been updated yet, the script would exit because the AWS CLI would return an `AccessDeniedException` and exit with an exit code of `254`. Modified the script, so that it wouldn't exit immediately when the AWS CLI call to retrieve the secret returns an `AccessDeniedException`. Instead, the script treats `AccessDeniedException`s (and any other exception that would cause the cli to exit with an exit code of `254`) as errors that need to be retried for.