### PR TITLE
CB-27690: Increased image size for x86-64 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ ifndef IMAGE_NAME
 @echo IMAGE_NAME was not defined as an environment variable. Generated value: $(IMAGE_NAME)
 endif
 
-IMAGE_SIZE=$(shell ./scripts/get-image-size.sh $(CLOUD_PROVIDER) $(OS) $(STACK_VERSION))
+IMAGE_SIZE=$(shell ./scripts/get-image-size.sh $(CLOUD_PROVIDER) $(OS) $(STACK_VERSION) $(ARCHITECTURE))
 
 ifeq ($(MAKE_PUBLIC_SNAPSHOTS),yes)
 	AWS_SNAPSHOT_GROUPS = "all"

--- a/scripts/get-image-size.sh
+++ b/scripts/get-image-size.sh
@@ -5,6 +5,7 @@ source scripts/utils.sh
 CLOUD_PROVIDER=$1
 OS=$2
 STACK_VERSION=$3
+ARCHITECTURE=$4
 
 if [ "$OS" == "centos7" ]; then
   if [ "$CLOUD_PROVIDER" == "GCP" ]; then
@@ -16,7 +17,11 @@ else
   compare_version $STACK_VERSION 7.2.18
   COMP_RESULT=$?
   if [[ "$CLOUD_PROVIDER" == "Azure" ]]; then
-    IMAGE_SIZE=64
+    if [[ "$ARCHITECTURE" == "arm64" ]]; then
+      IMAGE_SIZE=64
+    else
+      IMAGE_SIZE=70
+    fi
   elif [[ $COMP_RESULT -lt 2 ]]; then
     # stack version >= 7.2.18
     IMAGE_SIZE=52


### PR DESCRIPTION
Test build: https://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5817/
Validation: not needed, the lack of free space blocked image burning and now with this branch it's now unblocked.