### PR TITLE
CB-27275 Remove java 8 and 11 from arm64 images

### DIFF
--- a/saltstack/hortonworks/pillar/java/init.sls
+++ b/saltstack/hortonworks/pillar/java/init.sls
@@ -9,10 +9,12 @@ openjdk_packages:
   - java-11-openjdk-headless
   - java-11-openjdk-devel
 {% elif salt['environ.get']('OS') == 'redhat8' %}
+  {% if salt['environ.get']('ARCHITECTURE') != 'arm64' %}
   - java-1.8.0-openjdk-headless
   - java-1.8.0-openjdk-devel
   - java-11-openjdk-headless
   - java-11-openjdk-devel
+  {% endif %}
   - java-17-openjdk-headless
   - java-17-openjdk-devel
 {% else %}

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -34,6 +34,16 @@ install_openjdk:
   pkg.installed:
     - pkgs: {{ pillar['openjdk_packages'] }}
 
+{% if salt['environ.get']('ARCHITECTURE') == 'arm64' %}
+remove_unused_openjdk:
+  pkg.removed:
+    - pkgs:
+      - java-1.8.0-openjdk-headless
+      - java-1.8.0-openjdk-devel
+      - java-11-openjdk-headless
+      - java-11-openjdk-devel
+{% endif %}
+
 {% if salt['environ.get']('OS') == 'redhat8' %}
 {% if salt['environ.get']('IMAGE_BURNING_TYPE') == 'base' or salt['environ.get']('STACK_VERSION').split('.') | map('int') | list >= '7.2.18'.split('.') | map('int') | list %}
 download_rhel8_repo:


### PR DESCRIPTION
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5551/

```
"package_versions": {
  ...
  "java": "17",
  "java17": "17.0.12",
  "java21": "21.0.4",
  ...
},
```