### PR TITLE
CB-26812: Temporary RHEL 8.8 + JDK17 + 7.3.1 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,10 @@ $(error BUILD_RESOURCE_GROUP_NAME and ARM_BUILD_REGION should not be set togethe
 $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER, AZURE_IMAGE_OFFER, AZURE_IMAGE_SKU) should not be set together")
 		endif
 	else
-		ifeq ($(OS),redhat7)
-			AZURE_IMAGE_PUBLISHER ?= RedHat
-			AZURE_IMAGE_OFFER ?= RHEL
-			AZURE_IMAGE_SKU ?= 7_9
-		else ifeq ($(OS),redhat8)
+		ifeq ($(OS),redhat8)
 			AZURE_IMAGE_PUBLISHER ?= RedHat
 			AZURE_IMAGE_OFFER ?= rhel-byos
-			AZURE_IMAGE_SKU ?= rhel-lvm88
+			AZURE_IMAGE_SKU ?= rhel-lvm810
 		else ifeq ($(OS),centos7)
 			AZURE_IMAGE_PUBLISHER ?= OpenLogic
 			AZURE_IMAGE_OFFER ?= CentOS
@@ -66,10 +62,10 @@ ifeq ($(CLOUD_PROVIDER),AWS)
 	endif
 	ifeq ($(OS),redhat8)
 		ifeq ($(ARCHITECTURE),arm64)
-			AWS_SOURCE_AMI ?= ami-014a329a8d775a418
+			AWS_SOURCE_AMI ?= ami-05032c39067d77b1b
 			AWS_INSTANCE_TYPE ?= r7gd.2xlarge
 		else
-			AWS_SOURCE_AMI ?= ami-039ce2eddc1949546
+			AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 			AWS_INSTANCE_TYPE ?= t3.2xlarge
 		endif
 	endif

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER
 		ifeq ($(OS),redhat8)
 			AZURE_IMAGE_PUBLISHER ?= RedHat
 			AZURE_IMAGE_OFFER ?= rhel-byos
-			AZURE_IMAGE_SKU ?= rhel-lvm810
+			AZURE_IMAGE_SKU ?= rhel-lvm88
 		else ifeq ($(OS),centos7)
 			AZURE_IMAGE_PUBLISHER ?= OpenLogic
 			AZURE_IMAGE_OFFER ?= CentOS
@@ -62,10 +62,10 @@ ifeq ($(CLOUD_PROVIDER),AWS)
 	endif
 	ifeq ($(OS),redhat8)
 		ifeq ($(ARCHITECTURE),arm64)
-			AWS_SOURCE_AMI ?= ami-05032c39067d77b1b
+			AWS_SOURCE_AMI ?= ami-014a329a8d775a418
 			AWS_INSTANCE_TYPE ?= r7gd.2xlarge
 		else
-			AWS_SOURCE_AMI ?= ami-02073841a355a1e92
+			AWS_SOURCE_AMI ?= ami-039ce2eddc1949546
 			AWS_INSTANCE_TYPE ?= t3.2xlarge
 		endif
 	endif
@@ -88,7 +88,7 @@ ifeq ($(CLOUD_PROVIDER),GCP)
 		GCP_SOURCE_IMAGE ?= centos-7-v20200811
 	endif
 	ifeq ($(OS),redhat8)
-		GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
+		GCP_SOURCE_IMAGE ?= rhel-8-byos-v20230615
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ ifeq ($(CLOUD_PROVIDER),GCP)
 		GCP_SOURCE_IMAGE ?= centos-7-v20200811
 	endif
 	ifeq ($(OS),redhat8)
-		GCP_SOURCE_IMAGE ?= rhel-8-byos-v20230615
+		GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
 	endif
 endif
 

--- a/packer.json
+++ b/packer.json
@@ -427,8 +427,8 @@
         "Customer Delivered": "{{user `tag_customer_delivered`}}"
       },
       "plan_info": {
-        "plan_name": "rhel-lvm88",
-        "plan_product": "rhel-byos",
+        "plan_name": "{{user `azure_image_sku`}}",
+        "plan_product": "{{user `azure_image_offer`}}",
         "plan_publisher": "redhat"
       }
     },

--- a/saltstack/base/salt/prerequisites/init.sls
+++ b/saltstack/base/salt/prerequisites/init.sls
@@ -1,5 +1,6 @@
 include:
   - {{ slspath }}.path
+  - {{ slspath }}.setroubleshoot
   - {{ slspath }}.user_uid
   - {{ slspath }}.subscription-manager
   - {{ slspath }}.repository

--- a/saltstack/base/salt/prerequisites/setroubleshoot.sls
+++ b/saltstack/base/salt/prerequisites/setroubleshoot.sls
@@ -1,0 +1,13 @@
+# setroubleshoot breaks SCM group creation on Azure + it is unwanted for CIS compliance
+
+{% if salt['environ.get']('OS') == 'redhat8' and salt['environ.get']('RHEL_VERSION') == '8.10' and salt['environ.get']('CLOUD_PROVIDER') == 'Azure' %}
+remove_setroubleshoot_packages:
+  pkg.removed:
+    - pkgs:
+      - setroubleshoot
+      - setroubleshoot-server
+      - setroubleshoot-plugins
+remove_setroubleshoot_user:
+  user.absent:
+    - name: setroubleshoot
+{% endif %}

--- a/saltstack/final/salt/cis-controls/common.sls
+++ b/saltstack/final/salt/cis-controls/common.sls
@@ -168,15 +168,12 @@ Chrony_config:
     - name: setfacl -R -d -m o::--- /var/log
 
 #### CIS: Disable unused filesystems
-#https://jira.cloudera.com/browse/CB-8897
+# https://jira.cloudera.com/browse/CB-8897
+# Starting with RHEL 8 FAT is used on all cloud providers (with earlier OSes we could disable it at least for AWS)
 {% set filesystems_to_disable = ['cramfs', 'freevxfs', 'jffs2', 'hfs', 'hfsplus', 'squashfs'] %}
 {% if cloud_provider != 'Azure' %}
   # udf is required for Azure to mount cdrom - See CB-11012
   {% do filesystems_to_disable.append('udf') %}
-{% endif %}
-{% if cloud_provider != 'GCP' and not (cloud_provider == 'Azure' and os == 'redhat8') and not architecture == 'arm64' %}
-  # fat is required for gcp and azure rhel8 and arm64 images
-  {% do filesystems_to_disable.append('fat') %}
 {% endif %}
 
 create modrobe blacklist:

--- a/saltstack/final/salt/metadata/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/metadata/tmp/generate-package-versions.sh
@@ -151,6 +151,10 @@ if [[ -n "$PYTHON311" ]]; then
 	cat /tmp/package-versions.json | jq --arg version ${PYTHON311} '. + {"python311": $version}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
 fi
 
+if [[ -n "$RHEL_VERSION" ]]; then
+	cat /tmp/package-versions.json | jq --arg version ${RHEL_VERSION} '. + {"os-version": $version}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
+fi
+
 if [[ "$CLOUD_PROVIDER" == "AWS"* ]]; then
 	cat /tmp/package-versions.json | jq '. + {"imds": "v2"}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
 fi

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -61,6 +61,17 @@ delete_rhel8_repo:
 {% endif %}
 {% endif %}
 
+# Note: this should be 7.2.18+ + RHEL 8.10 only (but do we want RHEL 8.10 for 7.2.17 as well?!)
+set_openjdk_version_11:
+  file.append:
+    - name: /etc/profile.d/java.sh
+    - text:
+      - "sudo alternatives --set java java-11-openjdk.x86_64"
+      - "sudo ln -sfn /etc/alternatives/java_sdk_11 /usr/lib/jvm/java"
+      - "sudo mkdir -p /etc/alternatives/java_sdk_11/jre/lib/security"
+      - "sudo ln -sfn /etc/alternatives/java_sdk_11/conf/security/java.security /etc/alternatives/java_sdk_11/jre/lib/security/java.security"
+      - "sudo ln -sfn /etc/pki/java/cacerts /etc/alternatives/java_sdk_11/jre/lib/security/cacerts"
+
 add_openjdk_gplv2:
   file.managed:
     - name: {{ pillar['JAVA_HOME'] }}/OpenJDK_GPLv2_and_Classpath_Exception.pdf

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -63,7 +63,7 @@ delete_rhel8_repo:
 
 {% if salt['environ.get']('OS') == 'redhat8' %}
 
-{% if salt['environ.get']('STACK_VERSION').split('.') | map('int') | list >= '7.3.1.0'.split('.') | map('int') | list %}
+{% if salt['environ.get']('STACK_VERSION').split('.') | map('int') | list >= '7.3.1'.split('.') | map('int') | list %}
 set_openjdk_version_17:
   file.append:
     - name: /etc/profile.d/java.sh

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -39,7 +39,7 @@ install_openjdk:
 download_rhel8_repo:
   file.managed:
     - name: /etc/yum.repos.d/rhel8_cldr_mirrors.repo
-    - source: https://mirror.infra.cloudera.com/repos/rhel/server/8/8/rhel8_cldr_mirrors.repo
+    - source: https://mirror.infra.cloudera.com/repos/rhel/server/8/8.10/rhel8.10_cldr_mirrors.repo
     - skip_verify: True
 
 {% if salt['environ.get']('ARCHITECTURE') == 'arm64' %} # ubi-8-supplementary-cldr and ubi-8-codeready-builder-cldr are not yet available for arm64

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -71,6 +71,7 @@ set_openjdk_version_11:
       - "sudo mkdir -p /etc/alternatives/java_sdk_11/jre/lib/security"
       - "sudo ln -sfn /etc/alternatives/java_sdk_11/conf/security/java.security /etc/alternatives/java_sdk_11/jre/lib/security/java.security"
       - "sudo ln -sfn /etc/pki/java/cacerts /etc/alternatives/java_sdk_11/jre/lib/security/cacerts"
+      - "sudo mkdir -p /etc/alternatives/java_sdk_11/jre/lib/ext"
 
 add_openjdk_gplv2:
   file.managed:

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -39,7 +39,7 @@ install_openjdk:
 download_rhel8_repo:
   file.managed:
     - name: /etc/yum.repos.d/rhel8_cldr_mirrors.repo
-    - source: https://mirror.infra.cloudera.com/repos/rhel/server/8/8.10/rhel8.10_cldr_mirrors.repo
+    - source: https://mirror.infra.cloudera.com/repos/rhel/server/8/{{ salt['environ.get']('RHEL_VERSION') }}/rhel{{ salt['environ.get']('RHEL_VERSION') }}_cldr_mirrors.repo
     - skip_verify: True
 
 {% if salt['environ.get']('ARCHITECTURE') == 'arm64' %} # ubi-8-supplementary-cldr and ubi-8-codeready-builder-cldr are not yet available for arm64

--- a/scripts/salt-final.sh
+++ b/scripts/salt-final.sh
@@ -21,5 +21,10 @@ function highstate {
   ${SALT_PATH}/bin/salt-call --no-color --local state.highstate saltenv=${saltenv} -l info --log-file=/tmp/salt-build-${saltenv}.log --log-file-level=info --config-dir=/tmp/saltstack/config
 }
 
+if [ "${OS}" == "redhat8" ] ; then
+  RHEL_VERSION=$(cat /etc/redhat-release | grep -oP "[0-9\.]*")
+  export RHEL_VERSION=${RHEL_VERSION/.0/}
+fi
+
 echo "Running validation and cleanup"
 highstate "final"

--- a/scripts/salt-setup.sh
+++ b/scripts/salt-setup.sh
@@ -101,6 +101,11 @@ function add_prewarmed_roles {
   fi
 }
 
+if [ "${OS}" == "redhat8" ] ; then
+  RHEL_VERSION=$(cat /etc/redhat-release | grep -oP "[0-9\.]*")
+  export RHEL_VERSION=${RHEL_VERSION/.0/}
+fi
+
 : ${CUSTOM_IMAGE_TYPE:=$1}
 
 add_builder_type_grain


### PR DESCRIPTION
THIS WILL HAVE TO BE CANCELED, unless we want to merge the changes required to go to RHEL 8.10 without actually going to RHEL 8.10 (for whatever reason we'd have...)

If you merge this the following will happen:
 - the parent branch (CB-24945-RHEL810) will revert back to using RHEL 8.8 base images
 - all the changes required to still be able to work with RHEL 8.10 will still be on the parent branch (they are meant to be backward compatible!)
 - you'll be able to merge the parent branch to master without risking accidentally releasing RHEL 8.10 content on images
 
 If you don't merge this... well, you can still use this to build images for CB-26812 :-) You can also test the backward compatibility of the parent branch by for example building a 7.2.16 image with this branch. Neat, huh?