### PR TITLE
CB-28480: Remove default region from check-image-regions function in case of centos

### DIFF
--- a/scripts/check-image-regions.sh
+++ b/scripts/check-image-regions.sh
@@ -50,9 +50,6 @@ case "$CLOUD_PROVIDER" in
     case "$OS" in
       centos7)
         ALL_REGIONS=$AZURE_STORAGE_ACCOUNTS
-        if [[ ! $ALL_REGIONS == *"default"* ]]; then
-          ALL_REGIONS+=",default"
-        fi
         ;;
       redhat8)
         ALL_REGIONS="default"


### PR DESCRIPTION
We need to remove the default region requirement during checking function in case of centos7, because now we cannot publish centos7 image to MP due to EOL.