### PR TITLE
Updated jumpgate agent to 3.9.0 in freeIPA image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ INCLUDE_METERING ?= "Yes"
 USE_TELEMETRY_ARCHIVE ?= "Yes"
 
 # This one is OS-independent (right?)
-DEFAULT_JUMPGATE_AGENT_RPM_URL := https://archive.cloudera.com/ccm/3.8.0/jumpgate-agent.rpm
+DEFAULT_JUMPGATE_AGENT_RPM_URL := https://archive.cloudera.com/ccm/3.9.0/jumpgate-agent.rpm
 
 # This one is OS-independent (v2.0 is a rewrite done in GoLang)
 DEFAULT_METERING_AGENT_RPM_URL := "https://archive.cloudera.com/cp_clients/thunderhead-metering-heartbeat-application-2.0.0-b12639.x86_64.rpm"

--- a/docker/redhat8/Dockerfile
+++ b/docker/redhat8/Dockerfile
@@ -108,7 +108,7 @@ ENV INCLUDE_CDP_TELEMETRY="Yes"
 ENV INCLUDE_METERING="Yes"
 ENV FREEIPA_PLUGIN_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/49070467/thunderhead/1.x/redhat8/yum/cdp-hashed-pwd-1.0-20240109061814git4230396.el8.x86_64.rpm"
 ENV FREEIPA_LDAP_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/49050621/thunderhead/1.x/redhat8/yum/freeipa-ldap-agent-1.0.0-b12325.x86_64.rpm"
-ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.8.0/jumpgate-agent.rpm"
+ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.9.0/jumpgate-agent.rpm"
 
 #we build logic on the existance of this directory, please DO NOT REMOVE
 RUN mkdir /yarn-private


### PR DESCRIPTION
The custom freeIPA images were built with the new version of jumpgate agent and published. The information can be found here

- https://github.com/hortonworks/cloudbreak-images/tree/jumpgate-artifact/jumpgate. 

UUIDs for the images are below:

- AWS - "33d1490c-fee2-41f7-923f-000b90c09110"
- Azure - "5a5715e4-312c-4680-a83c-13acaad44809"
- GCP - "32fc7eba-baeb-4f01-bbb1-d74d827ad89a"

E2E tests were run with the custom freeIPA images and the tests were successful. Refer

- AWS - https://quanta.infra.cloudera.com/#/runDetails?gtn=62628916
- Azure - https://quanta.infra.cloudera.com/#/runDetails?gtn=62655154
- GCP - https://quanta.infra.cloudera.com/#/runDetails?gtn=62690983