### PR TITLE
CB-26169: Disabled weak SSL ciphers

### DIFF
--- a/saltstack/base/salt/nginx/etc/nginx/ssl.conf
+++ b/saltstack/base/salt/nginx/etc/nginx/ssl.conf
@@ -6,6 +6,9 @@ server {
     ssl_certificate      /etc/certs/cluster.pem;
     ssl_certificate_key  /etc/certs/cluster-key.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
+{% if pillar['OS'] != 'centos7' %}
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:DHE-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:DES-CBC3-SHA;
+{% endif %}
     rewrite ^([^/]*/ambari)$ $1/ permanent;
     # e.g.: https://172.22.107.133/img/white-logo.png -> https://172.22.107.133/ambari/img/white-logo.png
     if ($http_referer ~ .*/ambari/.*) {
@@ -36,6 +39,9 @@ server {
     ssl_certificate_key  /etc/certs/cluster-key.pem;
     ssl_client_certificate /etc/certs/cb-client.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
+{% if pillar['OS'] != 'centos7' %}
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:DHE-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:DES-CBC3-SHA;
+{% endif %}
     ssl_verify_client on;
 {% if pillar['CUSTOM_IMAGE_TYPE'] != 'freeipa' %}
     location / {


### PR DESCRIPTION
RHEL8 7.2.18 Test build: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4609/ 
(Successful validation: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/618/)

RHEL8 FreeIPA Test build: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4628/
(Successful validation: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/633/)

CentOS7 FreeIPA Test build: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4616/
CentOS7 7.2.16 Test build: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4617/

**UPDATE**: Dropped support for this on CentOS 7 as it consistently breaks FreeIPA on CentOS 7, however given it's nearly EOL, investigating and fixing a ciper-related issue won't worth the effort.