### PR TITLE
CB-28061: Reenable HTTPS for saltboot and ensure cert files are present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,11 +161,15 @@ else
 	PYZMQ_VERSION ?= 19.0
 endif
 SALTBOOT_VERSION ?= "0.14.0"
-SALTBOOT_MINOR_VERSION = $(shell echo $(SALTBOOT_VERSION) | cut -d. -f2)
-ifeq ($(shell [[ $(SALTBOOT_MINOR_VERSION) -ge 14 ]] && echo true),true)
-	SALTBOOT_HTTPS_ENABLED ?= false
-else
-	SALTBOOT_HTTPS_ENABLED ?= false
+ifneq ($(CLOUD_PROVIDER),YARN)
+	ifneq ($(OS),centos7)
+		SALTBOOT_MINOR_VERSION = $(shell echo $(SALTBOOT_VERSION) | cut -d. -f2)
+		ifeq ($(shell [[ $(SALTBOOT_MINOR_VERSION) -ge 14 ]] && echo true),true)
+			SALTBOOT_HTTPS_ENABLED ?= true
+		else
+			SALTBOOT_HTTPS_ENABLED ?= false
+		endif
+	endif
 endif
 
 # This block remains here for backward compatibility reasons when the IMAGE_NAME is not defined as an env variable

--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -117,10 +117,20 @@ create_certificates_certm() {
   mv $CERT_ROOT_PATH/server.pem $CERT_ROOT_PATH/cluster.pem
   cp $CERT_ROOT_PATH/cluster.pem /tmp/cluster.pem
   mv $CERT_ROOT_PATH/server-key.pem $CERT_ROOT_PATH/cluster-key.pem
+{% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
+  certm -d $CERT_ROOT_PATH server generate -o=saltboot --cert $CERT_ROOT_PATH/saltboot.pem --key $CERT_ROOT_PATH/saltboot-key.pem --overwrite
+{% endif %}
   rm $CERT_ROOT_PATH/ca-key.pem
   cp $CERT_ROOT_PATH/cluster.pem /etc/jumpgate/cluster.pem
   chmod 600 /etc/jumpgate/cluster.pem
   chown jumpgate:jumpgate /etc/jumpgate/cluster.pem
+}
+
+create_cert_for_saltboot_tls() {
+  CERT_ROOT_PATH=/etc/certs
+  certm -d $CERT_ROOT_PATH ca generate -o=saltboot
+  certm -d $CERT_ROOT_PATH server generate -o=saltboot --cert $CERT_ROOT_PATH/saltboot.pem --key $CERT_ROOT_PATH/saltboot-key.pem --overwrite
+  rm $CERT_ROOT_PATH/ca-key.pem
 }
 
 start_nginx() {
@@ -277,6 +287,10 @@ main() {
         start_nginx
       fi
       create_saltapi_certificates
+{% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
+    else
+      create_cert_for_saltboot_tls
+{% endif %}
     fi
 
     INSTANCE_ID=

--- a/saltstack/base/salt/salt-bootstrap/etc/systemd/system/salt-bootstrap.service
+++ b/saltstack/base/salt/salt-bootstrap/etc/systemd/system/salt-bootstrap.service
@@ -21,4 +21,7 @@ Environment='SALTBOOT_PORT=7070'
 {% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
 Environment='SALTBOOT_HTTPS_PORT=7071'
 Environment='SALTBOOT_HTTPS_ENABLED=true'
+Environment='SALTBOOT_HTTPS_CERT_FILE=/etc/certs/saltboot.pem'
+Environment='SALTBOOT_HTTPS_KEY_FILE=/etc/certs/saltboot-key.pem'
+Environment='SALTBOOT_HTTPS_CACERT_FILE=/etc/certs/ca.pem'
 {% endif %}


### PR DESCRIPTION
Previously salt-bootstrap wouldn't work with HTTPS enabled, on non-gateway instances, since we do not generate the cert files which salt-bootstrap was relying on, on these instances.

Added logic for always generating the necessary certs (given that saltboot HTTPS is enabled):
- On gateway instances, we generate them using the same ca cert used to generate the certs for nginx and jumpgate
- On all other instances, we generate a ca cert and use that to generate the necessary certs

Note: The host values in the generated certs still don't matter, as there is still neither client- nor host-side verification. We only use TLS to have the channel be encrypted.