### PR TITLE
CB-27290 Remove JDK 11 from x86 based 7.3.1 images

### DIFF
--- a/saltstack/hortonworks/pillar/java/init.sls
+++ b/saltstack/hortonworks/pillar/java/init.sls
@@ -12,8 +12,10 @@ openjdk_packages:
   {% if salt['environ.get']('ARCHITECTURE') != 'arm64' %}
   - java-1.8.0-openjdk-headless
   - java-1.8.0-openjdk-devel
+    {% if salt['environ.get']('STACK_VERSION').split('.') | map('int') | list < '7.3.1'.split('.') | map('int') | list %}
   - java-11-openjdk-headless
   - java-11-openjdk-devel
+    {% endif %}
   {% endif %}
   - java-17-openjdk-headless
   - java-17-openjdk-devel
@@ -27,4 +29,3 @@ openjdk_packages:
   - java-11-openjdk-javadoc
   - java-11-openjdk-src
 {% endif %}
-


### PR DESCRIPTION
7.2.18: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5564/
7.3.1: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5565/