### PR TITLE
CB-26331: Added missing arch info for AWS Gov builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ endif
 
 # AWS_GOV source ami specification
 ifeq ($(CLOUD_PROVIDER),AWS_GOV)
+	AWS_INSTANCE_TYPE ?= t3.2xlarge
     ifeq ($(OS),centos7)
 		AWS_GOV_SOURCE_AMI ?= ami-bbba86da
 	endif
@@ -428,6 +429,7 @@ build-aws-gov-redhat8:
 	$(ENVS) \
 	AWS_AMI_REGIONS="us-gov-west-1" \
 	AWS_GOV_SOURCE_AMI=$(AWS_GOV_SOURCE_AMI) \
+	AWS_INSTANCE_TYPE=$(AWS_INSTANCE_TYPE) \
 	OS=redhat8 \
 	OS_TYPE=redhat8 \
 	ATLAS_ARTIFACT_TYPE=amazon-gov \


### PR DESCRIPTION
Test build: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/4724/ - ✅ 
Validation: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/694/ - ⏳