### PR TITLE
CB-26379 Add ipa-server version to freeipa images' package-versions

### DIFF
--- a/saltstack/final/salt/metadata/tmp/generate-package-versions.sh
+++ b/saltstack/final/salt/metadata/tmp/generate-package-versions.sh
@@ -76,6 +76,8 @@ do
 done
 
 if [[ "$CUSTOM_IMAGE_TYPE" == "freeipa" ]]; then
+  set_version_for_rpm_pkg "ipa-server"
+
 	FREEIPA_REGEX=".*\/[_a-z\-]*\-(.*)\.x86_64\.rpm"
 	if [[ $FREEIPA_PLUGIN_RPM_URL =~ $FREEIPA_REGEX ]]; then
 		cat /tmp/package-versions.json | jq --arg freeipa_plugin_version ${BASH_REMATCH[1]} '. + {"freeipa-plugin": $freeipa_plugin_version}' > /tmp/package-versions.json.tmp && mv /tmp/package-versions.json.tmp /tmp/package-versions.json


### PR DESCRIPTION
```
        "uuid": "80a5dbe8-fc44-4b90-b696-da22c47f0af4",
        "package-versions": {
          "blackbox-exporter": "0.19.0",
          "cdp-logging-agent": "1.3.5_b1",
          "cdp-prometheus": "2.36.2",
          "cdp-request-signer": "1.3.5_b1",
          "cdp-telemetry": "1.3.5_b1",
          "cloudbreak_images": "79b665f130ee66dfe82ac80a83d2ea96ba2eea4f",
          "freeipa-health-agent": "0.1-20240306130845git17cc467",
          "freeipa-ldap-agent": "1.0.0-b12478",
          "freeipa-plugin": "1.1-b847.el8",
          "imds": "v2",
          "inverting-proxy-agent": "3.8.0-b23",
          "inverting-proxy-agent_gbn": "59355298",
          "ipa-server": "4.9.13",
          "node-exporter": "1.3.1",
          "os-version": "8.10",
          "python311": "3.11.9-7.el8_10",
          "python36": "3.6.8-39.module+el8.10.0+20784+edafcd43",
          "python38": "3.8.17-2.module+el8.9.0+19642+a12b4af6",
          "python39": "3.9.19-7.module+el8.10.0+22237+51382d7a",
          "salt": "3001.8",
          "salt-bootstrap": "0.13.9-2024-07-09T12:24:25",
          "source-image": "ami-02073841a355a1e92"
        },
```