### PR TITLE
CB-24115 CB-24117 CB-24118 CB-24119 CB-24120 CB-24121 CB-26031 Popula…

### DIFF
--- a/saltstack/base/salt/luks/bin/create-luks-volume.sh
+++ b/saltstack/base/salt/luks/bin/create-luks-volume.sh
@@ -124,7 +124,7 @@ mount_luks_volume() {
   if ! mountpoint -q "$MOUNT_POINT"; then
     # Mount the LUKS volume
     mount "$LUKS_MAPPER_DEVICE" "$MOUNT_POINT"
-    chmod 700 "$MOUNT_POINT"
+    chmod 755 "$MOUNT_POINT"
   else
     echo "Failed to mount the LUKS volume, as the path is already a mount point... Exiting LUKS volume creation with failed exit code!"
     exit 7

--- a/saltstack/base/salt/luks/bin/populate-luks-volume.sh
+++ b/saltstack/base/salt/luks/bin/populate-luks-volume.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+export LUKS_VOLUME_NAME="cdp-luks"
+export MOUNT_POINT="/mnt/$LUKS_VOLUME_NAME"
+
+validate_absolute_path() {
+  local location="$1"
+  if [[ ! "$location" =~ ^/.* ]]
+  then
+    echo "Location \"$location\" must be an absolute path!"
+    exit 1
+  fi
+}
+
+validate_location_exists() {
+  local location="$1"
+  if [ ! -d "$location" ]
+  then
+    echo "Location \"$location\" must be an existing directory!"
+    exit 2
+  fi
+}
+
+create_location_if_necessary() {
+  local location="$1"
+  local owner=$2
+  local group=$3
+  local mode=$4
+  if [ ! -d "$location" ]
+  then
+    echo "Location \"$location\" does not exist; creating it with owner \"$owner\", group \"$group\", mode \"$mode\"."
+    install -o $owner -g $group -m $mode -d "$location"
+  fi
+}
+
+create_location_parent_tree_if_necessary() {
+  local source_location_parent
+  source_location_parent=$(dirname "$1")
+  if [ "$source_location_parent" != "/" ]
+  then
+    echo "Creating source location parent tree \"$source_location_parent\" if necessary."
+    source_location_parent="${source_location_parent#/}"
+    local source_location=""
+    local luks_location="$MOUNT_POINT"
+    local line
+    while read -r line
+    do
+      source_location="$source_location/$line"
+      rsync -dAogqk "$source_location" "$luks_location"
+      luks_location="$luks_location/$line"
+    done < <(echo "$source_location_parent" | awk -F / '{for (i=1; i<=NF; i++) print $i}')
+  fi
+}
+
+process_location() {
+  local source_location="$1"
+  echo "Processing source location \"$source_location\"."
+  validate_absolute_path "$source_location"
+  validate_location_exists "$source_location"
+  create_location_parent_tree_if_necessary "$source_location"
+  local luks_location="$MOUNT_POINT$source_location"
+  echo "Moving source location \"$source_location\" into LUKS location \"$luks_location\"."
+  local luks_location_parent
+  luks_location_parent=$(dirname "$luks_location")
+  mv "$source_location" "$luks_location_parent"
+  echo "Creating symlink \"$source_location\" pointing to \"$luks_location\"."
+  ln -s "$luks_location" "$source_location"
+}
+
+process_location_with_create() {
+  local location="$1"
+  validate_absolute_path "$location"
+  create_location_if_necessary "$@"
+  process_location "$location"
+}
+
+log_processing_needed() {
+  echo "Processing $1 locations."
+}
+
+log_processing_skipped() {
+  echo "No need to process $1 locations."
+}
+
+process_global_locations() {
+  log_processing_needed "global"
+  process_location_with_create "/etc/salt-bootstrap" root root 700
+  create_location_if_necessary "/etc/salt/pki" root root 744
+  process_location_with_create "/etc/salt/pki/minion" root root 700
+  process_location "/etc/ipa/nssdb"
+  process_location "/var/lib/sss/db"
+  process_location "/var/lib/sss/keytabs"
+  process_location "/var/lib/sss/secrets"
+}
+
+process_nginx_locations() {
+  if [[ -n "$CB_CERT" ]]
+  then
+    log_processing_needed "nginx"
+    process_location_with_create "/etc/certs" root root 750
+  else
+    log_processing_skipped "nginx"
+  fi
+}
+
+process_gateway_locations() {
+  if [[ "$IS_GATEWAY" == "true" ]]
+  then
+    log_processing_needed "gateway"
+    process_location "/etc/pki/tls/certs"
+    process_location_with_create "/etc/salt/pki/master" root root 700
+    process_location_with_create "/srv/pillar" root root 644
+    process_nginx_locations
+  else
+    log_processing_skipped "gateway"
+  fi
+}
+
+process_ccmv2_locations() {
+  if [[ "$IS_CCM_V2_JUMPGATE_ENABLED" == "true" && "$IS_FREEIPA" == "true" || "$IS_CCM_V2_ENABLED" == "true" && "$IS_CCM_V2_JUMPGATE_ENABLED" != "true" ]]
+  then
+    log_processing_needed "CCMv2"
+    process_location_with_create "/etc/ccmv2" root root 755
+    process_location "/etc/jumpgate"
+  else
+    log_processing_skipped "CCMv2"
+  fi
+}
+
+process_http_proxy_locations() {
+  if [[ "$IS_PROXY_ENABLED" == "true" ]];
+  then
+    log_processing_needed "HTTP proxy"
+    # TODO Double-check user:group & mode
+    process_location_with_create "/etc/cdp" root root 750
+  else
+    log_processing_skipped "HTTP proxy"
+  fi
+}
+
+process_freeipa_locations() {
+  if [[ "$IS_FREEIPA" == "true" ]]
+  then
+    log_processing_needed "FreeIPA"
+    process_location "/cdp/ipahealthagent"
+    process_location "/etc/dirsrv"
+    process_location_with_create "/etc/httpd/alias" root root 755
+    process_location "/etc/ipa/custodia"
+    process_location "/etc/ipa/dnssec"
+    process_location_with_create "/etc/pki/pki-tomcat" pkiuser pkiuser 770
+    process_location "/var/kerberos/krb5kdc"
+    process_location "/var/lib/ipa"
+  else
+    log_processing_skipped "FreeIPA"
+  fi
+}
+
+main() {
+  process_global_locations
+  process_gateway_locations
+  process_ccmv2_locations
+  process_http_proxy_locations
+  process_freeipa_locations
+}
+
+main

--- a/saltstack/base/salt/luks/bin/reopen-luks-volume.sh
+++ b/saltstack/base/salt/luks/bin/reopen-luks-volume.sh
@@ -72,7 +72,7 @@ remount_luks_volume() {
   if ! mountpoint "$MOUNT_POINT"; then
     # Remount the LUKS volume
     mount "$LUKS_MAPPER_DEVICE" "$MOUNT_POINT"
-    chmod 700 "$MOUNT_POINT"
+    chmod 755 "$MOUNT_POINT"
   else
     echo "Did not mount the LUKS volume, as the path is already a mount point... Exiting LUKS volume reopen script with failed exit code!"
     exit 4

--- a/saltstack/base/salt/luks/init.sls
+++ b/saltstack/base/salt/luks/init.sls
@@ -48,6 +48,14 @@
     - group: root
     - mode: 700
 
+/etc/cdp-luks/bin/populate-luks-volume.sh:
+  file.managed:
+    - name: /etc/cdp-luks/bin/populate-luks-volume.sh
+    - source: salt://{{ slspath }}/bin/populate-luks-volume.sh
+    - user: root
+    - group: root
+    - mode: 700
+
 /etc/cdp-luks/bin/reopen-luks-volume.sh:
   file.managed:
     - name: /etc/cdp-luks/bin/reopen-luks-volume.sh

--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -22,9 +22,9 @@ fi
 : ${PROXY_PROTOCOL:=http}
 
 {% if pillar['CUSTOM_IMAGE_TYPE'] == 'freeipa' %}
-IS_FREEIPA=true
+export IS_FREEIPA=true
 {% else %}
-IS_FREEIPA=false
+export IS_FREEIPA=false
 {% endif %}
 OS={{ pillar['OS'] }}
 
@@ -84,6 +84,12 @@ create_luks_volume() {
   echo "LUKS volume creation started."
   /etc/cdp-luks/bin/create-luks-volume.sh
   echo "LUKS volume creation finished."
+}
+
+populate_luks_volume() {
+  echo "LUKS volume population with secrets started."
+  /etc/cdp-luks/bin/populate-luks-volume.sh
+  echo "LUKS volume population with secrets finished."
 }
 
 configure-salt-bootstrap() {
@@ -251,8 +257,7 @@ resize_partitions() {
 main() {
   if [[ "$SECRET_ENCRYPTION_ENABLED" == "true" ]]; then
     create_luks_volume
-    # then extract EC2 userdata secrets and store them (for example as plaintext on the LUKS volume)
-    # then move secrets to LUKS volume and symlink them to their original place
+    populate_luks_volume
   fi
   configure-salt-bootstrap
   reload_sysconf


### PR DESCRIPTION
…te secret storage

* Fix the permission of the LUKS mount point (700 -> 755).
* Add new script `/etc/cdp-luks/bin/populate-luks-volume.sh` for populating the LUKS volume with secrets.
  * Invoked from `user-data-helper.sh` right after the LUKS volume creation.
* Secrets covered here:
  * Salt pillars: Gateway nodes only.
  * CCMv2 configs: FreeIPA nodes only for v2.5 Jumpgate; all the nodes otherwise if CCMv2 is enabled.
  * HTTP Proxy configs: All the nodes if HTTP Proxy is enabled.
  * nginx host certificate private key: Gateway nodes only.
  * `ipahealthagent` certificate private key: FreeIPA nodes only.
  * Salt Bootstrap configs: All the nodes.
  * Salt API certificate private key: Gateway nodes only.
  * Salt Master certificate private keys: Gateway nodes only.
  * Salt Minion certificate private key: All the nodes.
  * FreeIPA services (GSS API, GSS Proxy, custodia, dnssec, NSS DB, Kerberos KDC, Kerberos keytabs): `/etc/ipa/nssdb` for all the nodes; the rest for FreeIPA nodes only.
  * SSSD (SSSD cache, AD trust keytabs, KCM cache): All the nodes.
* Secrets covered later:
  * KDC default keytab (`/etc/krb5.keytab`): See [CB-26477](https://jira.cloudera.com/browse/CB-26477).
  * Kerberos TGT cache (ccache): See [CB-26478](https://jira.cloudera.com/browse/CB-26478).
  * `dirsrv` / `slapd` DB (if Kerberos principal password hashes need to be protected): See [CB-26479](https://jira.cloudera.com/browse/CB-26479).