### PR TITLE
CB-27728: Burn 7.2.18 images with RHEL 8.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER
 			AZURE_IMAGE_OFFER ?= rhel-byos
 			ifeq ($(STACK_VERSION),7.3.1)
 				AZURE_IMAGE_SKU ?= rhel-lvm810
+			else ifeq ($(STACK_VERSION),7.2.18)
+				AZURE_IMAGE_SKU ?= rhel-lvm810
 			else ifeq ($(IMAGE_BURNING_TYPE),base)
 				AZURE_IMAGE_SKU ?= rhel-lvm810
 			else ifeq ($(CUSTOM_IMAGE_TYPE),freeipa)
@@ -83,6 +85,8 @@ ifeq ($(CLOUD_PROVIDER),AWS)
 		else
 			ifeq ($(STACK_VERSION),7.3.1)
 				AWS_SOURCE_AMI ?= ami-02073841a355a1e92
+			else ifeq ($(STACK_VERSION),7.2.18)
+				AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 			else ifeq ($(IMAGE_BURNING_TYPE),base)
 				AWS_SOURCE_AMI ?= ami-02073841a355a1e92
 			else ifeq ($(CUSTOM_IMAGE_TYPE),freeipa)
@@ -113,6 +117,8 @@ ifeq ($(CLOUD_PROVIDER),GCP)
 	endif
 	ifeq ($(OS),redhat8)
 		ifeq ($(STACK_VERSION),7.3.1)
+			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
+		else ifeq ($(STACK_VERSION),7.2.18)
 			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709
 		else ifeq ($(IMAGE_BURNING_TYPE),base)
 			GCP_SOURCE_IMAGE ?= rhel-8-byos-v20240709


### PR DESCRIPTION
Image burning tests:
 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5972/
 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5978/
 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/5979/
Validations:
 - http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/1855/
 - http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/1859/
 - http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/1863/