### PR TITLE
CB-28369: Bump saltboot version to `0.14.2` which includes fallback to HTTP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,12 +166,14 @@ ifeq ($(SALT_NEWER_PYZMQ),1)
 else
 	PYZMQ_VERSION ?= 19.0
 endif
-SALTBOOT_VERSION ?= "0.14.0"
+SALTBOOT_VERSION ?= "0.14.2"
 ifneq ($(CLOUD_PROVIDER),YARN)
 	ifneq ($(OS),centos7)
 		SALTBOOT_MINOR_VERSION = $(shell echo $(SALTBOOT_VERSION) | cut -d. -f2)
-		ifeq ($(shell [[ $(SALTBOOT_MINOR_VERSION) -ge 14 ]] && echo true),true)
-			SALTBOOT_HTTPS_ENABLED ?= false
+		SALTBOOT_PATCH_VERSION = $(shell echo $(SALTBOOT_VERSION) | cut -d. -f3)
+		# Version 0.14.1 introduced saltboot HTTPS including fallback to HTTP
+		ifeq ($(shell [[ ($(SALTBOOT_MINOR_VERSION) -eq 14 && $(SALTBOOT_PATCH_VERSION) -ge 2) || $(SALTBOOT_MINOR_VERSION) -ge 15 ]] && echo true),true)
+			SALTBOOT_HTTPS_ENABLED ?= true
 		else
 			SALTBOOT_HTTPS_ENABLED ?= false
 		endif


### PR DESCRIPTION
Enable the saltboot HTTPS feature if the saltboot version has:
- minor version = 14 AND patch version >= 2
OR
- minor version >= 15

salt-bootstrap version `0.14.2` includes:
- fallback to HTTP on port 7070 if the target is not listening for HTTPS on port 7071
- using the same timeout settings on both the HTTP and HTTPS client