### PR TITLE
CB-26201: Add a way to build CentOS7 Runtime/FreeIPA images from a base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 # AWS source ami and instance type specification
 ifeq ($(CLOUD_PROVIDER),AWS)
 	ifeq ($(OS),centos7)
-		AWS_SOURCE_AMI ?= ami-098f55b4287a885ba
+		AWS_SOURCE_AMI ?= ami-0f2d991bb08fccb7a
 		AWS_INSTANCE_TYPE ?= t3.2xlarge
 	endif
 	ifeq ($(OS),redhat8)

--- a/saltstack/base/salt/prerequisites/corkscrew.sls
+++ b/saltstack/base/salt/prerequisites/corkscrew.sls
@@ -1,5 +1,6 @@
 {%if pillar['subtype'] != 'Docker' %}
 
+{% if pillar['OS'] != 'centos7' %}
 clone_corkscrew:
   git.latest:
     - name: https://github.com/bryanpkc/corkscrew.git
@@ -18,6 +19,7 @@ cleanup_corkscrew:
 create_corkscrew_softlink:
   cmd.run:
     - name: ln -s /usr/local/bin/corkscrew /usr/bin/corkscrew
+{% endif %}
 
 {% elif pillar['OS'] == 'redhat8' %}
 

--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -71,7 +71,7 @@ packages_install:
       - httpd-tools
 
 {% if pillar['subtype'] != 'Docker' %}
-
+{% if pillar['OS'] != 'centos7' %}
 {% if salt['environ.get']('CLOUD_PROVIDER') == '' %}
 missing_cloudprovider:
   cmd.run:
@@ -112,5 +112,5 @@ remove_azcopy_extract:
     - name: /tmp/azcopy
     - clean: True
 {% endif %}
-
+{% endif %}
 {% endif %}

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -235,7 +235,10 @@ echo "Network interfaces: $(ifconfig)"
 echo "Public address: $(curl -s https://checkip.amazonaws.com)"
 
 case ${SALT_INSTALL_OS} in
-  centos|redhat)
+  centos)
+    echo "Skipping installation as Salt is already present on the base image".
+    ;;
+  redhat)
     echo "Install with yum"
     install_with_yum
     ;;


### PR DESCRIPTION
Test build - AWS, Runtime: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4758/
This is based on the foundation image burned with https://github.com/hortonworks/cloudbreak-images/pull/999