### PR TITLE
CB-28730: Bump cdp-request-signer version to be able to configure TLS ciphers

### DIFF
--- a/saltstack/base/salt/telemetry/init.sls
+++ b/saltstack/base/salt/telemetry/init.sls
@@ -34,10 +34,10 @@ override_cdp_request_signer:
   cmd.run:
     - name: |
 {% if pillar['OS'] == 'redhat8' and salt['environ.get']('ARCHITECTURE') == 'arm64' %}
-        dnf -y install https://archive.cloudera.com/cdp-infra-tools/1.3.6/redhat8arm64/yum/cdp_request_signer-1.3.6_b2.rpm
+        dnf -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat8arm64/yum/cdp_request_signer-1.3.7_b2.rpm
 {% elif pillar['OS'] == 'redhat8' %}
-        dnf -y install https://archive.cloudera.com/cdp-infra-tools/1.3.6/redhat8/yum/cdp_request_signer-1.3.6_b2.rpm
+        dnf -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat8/yum/cdp_request_signer-1.3.7_b2.rpm
 {% else %}
-        yum -y install https://archive.cloudera.com/cdp-infra-tools/1.3.6/redhat7/yum/cdp_request_signer-1.3.6_b2.rpm
+        yum -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat7/yum/cdp_request_signer-1.3.7_b2.rpm
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Previous version: `1.3.6-b2`
New version: `1.3.7-b2`

The TLS cipher configuration wasn't properly taken into consideration, as it wasn't applied to the actual cdp-request-signer server, only the client passed to the proxy request handler.