### PR TITLE
CB-27820 Loopback filesystem mounted with noexec as /tmp

### DIFF
--- a/saltstack/final/salt/cis-controls/common.sls
+++ b/saltstack/final/salt/cis-controls/common.sls
@@ -199,3 +199,43 @@ remove_unnecessary_whitespaces_from_yum_repo_files:
   cmd.run:
     - name: find /etc/yum.repos.d -type f -exec sed -i 's/ = /=/g' {} \;
     - onlyif: ls -la /etc/yum.repos.d/
+
+{% if not salt['file.contains']('/etc/fstab', '/tmp') %}
+create_tmpfs:
+  cmd.run:
+    - name: dd if=/dev/zero of=/var/tmpfs bs=1M count=12288 # 12GB file, same as Azure LVM
+
+{% if cloud_provider == 'GCP' %}
+build_tmpfs_filesystem:
+  cmd.run:
+    - name: yes | mkfs.ext4 /var/tmpfs
+
+keep_tmp_contents:
+  cmd.run:
+    - name: |
+        mkdir /media/tmpfs
+        mount /var/tmpfs /media/tmpfs
+        mv /tmp/* /media/tmpfs
+        umount /media/tmpfs
+        rm -rf /media/tmpfs
+
+set_startup_script_location:
+  file.replace:
+    - name: /etc/default/instance_configs.cfg
+    - pattern: '^run_dir ='
+    - repl: 'run_dir = /root'
+{% else %}
+build_tmpfs_filesystem_from_tmp:
+  cmd.run:
+    - name: mkfs.ext4 /var/tmpfs -d /tmp
+{% endif %}
+
+tmpfs_mount_fstab:
+  file.append:
+    - name: /etc/fstab
+    - text: "/var/tmpfs       /tmp       ext4   defaults,strictatime,nosuid,nodev,noexec        0   0"
+
+tmpfs_mount:
+  cmd.run:
+    - name: mount -a
+{% endif %}

--- a/saltstack/final/salt/cis-controls/redhat8.sls
+++ b/saltstack/final/salt/cis-controls/redhat8.sls
@@ -82,19 +82,15 @@ deny_nobody:
 
 add_cis_control_sh:
   file.managed:
-    - name: /tmp/cis_control.sh
+    - name: /opt/provision-scripts/cis_control.sh
     - makedirs: True
     - mode: 755
     - source: salt://cis-controls/scripts/cis_control.sh
 
 execute_cis_control_sh:
   cmd.run:
-    - name: /tmp/cis_control.sh
+    - name: /opt/provision-scripts/cis_control.sh
     - env:
       - IMAGE_BASE_NAME: {{ salt['environ.get']('IMAGE_BASE_NAME') }}
       - CLOUD_PROVIDER: {{ salt['environ.get']('CLOUD_PROVIDER') }}
       - STIG_ENABLED: {{ salt['environ.get']('STIG_ENABLED') }}
-
-remove_cis_control_sh:
-  file.absent:
-    - name: /tmp/cis_control.sh

--- a/saltstack/final/salt/cis-controls/scripts/cis_control.sh
+++ b/saltstack/final/salt/cis-controls/scripts/cis_control.sh
@@ -38,8 +38,6 @@ if [ "${CLOUD_PROVIDER}" == "Azure" ]; then
     if [ "${STIG_ENABLED}" != "True" ]; then
         SKIP_TAGS+=",kernel_module_udf_disabled"
     fi
-    # Temporarily disable tmp noexec as CM fails to start REGIONSERVER. Can be removed when CM side fix is done by OPSAPS-68448
-    SKIP_TAGS+=",mount_option_tmp_noexec"
 fi
 
 #Install and download what we need for the hardening


### PR DESCRIPTION
Create a loopback ext4 filesystem with the same size as the Azure logical volume for /tmp (12GB), back up current /tmp contents into it and mount it as /tmp with noexec option.

Azure freeipa: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/1865/
AWS arm64: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/1876/
GCP 7.2.16: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/1885/