### PR TITLE
CB-27029 Update handling of major java version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER
 				# CB-26812: Temp rollback!
 				# AZURE_IMAGE_SKU ?= rhel-lvm10
 				AZURE_IMAGE_SKU ?= rhel-lvm88
+			else ifeq ($(STACK_VERSION),7.2.18)
+				AZURE_IMAGE_SKU ?= rhel-lvm810
 			else
 				AZURE_IMAGE_SKU ?= rhel-lvm88
 			endif
@@ -77,6 +79,8 @@ ifeq ($(CLOUD_PROVIDER),AWS)
 				# CB-26812: Temp rollback!
 				# AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 				AWS_SOURCE_AMI ?= ami-039ce2eddc1949546
+			else ifeq ($(STACK_VERSION),7.2.18)
+				AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 			else
 				AWS_SOURCE_AMI ?= ami-039ce2eddc1949546
 			endif
@@ -106,6 +110,8 @@ ifeq ($(CLOUD_PROVIDER),GCP)
 			# CB-26812: Temp rollback!
 			# GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
 			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20230615
+		else ifeq ($(STACK_VERSION),7.2.18)
+			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
 		else
 			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20230615
 		endif

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,6 @@ $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER
 				# CB-26812: Temp rollback!
 				# AZURE_IMAGE_SKU ?= rhel-lvm10
 				AZURE_IMAGE_SKU ?= rhel-lvm88
-			else ifeq ($(STACK_VERSION),7.2.18)
-				AZURE_IMAGE_SKU ?= rhel-lvm810
 			else
 				AZURE_IMAGE_SKU ?= rhel-lvm88
 			endif
@@ -79,8 +77,6 @@ ifeq ($(CLOUD_PROVIDER),AWS)
 				# CB-26812: Temp rollback!
 				# AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 				AWS_SOURCE_AMI ?= ami-039ce2eddc1949546
-			else ifeq ($(STACK_VERSION),7.2.18)
-				AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 			else
 				AWS_SOURCE_AMI ?= ami-039ce2eddc1949546
 			endif
@@ -110,8 +106,6 @@ ifeq ($(CLOUD_PROVIDER),GCP)
 			# CB-26812: Temp rollback!
 			# GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
 			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20230615
-		else ifeq ($(STACK_VERSION),7.2.18)
-			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
 		else
 			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20230615
 		endif

--- a/packer.json
+++ b/packer.json
@@ -118,7 +118,8 @@
     "cloud_provider": "{{ env `CLOUD_PROVIDER` }}",
     "ssh_public_key": "{{ env `SSH_PUBLIC_KEY` }}",
     "fips_mode": "{{ env `FIPS_MODE` }}",
-    "stig_enabled": "{{ env `STIG_ENABLED` }}"
+    "stig_enabled": "{{ env `STIG_ENABLED` }}",
+    "default_java_major_version": "{{ env `DEFAULT_JAVA_MAJOR_VERSION` }}"
   },
   "builders": [
     {
@@ -593,7 +594,8 @@
         "SALT_PATH={{user `salt_path`}}",
         "SALT_REPO_FILE={{user `salt_repo_file` }}",
         "CLOUD_PROVIDER={{user `cloud_provider`}}",
-        "STIG_ENABLED={{user `stig_enabled`}}"
+        "STIG_ENABLED={{user `stig_enabled`}}",
+        "DEFAULT_JAVA_MAJOR_VERSION={{user `default_java_major_version`}}"
       ],
       "execute_command": "chmod +x {{ .Path }}; sudo {{ .Vars }} {{ .Path }}",
       "remote_folder": "/opt/provision-scripts"
@@ -666,7 +668,8 @@
         "NO_PROXY={{ user `gov_no_proxy` }}",
         "CLOUD_PROVIDER={{user `cloud_provider`}}",
         "IMAGE_BURNING_TYPE={{ user `image_burning_type` }}",
-        "STIG_ENABLED={{user `stig_enabled`}}"
+        "STIG_ENABLED={{user `stig_enabled`}}",
+        "DEFAULT_JAVA_MAJOR_VERSION={{user `default_java_major_version`}}"
       ],
       "remote_folder": "/opt/provision-scripts"
     },

--- a/saltstack/final/salt/krb5/init.sls
+++ b/saltstack/final/salt/krb5/init.sls
@@ -9,7 +9,7 @@ disable_sssd_conf_dir:
   file.absent:
     - name: /etc/krb5.conf.d/enable_sssd_conf_dir
 
-{% if salt['environ.get']('DEFAULT_JAVA_MAJOR_VERSION') == '8' %}
+{% if salt['environ.get']('DEFAULT_JAVA_MAJOR_VERSION') == '8' and salt['environ.get']('RHEL_VERSION') == '8.10' %}
 change_krb5_conf_crypto_policies:
   file.managed:
     - name: /etc/krb5.conf.d/crypto-policies

--- a/saltstack/final/salt/krb5/init.sls
+++ b/saltstack/final/salt/krb5/init.sls
@@ -8,4 +8,14 @@ disable_kcm_ccache:
 disable_sssd_conf_dir:
   file.absent:
     - name: /etc/krb5.conf.d/enable_sssd_conf_dir
+
+{% if salt['environ.get']('DEFAULT_JAVA_MAJOR_VERSION') == '8' %}
+change_krb5_conf_crypto_policies:
+  file.managed:
+    - name: /etc/krb5.conf.d/crypto-policies
+    - replace: True
+    - contents: |
+        [libdefaults]
+        permitted_enctypes = aes256-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 camellia256-cts-cmac aes128-cts-hmac-sha1-96 aes128-cts-hmac-sha256-128 camellia128-cts-cmac
+{% endif %}
 {% endif %}

--- a/saltstack/final/salt/metadata/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/metadata/tmp/generate-package-versions.sh
@@ -109,11 +109,6 @@ elif [[ "$CUSTOM_IMAGE_TYPE" == "hortonworks" ]]; then
 	if [ -n "$STACK_VERSION" ] && [ $(version $STACK_VERSION) -lt $(version "7.2.15") ]; then
 		echo "Skip java versions as CB should not allow to force java version before 7.2.15"
 	else
-		CALCULATED_DEFAULT_JAVA_MAJOR_VERSION=$(java -version 2>&1 | grep -oP "version [^0-9]?(1\.)?\K\d+" || true)
-		if [[ $CALCULATED_DEFAULT_JAVA_MAJOR_VERSION != $DEFAULT_JAVA_MAJOR_VERSION ]]; then
-			echo "Java major version from packer.sh ($DEFAULT_JAVA_MAJOR_VERSION) differs from the actual system defaut ($CALCULATED_DEFAULT_JAVA_MAJOR_VERSION)!"
-			exit 1
-		fi
 		cat /tmp/package-versions.json | jq --arg default_java_version ${DEFAULT_JAVA_MAJOR_VERSION} '. + {"java": $default_java_version}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
 
 		alternatives --display java | grep priority | grep -oP '^[^ ]*java' | while read -r java_path ; do

--- a/saltstack/final/salt/metadata/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/metadata/tmp/generate-package-versions.sh
@@ -109,7 +109,11 @@ elif [[ "$CUSTOM_IMAGE_TYPE" == "hortonworks" ]]; then
 	if [ -n "$STACK_VERSION" ] && [ $(version $STACK_VERSION) -lt $(version "7.2.15") ]; then
 		echo "Skip java versions as CB should not allow to force java version before 7.2.15"
 	else
-		DEFAULT_JAVA_MAJOR_VERSION=$(java -version 2>&1 | grep -oP "version [^0-9]?(1\.)?\K\d+" || true)
+		CALCULATED_DEFAULT_JAVA_MAJOR_VERSION=$(java -version 2>&1 | grep -oP "version [^0-9]?(1\.)?\K\d+" || true)
+		if [[ $CALCULATED_DEFAULT_JAVA_MAJOR_VERSION != $DEFAULT_JAVA_MAJOR_VERSION ]]; then
+			echo "Java major version from packer.sh ($DEFAULT_JAVA_MAJOR_VERSION) differs from the actual system defaut ($CALCULATED_DEFAULT_JAVA_MAJOR_VERSION)!"
+			exit 1
+		fi
 		cat /tmp/package-versions.json | jq --arg default_java_version ${DEFAULT_JAVA_MAJOR_VERSION} '. + {"java": $default_java_version}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json
 
 		alternatives --display java | grep priority | grep -oP '^[^ ]*java' | while read -r java_path ; do

--- a/saltstack/final/salt/validate/init.sls
+++ b/saltstack/final/salt/validate/init.sls
@@ -15,5 +15,7 @@ check_javac_javahome:
 
 check_default_java_major_version:
   cmd.run:
-    - name: '$(if [[ $(java -version 2>&1 | grep -oP "version [^0-9]?(1\.)?\K\d+" || true) == $DEFAULT_JAVA_MAJOR_VERSION ]]; then exit 0; else exit 1; fi)'
+    - env:
+      - DEFAULT_JAVA_MAJOR_VERSION: {{ salt['environ.get']('DEFAULT_JAVA_MAJOR_VERSION') }}
+    - name: '$(if [[ "$(java -version 2>&1 | grep -oP "version [^0-9]?(1\.)?\K\d+" || true)" == "$DEFAULT_JAVA_MAJOR_VERSION" ]]; then exit 0; else exit 1; fi)'
     - failhard: True

--- a/saltstack/final/salt/validate/init.sls
+++ b/saltstack/final/salt/validate/init.sls
@@ -12,3 +12,8 @@ check_javac_javahome:
   cmd.run:
     - name: '. /etc/profile.d/java.sh && $JAVA_HOME/bin/javac -version'
     - failhard: True
+
+check_default_java_major_version:
+  cmd.run:
+    - name: '$(if [[ $(java -version 2>&1 | grep -oP "version [^0-9]?(1\.)?\K\d+" || true) == $DEFAULT_JAVA_MAJOR_VERSION ]]; then exit 0; else exit 1; fi)'
+    - failhard: True

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -63,22 +63,21 @@ delete_rhel8_repo:
 {% endif %}
 {% endif %}
 
-# CB-26812: Temp rollback!
-# {% if salt['environ.get']('OS') == 'redhat8' %}
-# {% if salt['environ.get']('STACK_VERSION').split('.') | map('int') | list >= '7.3.1'.split('.') | map('int') | list %}
-# set_openjdk_version_17:
-#   file.append:
-#     - name: /etc/profile.d/java.sh
-#     - text:
-#       - "sudo alternatives --set java java-17-openjdk.x86_64"
-#       - "sudo ln -sfn /etc/alternatives/java_sdk_17 /usr/lib/jvm/java"
-#       - "sudo mkdir -p /etc/alternatives/java_sdk_17/jre/lib/security"
-#       - "sudo ln -sfn /etc/alternatives/java_sdk_17/conf/security/java.security /etc/alternatives/java_sdk_17/jre/lib/security/java.security"
-#       - "sudo ln -sfn /etc/pki/java/cacerts /etc/alternatives/java_sdk_17/jre/lib/security/cacerts"
-#       - "sudo mkdir -p /etc/alternatives/java_sdk_17/jre/lib/ext"
-# {% endif %}
-# # Else: we're staying with JDK 8 as default for now...
-# {% endif %}
+{% if salt['environ.get']('OS') == 'redhat8' %}
+{% if salt['environ.get']('DEFAULT_JAVA_MAJOR_VERSION') == '17' %}
+set_openjdk_version_17:
+  file.append:
+    - name: /etc/profile.d/java.sh
+    - text:
+      - "sudo alternatives --set java java-17-openjdk.x86_64"
+      - "sudo ln -sfn /etc/alternatives/java_sdk_17 /usr/lib/jvm/java"
+      - "sudo mkdir -p /etc/alternatives/java_sdk_17/jre/lib/security"
+      - "sudo ln -sfn /etc/alternatives/java_sdk_17/conf/security/java.security /etc/alternatives/java_sdk_17/jre/lib/security/java.security"
+      - "sudo ln -sfn /etc/pki/java/cacerts /etc/alternatives/java_sdk_17/jre/lib/security/cacerts"
+      - "sudo mkdir -p /etc/alternatives/java_sdk_17/jre/lib/ext"
+{% endif %}
+# Else: we're staying with JDK 8 as default for now...
+{% endif %}
 
 add_openjdk_gplv2:
   file.managed:

--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex -o pipefail -o errexit
 
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
 packer_in_container() {
   local dockerOpts=""
   local packerFile="packer.json"
@@ -39,6 +41,12 @@ packer_in_container() {
     LOCAL_URL_HDP=${BASEURL}/${REPOSITORY_NAME}/${OS}/${STACK_TYPE}-${STACK_VERSION}
     LOCAL_URL_HDP_UTILS=${BASEURL}/${REPOSITORY_NAME}/${OS}/HDP-UTILS-${HDPUTIL_VERSION}
   fi
+
+  export DEFAULT_JAVA_MAJOR_VERSION=8
+  # CB-26812: Temp rollback!
+  # if [ -n "$STACK_VERSION" ] && [ $(version $STACK_VERSION) -gt $(version "7.3.0") ]; then
+  #   export DEFAULT_JAVA_MAJOR_VERSION=17
+  # fi
 
   if [[ "$ENABLE_POSTPROCESSORS" ]]; then
     echo "Postprocessors are enabled"
@@ -226,6 +234,7 @@ packer_in_container() {
     -e FIPS_MODE="$FIPS_MODE" \
     -e STIG_ENABLED="$STIG_ENABLED" \
     -e PACKER_VERSION="$PACKER_VERSION" \
+    -e DEFAULT_JAVA_MAJOR_VERSION="$DEFAULT_JAVA_MAJOR_VERSION" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v $PWD:$PWD \
     -w $PWD \


### PR DESCRIPTION
This commit:
- introduces DEFAULT_JAVA_MAJOR_VERSION at the top level in packer.json
- changes scripts to respect it's value when setting java version and metadata
- adds valdation (~both~ in validation state ~and in the generate package versions script~) to check java version is the same in the var and on the system
- introduces the "hack" for java 8 enctype order only if the default java major version is 8 _and_ the OS is RHEL 8.10

Testing:
image burning rhel 8.10 cdh 7.2.18, verified /etc/krb5.conf.d/crypto-policies contents:
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5457/consoleFull
image burning rhel 8.8 cdh 7.3.1, verified /etc/krb5.conf.d/crypto-policies contents:
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5456/console