### PR TITLE
CB-23918: RHEL 8.10 + JDK 8 breaks image burning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER
 				# CB-26812: Temp rollback!
 				# AZURE_IMAGE_SKU ?= rhel-lvm10
 				AZURE_IMAGE_SKU ?= rhel-lvm88
+			else ifeq ($(STACK_VERSION),7.2.18)
+				AZURE_IMAGE_SKU ?= rhel-lvm810
 			else
 				AZURE_IMAGE_SKU ?= rhel-lvm88
 			endif
@@ -77,6 +79,8 @@ ifeq ($(CLOUD_PROVIDER),AWS)
 				# CB-26812: Temp rollback!
 				# AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 				AWS_SOURCE_AMI ?= ami-039ce2eddc1949546
+			else ifeq ($(STACK_VERSION),7.2.18)
+				AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 			else
 				AWS_SOURCE_AMI ?= ami-039ce2eddc1949546
 			endif
@@ -106,6 +110,8 @@ ifeq ($(CLOUD_PROVIDER),GCP)
 			# CB-26812: Temp rollback!
 			# GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
 			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20230615
+		else ifeq ($(STACK_VERSION),7.2.18)
+			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
 		else
 			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20230615
 		endif

--- a/saltstack/final/salt/krb5/init.sls
+++ b/saltstack/final/salt/krb5/init.sls
@@ -8,4 +8,14 @@ disable_kcm_ccache:
 disable_sssd_conf_dir:
   file.absent:
     - name: /etc/krb5.conf.d/enable_sssd_conf_dir
+
+{% if salt['environ.get']('RHEL_VERSION') == '8.10' %}
+change_krb5_conf_crypto_policies:
+  file.managed:
+    - name: /etc/krb5.conf.d/crypto-policies
+    - replace: True
+    - contents: |
+        [libdefaults]
+        permitted_enctypes = aes256-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 camellia256-cts-cmac aes128-cts-hmac-sha1-96 aes128-cts-hmac-sha256-128 camellia128-cts-cmac
+{% endif %}
 {% endif %}


### PR DESCRIPTION
Image burning with runtime version 7.2.18 rhel 8.10 and jdk8