### PR TITLE
CB-28300 Generate LUKS volume key using `kms:GenerateRandom`

### DIFF
--- a/saltstack/base/salt/luks/bin/create-luks-volume.sh
+++ b/saltstack/base/salt/luks/bin/create-luks-volume.sh
@@ -10,6 +10,7 @@ export PASSPHRASE_TMPFS="/mnt/cdp-luks_passphrase_tmpfs"
 export PASSPHRASE_TMPFS_SIZE="16k"
 export PASSPHRASE_PLAINTEXT="$PASSPHRASE_TMPFS/passphrase"
 export PASSPHRASE_CIPHERTEXT="$LUKS_DIR/passphrase_ciphertext"
+export VOLUME_KEY_PLAINTEXT="$PASSPHRASE_TMPFS/volume_key"
 export LUKS_LOG_DIR="/var/log/$LUKS_VOLUME_NAME"
 export LUKS_BACKUP_DIR="$LUKS_DIR/backup"
 export LUKS_MAPPER_DEVICE="/dev/mapper/$LUKS_VOLUME_NAME"
@@ -20,12 +21,18 @@ export AWS_USE_FIPS_ENDPOINT=true
 export AWS_RETRY_MODE=standard
 export AWS_MAX_ATTEMPTS=15
 
+log() {
+  echo "$(date +"%F-%T") $*"
+}
+
 setup_backing_file() {
   if [[ -e "$LUKS_BACKING_FILE" && $(stat -c "%a" "$LUKS_BACKING_FILE" | tr -d '\n') == 600 ]]; then
     # Set the backing file to the specified size if it exists
+    log "Truncating existing LUKS backing file"
     truncate -s "$LUKS_BACKING_FILE_DEFAULT_SIZE" "$LUKS_BACKING_FILE"
   else
     # Create the backing file if it doesn't exist
+    log "Creating LUKS backing file"
     dd if=/dev/zero of="$LUKS_BACKING_FILE" bs="$LUKS_BACKING_FILE_DEFAULT_SIZE" count=1
     chmod 600 "$LUKS_BACKING_FILE"
   fi
@@ -33,17 +40,20 @@ setup_backing_file() {
 
 setup_tmpfs_for_plaintext_passphrase() {
   if ! mountpoint "$PASSPHRASE_TMPFS"; then
-    # Create the tmpfs for the plaintext passphrase
+    # Create the tmpfs for the plaintext passphrase and volume key
+    log "Creating tmpfs for the plaintext passphrase and volume key"
     mount -t tmpfs -o size="$PASSPHRASE_TMPFS_SIZE",mode=700 tmpfs "$PASSPHRASE_TMPFS"
   fi
 }
 
 generate_passphrase() {
   if [[ -e "$PASSPHRASE_PLAINTEXT" ]]; then
-    echo "Plaintext passphrase already exists... Exiting LUKS volume creation with failed exit code!"
+    log "Plaintext passphrase already exists... Exiting LUKS volume creation with failed exit code!"
     exit 1
   else
-    aws kms generate-random \
+    # Generate the plaintext passphrase
+    log "Generating plaintext passphrase"
+    aws --debug kms generate-random \
         --number-of-bytes 64 \
         --output text \
         --query Plaintext \
@@ -58,33 +68,56 @@ encrypt_passphrase_ciphertext() {
                                   curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)"
   METADATA_LOG_FILE="$LUKS_LOG_DIR/passphrase_encryption_md-$(date +"%F-%T").json"
   # Encrypt the plaintext passphrase and store the ciphertext
+  log "Encrypting plaintext passphrase"
   if ! /usr/local/bin/aws-encryption-cli \
+         -v -v -v -v \
          --encrypt \
          --input "$PASSPHRASE_PLAINTEXT" \
          --output "$PASSPHRASE_CIPHERTEXT" \
          --wrapping-keys provider=aws-kms key="$(cat "$ENCRYPTION_KEY_FILE")" \
          --metadata-output "$METADATA_LOG_FILE" \
          --encryption-context INSTANCE_ID="$INSTANCE_ID"; then
-    echo "Failed to encrypt plaintext passphrase... Exiting LUKS volume creation with failed exit code!"
+    log "Failed to encrypt plaintext passphrase... Exiting LUKS volume creation with failed exit code!"
     exit 2
   fi
   chmod 600 "$PASSPHRASE_CIPHERTEXT"
   chmod 600 "$METADATA_LOG_FILE"
 }
 
+generate_volume_key() {
+  if [[ -e "$VOLUME_KEY_PLAINTEXT" ]]; then
+    log "Plaintext volume key already exists... Exiting LUKS volume creation with failed exit code!"
+    exit 8
+  else
+    # Generate the plaintext volume key; must be of size 64 bytes / 512 bits when using the cipher aes-xts-plain64
+    log "Generating plaintext volume key"
+    aws --debug kms generate-random \
+        --number-of-bytes 64 \
+        --output text \
+        --query Plaintext \
+      | base64 --decode \
+      > "$VOLUME_KEY_PLAINTEXT"
+      chmod 600 "$VOLUME_KEY_PLAINTEXT"
+  fi
+}
+
 setup_loop_device() {
   # Create the loop device
+  log "Creating loop device for the LUKS backing file"
   LOOP_DEVICE=$(losetup --find --show "$LUKS_BACKING_FILE")
   if [[ $(losetup -j "$LUKS_BACKING_FILE" | cut -d ':' -f1 | tr -d '\n') != "$LOOP_DEVICE" ]]; then
-    echo "Failed to set up the loop device correctly... Exiting LUKS volume creation with failed exit code!"
+    log "Failed to set up the loop device correctly... Exiting LUKS volume creation with failed exit code!"
     exit 3
   fi
+  log "Allocated loop device: $LOOP_DEVICE"
 }
 
 create_luks_volume() {
   # Create the LUKS volume
+  log "Creating LUKS volume"
   if ! echo "YES" | cryptsetup luksFormat "$LOOP_DEVICE" \
                      --key-file "$PASSPHRASE_PLAINTEXT" \
+                     --master-key-file "$VOLUME_KEY_PLAINTEXT" \
                      --type luks2 \
                      --hash "sha3-512" \
                      --cipher "aes-xts-plain64" \
@@ -92,53 +125,65 @@ create_luks_volume() {
                      --iter-time 2000 \
                      --pbkdf "pbkdf2" \
                      --debug; then
-    echo "Failed to create the LUKS volume... Exiting LUKS volume creation with failed exit code!"
+    log "Failed to create the LUKS volume... Exiting LUKS volume creation with failed exit code!"
     exit 4
   fi
 }
 
+delete_volume_key() {
+  # Delete the plaintext volume key
+  log "Deleting plaintext volume key"
+  rm -f "$VOLUME_KEY_PLAINTEXT"
+}
+
 open_luks_volume() {
   # Open the LUKS volume
+  log "Opening LUKS volume"
   if ! cryptsetup open "$LOOP_DEVICE" "$LUKS_VOLUME_NAME" \
            --key-file "$PASSPHRASE_PLAINTEXT" \
            --type luks2 \
            --debug; then
-    echo "Failed to open the LUKS volume... Exiting LUKS volume creation with failed exit code!"
+    log "Failed to open the LUKS volume... Exiting LUKS volume creation with failed exit code!"
     exit 5
   fi
 }
 
 create_fs_on_luks_volume() {
   # Create the file system on the LUKS volume
+  log "Creating file system on the LUKS volume"
   if ! mkfs.xfs "$LUKS_MAPPER_DEVICE"; then
-    echo "Failed to create the file system on the LUKS volume... Exiting LUKS volume creation with failed exit code!"
+    log "Failed to create the file system on the LUKS volume... Exiting LUKS volume creation with failed exit code!"
     exit 6
   fi
 }
 
 backup_luks_header() {
-  # Create backup of LUKS volume header
+  # Create backup of the LUKS volume header
+  log "Backing up LUKS volume header"
   if ! cryptsetup luksHeaderBackup "$LOOP_DEVICE" \
                     --header-backup-file "$LUKS_BACKUP_DIR/luks_header_backup-$(date +"%F-%T")" \
                     --debug; then
-    echo "Failed to create backup of the header of the LUKS volume... Without backup, if the header gets corrupted, the entire volume will become undecryptable!"
+    log "Failed to create backup of the header of the LUKS volume... Without backup, if the header gets corrupted, the entire volume will become undecryptable!"
   fi
 }
 
 mount_luks_volume() {
   if ! mountpoint -q "$MOUNT_POINT"; then
     # Mount the LUKS volume
+    log "Mounting LUKS volume"
     mount "$LUKS_MAPPER_DEVICE" "$MOUNT_POINT"
     chmod 755 "$MOUNT_POINT"
   else
-    echo "Failed to mount the LUKS volume, as the path is already a mount point... Exiting LUKS volume creation with failed exit code!"
+    log "Failed to mount the LUKS volume, as the path is already a mount point... Exiting LUKS volume creation with failed exit code!"
     exit 7
   fi
 }
 
 main() {
+  log "$(basename $0) Start"
+
   if mountpoint "$MOUNT_POINT"; then
-    echo "Volume already mounted at mount point... Exiting LUKS volume creation!"
+    log "Volume already mounted at mount point... Exiting LUKS volume creation!"
     exit
   fi
 
@@ -146,8 +191,10 @@ main() {
   setup_tmpfs_for_plaintext_passphrase
   generate_passphrase
   encrypt_passphrase_ciphertext
+  generate_volume_key
   setup_loop_device
   create_luks_volume
+  delete_volume_key
   open_luks_volume
   create_fs_on_luks_volume
   backup_luks_header
@@ -156,6 +203,8 @@ main() {
   # If everything went fine up to this point, we can enable the reopen service,
   # the guards in the unit file will stop it from actually executing the reopen script
   systemctl enable cdp-reopen-luks-volume.service
+
+  log "$(basename $0) Finish"
 }
 
 main

--- a/saltstack/base/salt/userdata-secrets/bin/cdp-retrieve-userdata-secrets.sh
+++ b/saltstack/base/salt/userdata-secrets/bin/cdp-retrieve-userdata-secrets.sh
@@ -4,6 +4,10 @@ set -e +x
 
 # DO NOT EXPORT environment variables in this file, because this file is called with `source` in `user-data-helper.sh`!
 
+log() {
+  echo "$(date +"%F-%T") $*"
+}
+
 # This function implements basically the same exponential backoff strategy as the aws cli in standard retry mode
 retry_until_non_placeholder_value() {
   local BASE_FACTOR=2
@@ -22,17 +26,17 @@ retry_until_non_placeholder_value() {
   set -e
   while [[ "$SECRET_STRING" == "PLACEHOLDER" || "$exit_code" == "$ACCESS_DENIED_EXIT_CODE" ]]; do
     if (( attempt > MAX_ATTEMPT )); then
-      echo "Maximum number of retry attempts reached while waiting for userdata secret to update! Total wait time was $total_wait_time seconds. Exiting..."
+      log "Maximum number of retry attempts reached while waiting for userdata secret to update! Total wait time was $total_wait_time seconds. Exiting..."
       exit 1
     fi
     if [[ "$exit_code" == "$ACCESS_DENIED_EXIT_CODE" ]]; then
       non_transient_aws_service_error_count=$(( non_transient_aws_service_error_count + 1 ))
-      echo "Getting the userdata secret failed with a non-transient error. See the error returned by aws-cli above! "
+      log "Getting the userdata secret failed with a non-transient error. See the error returned by aws-cli above! "
     else
-      echo "Userdata secret still has PLACEHOLDER value."
+      log "Userdata secret still has PLACEHOLDER value."
     fi
 
-    echo "Waiting $timeout seconds until the next attempt to retrieve the secret."
+    log "Waiting $timeout seconds until the next attempt to retrieve the secret."
     sleep $timeout
 
     total_wait_time=$(( total_wait_time + timeout ))
@@ -44,8 +48,8 @@ retry_until_non_placeholder_value() {
     exit_code=$?
     set -e
   done
-  echo "Total number of non-transient AWS errors: $non_transient_aws_service_error_count."
-  echo "Userdata secret's value was retrieved after waiting $total_wait_time seconds."
+  log "Total number of non-transient AWS errors: $non_transient_aws_service_error_count."
+  log "Userdata secret's value was retrieved after waiting $total_wait_time seconds."
 }
 
 # Helper function for passing aws-cli params related to the built-in retry mechanism, and param to instruct aws-cli to use FIPS endpoints
@@ -62,32 +66,36 @@ aws_with_cli_params() {
 # Intermittent issues like throttling of AWS APIs are handled by the built in retry mechanism of the aws cli.
 # Waiting for CB to update the secret's value to the actual secrets is handled by the `retry_until_non_placeholder_value` function.
 main() {
+  log "$(basename $0) Start"
+
   if [[ -z "$USERDATA_SECRET_ID" ]]; then
-    echo "USERDATA_SECRET_ID is empty. Cannot retrieve userdata secrets!"
+    log "USERDATA_SECRET_ID is empty. Cannot retrieve userdata secrets!"
     exit 1
   fi
 
   if [[ "$CLOUD_PLATFORM" == "AWS" ]]; then
-    echo "Retrieving userdata secrets..."
+    log "Retrieving userdata secrets..."
     retry_until_non_placeholder_value \
     aws_with_cli_params \
-    aws secretsmanager get-secret-value \
+    aws --debug secretsmanager get-secret-value \
       --output text \
       --query SecretString \
       --secret-id "$USERDATA_SECRET_ID"
     eval "$SECRET_STRING"
-    echo "Successfully retrieved userdata secrets!"
+    log "Successfully retrieved userdata secrets!"
 
-    echo "Deleting secret associated with this instance..."
+    log "Deleting secret associated with this instance..."
     aws_with_cli_params \
-    aws secretsmanager delete-secret \
+    aws --debug secretsmanager delete-secret \
       --force-delete-without-recovery \
       --secret-id "$USERDATA_SECRET_ID"
-    echo "Successfully deleted secret associated with this instance!"
+    log "Successfully deleted secret associated with this instance!"
   else
-    echo "Userdata secret retrieval not implemented for CLOUD_PLATFORM $CLOUD_PLATFORM."
+    log "Userdata secret retrieval not implemented for CLOUD_PLATFORM $CLOUD_PLATFORM."
     exit 2
   fi
+
+  log "$(basename $0) Finish"
 }
 
 main


### PR DESCRIPTION
* `create-luks-volume.sh`:
  * Pass a manually obtained LUKS volume key to `cryptsetup luksFormat`.
  * The volume key is generated using `kms:GenerateRandom` with size 64 bytes / 512 bits.
  * The plaintext volume key file is kept on the same `tmpfs` volume already used for the plaintext passphrase.
  * Since the volume key in plaintext form is only needed at the time of `cryptsetup luksFormat` invocation, the volume key file gets immediately removed after the successful completion of this command.
* `cdp-retrieve-userdata-secrets.sh`, `create-luks-volume.sh`, `populate-luks-volume.sh`, `reopen-luks-volume.sh`:
  * Prefix log messages with a timestamp header.
  * Add some additional log messages for easier troubleshooting.
  * Enable debug logging for AWS CLI and AWS Encryption CLI invocations.