### PR TITLE
CB-28865: Bump saltboot version to `0.14.3` and turn HTTPS back on

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,12 +166,13 @@ ifeq ($(SALT_NEWER_PYZMQ),1)
 else
 	PYZMQ_VERSION ?= 19.0
 endif
-SALTBOOT_VERSION ?= "0.14.0"
+SALTBOOT_VERSION ?= "0.14.3"
 ifneq ($(CLOUD_PROVIDER),YARN)
 	ifneq ($(OS),centos7)
 		SALTBOOT_MINOR_VERSION = $(shell echo $(SALTBOOT_VERSION) | cut -d. -f2)
-		ifeq ($(shell [[ $(SALTBOOT_MINOR_VERSION) -ge 14 ]] && echo true),true)
-			SALTBOOT_HTTPS_ENABLED ?= false
+		SALTBOOT_PATCH_VERSION = $(shell echo $(SALTBOOT_VERSION) | cut -d. -f3)
+		ifeq ($(shell [[ ($(SALTBOOT_MINOR_VERSION) -eq 14 && $(SALTBOOT_PATCH_VERSION) -ge 3) || $(SALTBOOT_MINOR_VERSION) -ge 15 ]] && echo true),true)
+			SALTBOOT_HTTPS_ENABLED ?= true
 		else
 			SALTBOOT_HTTPS_ENABLED ?= false
 		endif


### PR DESCRIPTION
Enable the saltboot HTTPS feature if the saltboot version has:
- minor version = 14 AND patch version >= 3
- OR
- minor version >= 15

salt-bootstrap version `0.14.3` includes:
- fallback to HTTP on port 7070 if the target is not listening for HTTPS on port 7071
- using the same timeout settings on both the HTTP and HTTPS client
- configurable TLS version and cipher suites