### PR TITLE
CB-26973: Fix changelog generation in case of redhat8/x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,17 +317,6 @@ build-aws-centos7:
 	GIT_TAG=$(GIT_TAG) \
 	./scripts/sparseimage/packer.sh build -color=false -force $(PACKER_OPTS)
 
-generate-aws-centos7-changelog:
-ifdef IMAGE_UUID
-ifdef SOURCE_IMAGE
-	$(ENVS) \
-	OS=centos \
-	IMAGE_UUID=$(IMAGE_UUID) \
-	SOURCE_IMAGE=$(SOURCE_IMAGE) \
-	./scripts/changelog/packer.sh build -color=false -only=aws-centos7 -force $(PACKER_OPTS)
-endif
-endif
-
 build-aws-redhat8:
 	$(ENVS) \
 	AWS_AMI_REGIONS="us-west-1" \
@@ -342,17 +331,6 @@ build-aws-redhat8:
 	GIT_BRANCH=$(GIT_BRANCH) \
 	GIT_TAG=$(GIT_TAG) \
 	./scripts/packer.sh build -color=false -only=aws-redhat8 $(PACKER_OPTS)
-
-generate-aws-redhat8-changelog:
-ifdef IMAGE_UUID
-ifdef SOURCE_IMAGE
-	$(ENVS) \
-	OS=redhat8 \
-	IMAGE_UUID=$(IMAGE_UUID) \
-	SOURCE_IMAGE=$(SOURCE_IMAGE) \
-	./scripts/changelog/packer.sh build -color=false -only=aws-redhat8 -force $(PACKER_OPTS)
-endif
-endif
 
 build-azure-redhat8:
 	$(ENVS) \
@@ -454,28 +432,6 @@ build-aws-gov-redhat8:
 	PACKER_VERSION="1.8.3" \
 	./scripts/packer.sh build -color=false -only=aws-gov-redhat8 $(PACKER_OPTS)
 
-generate-aws-gov-centos7-changelog:
-ifdef IMAGE_UUID
-ifdef SOURCE_IMAGE
-	$(ENVS) \
-	OS=centos \
-	IMAGE_UUID=$(IMAGE_UUID) \
-	SOURCE_IMAGE=$(SOURCE_IMAGE) \
-	./scripts/changelog/packer.sh build -color=false -only=aws-gov-centos7 -force $(PACKER_OPTS)
-endif
-endif
-
-generate-aws-gov-redhat8-changelog:
-ifdef IMAGE_UUID
-ifdef SOURCE_IMAGE
-	$(ENVS) \
-	OS=redhat8 \
-	IMAGE_UUID=$(IMAGE_UUID) \
-	SOURCE_IMAGE=$(SOURCE_IMAGE) \
-	./scripts/changelog/packer.sh build -color=false -only=aws-gov-redhat8 -force $(PACKER_OPTS)
-endif
-endif
-
 copy-aws-gov-images:
 	docker run -i --rm \
 		-v "${PWD}/scripts:/scripts" \
@@ -513,28 +469,6 @@ build-gc-centos7:
 	GIT_BRANCH=$(GIT_BRANCH) \
 	GIT_TAG=$(GIT_TAG) \
 	./scripts/packer.sh build -color=false -only=gc-centos7 $(PACKER_OPTS)
-
-generate-gc-centos7-changelog:
-ifdef IMAGE_UUID
-ifdef SOURCE_IMAGE
-	$(ENVS) \
-	OS=centos \
-	IMAGE_UUID=$(IMAGE_UUID) \
-	SOURCE_IMAGE=$(SOURCE_IMAGE) \
-	./scripts/changelog/packer.sh build -color=false -only=gc-centos7 -force $(PACKER_OPTS)
-endif
-endif
-
-generate-gc-redhat8-changelog:
-ifdef IMAGE_UUID
-ifdef SOURCE_IMAGE
-	$(ENVS) \
-	OS=redhat8 \
-	IMAGE_UUID=$(IMAGE_UUID) \
-	SOURCE_IMAGE=$(SOURCE_IMAGE) \
-	./scripts/changelog/packer.sh build -color=false -only=gc-redhat8 -force $(PACKER_OPTS)
-endif
-endif
 
 build-azure-centos7:
 	$(ENVS) \
@@ -578,6 +512,28 @@ ifeq ($(AZURE_INITIAL_COPY),true)
 	TRACE=1 AZURE_STORAGE_ACCOUNTS=$(AZURE_BUILD_STORAGE_ACCOUNT) ./scripts/azure-copy.sh
 endif
 
+generate-aws-centos7-changelog:
+ifdef IMAGE_UUID
+ifdef SOURCE_IMAGE
+	$(ENVS) \
+	OS=centos \
+	IMAGE_UUID=$(IMAGE_UUID) \
+	SOURCE_IMAGE=$(SOURCE_IMAGE) \
+	./scripts/changelog/packer.sh build -color=false -only=aws-centos7 -force $(PACKER_OPTS)
+endif
+endif
+
+generate-aws-redhat8-changelog:
+ifdef IMAGE_UUID
+ifdef SOURCE_IMAGE
+	$(ENVS) \
+	OS=redhat8 \
+	IMAGE_UUID=$(IMAGE_UUID) \
+	SOURCE_IMAGE=$(SOURCE_IMAGE) \
+	./scripts/changelog/packer.sh build -color=false -only=aws-redhat8 -force $(PACKER_OPTS)
+endif
+endif
+
 generate-azure-centos7-changelog:
 ifdef IMAGE_UUID
 ifdef SOURCE_IMAGE
@@ -598,7 +554,35 @@ ifdef SOURCE_IMAGE
 	IMAGE_UUID=$(IMAGE_UUID) \
 	SOURCE_IMAGE=$(SOURCE_IMAGE) \
 	BUILD_RESOURCE_GROUP_NAME=$(BUILD_RESOURCE_GROUP_NAME) \
-	./scripts/changelog/packer.sh build -color=false -only=arm-centos7 -force $(PACKER_OPTS)
+	./scripts/changelog/packer.sh build -color=false -only=arm-redhat8 -force $(PACKER_OPTS)
+endif
+endif
+
+generate-gc-centos7-changelog:
+ifdef IMAGE_UUID
+ifdef SOURCE_IMAGE
+	$(ENVS) \
+	OS=centos \
+	IMAGE_UUID=$(IMAGE_UUID) \
+	SOURCE_IMAGE=$(SOURCE_IMAGE) \
+	GCP_STORAGE_BUNDLE=$(GCP_STORAGE_BUNDLE) \
+	GCP_STORAGE_BUNDLE_LOG=$(GCP_STORAGE_BUNDLE_LOG) \
+	STACK_VERSION=$(STACK_VERSION) \
+	./scripts/changelog/packer.sh build -color=false -only=gc-centos7 -force $(PACKER_OPTS)
+endif
+endif
+
+generate-gc-redhat8-changelog:
+ifdef IMAGE_UUID
+ifdef SOURCE_IMAGE
+	$(ENVS) \
+	OS=redhat8 \
+	IMAGE_UUID=$(IMAGE_UUID) \
+	SOURCE_IMAGE=$(SOURCE_IMAGE) \
+	GCP_STORAGE_BUNDLE=$(GCP_STORAGE_BUNDLE) \
+	GCP_STORAGE_BUNDLE_LOG=$(GCP_STORAGE_BUNDLE_LOG) \
+	STACK_VERSION=$(STACK_VERSION) \
+	./scripts/changelog/packer.sh build -color=false -only=gc-redhat8 -force $(PACKER_OPTS)
 endif
 endif
 

--- a/scripts/bundle-gcp-image.sh
+++ b/scripts/bundle-gcp-image.sh
@@ -46,8 +46,8 @@ main() {
 	docker run --rm --name gcloud-create-instance-$IMAGE_NAME --volumes-from gcloud-config-$IMAGE_NAME google/cloud-sdk gcloud compute images export --quiet --destination-uri gs://${GCP_STORAGE_BUNDLE}/${IMAGE_PRE_NAME}${IMAGE_NAME}.tar.gz --image ${IMAGE_NAME} --project ${GCP_PROJECT}
 	docker run --rm --name gcloud-create-instance-public-$IMAGE_NAME --volumes-from gcloud-config-$IMAGE_NAME google/cloud-sdk gsutil -m acl ch -r -u AllUsers:R gs://${GCP_STORAGE_BUNDLE}/${IMAGE_PRE_NAME}${IMAGE_NAME}.tar.gz
 
-  echo "Removing compute image"
-  docker run --rm --name gcloud-remove-compute-image-$IMAGE_NAME --volumes-from gcloud-config-$IMAGE_NAME google/cloud-sdk gcloud compute images delete --quiet $IMAGE_NAME
+    echo "Removing compute image"
+    docker run --rm --name gcloud-remove-compute-image-$IMAGE_NAME --volumes-from gcloud-config-$IMAGE_NAME google/cloud-sdk gcloud compute images delete --quiet $IMAGE_NAME
 
 	exit 0
 }

--- a/scripts/changelog/packer.json
+++ b/scripts/changelog/packer.json
@@ -98,84 +98,6 @@
       "skip_create_ami": true
     },
     {
-      "name": "aws-gov-centos7",
-      "type": "amazon-ebs",
-      "region": "us-gov-west-1",
-      "ssh_pty": true,
-      "source_ami": "{{ user `source_image` }}",
-      "instance_type": "{{ user `aws_instance_type` }}",
-      "ssh_username": "cloudbreak",
-      "ena_support": true,
-      "skip_region_validation": true,
-      "tags": {
-        "builder": "packer",
-        "cb-creation-timestamp": "{{timestamp}}",
-        "owner": "{{ user `image_owner` }}"
-      },
-      "run_tags": {
-        "owner": "{{ user `image_owner` }}"
-      },
-      "ami_block_device_mappings": [
-        {
-          "device_name": "/dev/sda1",
-          "volume_type": "gp2",
-          "delete_on_termination": true,
-          "volume_size": "{{user `image_size`}}"
-        }
-      ],
-      "launch_block_device_mappings": [
-        {
-          "device_name": "/dev/sda1",
-          "volume_type": "gp2",
-          "delete_on_termination": true,
-          "volume_size": "{{user `image_size`}}"
-        }
-      ],
-      "ami_name": "{{ user `image_name`}}",
-      "subnet_id": "{{ user `subnet_id`}}",
-      "vpc_id": "{{ user `vpc_id`}}",
-      "skip_create_ami": true
-    },
-    {
-      "name": "aws-gov-redhat8",
-      "type": "amazon-ebs",
-      "region": "us-gov-west-1",
-      "ssh_pty": true,
-      "source_ami": "{{ user `source_image` }}",
-      "instance_type": "{{ user `aws_instance_type` }}",
-      "ssh_username": "cloudbreak",
-      "ena_support": true,
-      "skip_region_validation": true,
-      "tags": {
-        "builder": "packer",
-        "cb-creation-timestamp": "{{timestamp}}",
-        "owner": "{{ user `image_owner` }}"
-      },
-      "run_tags": {
-        "owner": "{{ user `image_owner` }}"
-      },
-      "ami_block_device_mappings": [
-        {
-          "device_name": "/dev/sda1",
-          "volume_type": "gp2",
-          "delete_on_termination": true,
-          "volume_size": "{{user `image_size`}}"
-        }
-      ],
-      "launch_block_device_mappings": [
-        {
-          "device_name": "/dev/sda1",
-          "volume_type": "gp2",
-          "delete_on_termination": true,
-          "volume_size": "{{user `image_size`}}"
-        }
-      ],
-      "ami_name": "{{ user `image_name`}}",
-      "subnet_id": "{{ user `subnet_id`}}",
-      "vpc_id": "{{ user `vpc_id`}}",
-      "skip_create_ami": true
-    },
-    {
       "name": "arm-centos7",
       "type": "azure-arm",
       "client_id": "{{user `client_id`}}",
@@ -250,6 +172,7 @@
       "disable_default_service_account" : true,
       "account_file": "{{user `gcp_account_file`}}",
       "source_image": "{{ user `source_image` }}",
+      "source_image_project_id": "gcp-cdp-cb-images",
       "zone": "us-west2-a",
       "project_id": "gcp-cdp-cb-images",
       "network_project_id": "gcp-eng-network-enterprise",
@@ -280,7 +203,7 @@
       "disable_default_service_account" : true,
       "account_file": "{{user `gcp_account_file`}}",
       "source_image": "{{user `source_image`}}",
-      "source_image_project_id": "rhel-byos-cloud",
+      "source_image_project_id": "gcp-cdp-cb-images",
       "zone": "us-west2-a",
       "project_id": "gcp-cdp-cb-images",
       "network_project_id": "gcp-eng-network-enterprise",
@@ -299,7 +222,6 @@
         "builder--packer",
         "cb-creation-timestamp--{{timestamp}}",
         "owner--{{ user `image_owner` | clean_resource_name }}",
-        "customer-delivered--{{user `tag_customer_delivered` | clean_resource_name}}",
         "gcp-dev-cloudbreak-ingress-internet-deny",
         "gcp-dev-cloudbreak-egress-internet-allow",
         "gcp-dev-cloudbreak-ingress-rfc1918-allow"

--- a/scripts/changelog/packer.sh
+++ b/scripts/changelog/packer.sh
@@ -1,5 +1,58 @@
 #!/bin/bash
 
+TMP_GCP_IMAGE_CREATED=false
+
+create_glcloud_compute_image() {
+  : ${GCP_STORAGE_BUNDLE?= required}
+  : ${GCP_STORAGE_BUNDLE_LOG?= required}
+  : ${GCP_ACCOUNT_FILE?= required}
+
+  if ! [[ -f $GCP_ACCOUNT_FILE ]]; then
+    echo "Account file is missing: $GCP_ACCOUNT_FILE"
+    exit 2
+  fi
+
+  : ${START_TIME:=$(date +%s)}
+  export START_TIME
+  export PS4='+ [TRACE $BASH_SOURCE:$LINENO][ellapsed: $(( $(date +%s) -  $START_TIME ))] '
+
+  : ${GCP_PROJECT:=$(cat $GCP_ACCOUNT_FILE | jq .project_id -r)}
+  : ${SERVICE_ACCOUNT_EMAIL:=$(cat $GCP_ACCOUNT_FILE | jq .client_email -r)}
+  : ${IMAGE_PRE_NAME:=}
+
+  STACK_VERSION_SHORT=${STACK_TYPE}-$(echo ${STACK_VERSION} | tr -d . | cut -c1-4 )
+  export TMP_GCP_IMAGE_NAME=${BASE_NAME}-$(echo ${STACK_VERSION_SHORT} | tr '[:upper:]' '[:lower:]')-$(date +%s)
+
+  docker rm -f gcloud-config-$TMP_GCP_IMAGE_NAME || true
+
+  echo "Checking Google Cloud SDK version ..."
+  docker run google/cloud-sdk:latest gcloud version
+  docker run --name gcloud-config-$TMP_GCP_IMAGE_NAME -v "${GCP_ACCOUNT_FILE}":/gcp.p12 google/cloud-sdk gcloud auth activate-service-account $SERVICE_ACCOUNT_EMAIL --key-file /gcp.p12 --project $GCP_PROJECT
+
+  echo "Checking source tar.gz ${SOURCE_IMAGE} in project $GCP_PROJECT under gs://${GCP_STORAGE_BUNDLE} ..."
+  if docker run --rm --name gcloud-pre-check-$TMP_GCP_IMAGE_NAME --volumes-from gcloud-config-$TMP_GCP_IMAGE_NAME google/cloud-sdk gsutil ls gs://${GCP_STORAGE_BUNDLE}/${IMAGE_PRE_NAME}${SOURCE_IMAGE}.tar.gz 2>/dev/null; then
+    echo ${SOURCE_IMAGE}.tar.gz found.
+    docker rm -f gcloud-create-instance-$TMP_GCP_IMAGE_NAME || true
+    echo "Creating GCP compute image $TMP_GCP_IMAGE_NAME from $SOURCE_IMAGE.tar.gz ..."
+    docker run --rm --name gcloud-create-instance-$TMP_GCP_IMAGE_NAME --volumes-from gcloud-config-$TMP_GCP_IMAGE_NAME google/cloud-sdk gcloud compute images create --quiet ${TMP_GCP_IMAGE_NAME} --source-uri gs://${GCP_STORAGE_BUNDLE}/${IMAGE_PRE_NAME}${SOURCE_IMAGE}.tar.gz --guest-os-features "UEFI_COMPATIBLE,MULTI_IP_SUBNET"
+    TMP_GCP_IMAGE_CREATED=true
+  else
+    echo ${SOURCE_IMAGE}.tar.gz cannot be found.
+    exit 1
+  fi
+
+  echo "Changing source image refernce to temporarily created image $TMP_GCP_IMAGE_NAME ..."
+  SOURCE_IMAGE=$TMP_GCP_IMAGE_NAME
+}
+
+remove_glcoud_compute_image() {
+  if [ "$TMP_GCP_IMAGE_CREATED" = true ]; then
+    echo "Removing compute image $TMP_GCP_IMAGE_NAME ..."
+    docker run --rm --name gcloud-remove-compute-image-$TMP_GCP_IMAGE_NAME --volumes-from gcloud-config-$TMP_GCP_IMAGE_NAME google/cloud-sdk gcloud compute images delete --quiet $TMP_GCP_IMAGE_NAME
+  fi
+  docker rm gcloud-config-$TMP_GCP_IMAGE_NAME
+}
+
 packer_in_container() {
   local dockerOpts=""
   local packerFile="./scripts/changelog/packer.json"
@@ -46,6 +99,12 @@ packer_in_container() {
 
 main() {
   echo $IMAGE_NAME
+
+  if [[ $CLOUD_PROVIDER == "GCP" ]]; then
+    trap remove_glcoud_compute_image EXIT
+    create_glcloud_compute_image
+  fi
+
   packer_in_container "$@"
 }
 


### PR DESCRIPTION
Fix the changelog generation in case of GCP provider, there was a previous improvement where a tar.gz has been stored instead of the concrete image due to cost reduction, so at first we need to create the compute image from tar.gz before changelog generation.