### PR TITLE
CB-29009: Reverted SHA1 related changes as they break CCMv1

### DIFF
--- a/saltstack/final/salt/cis-controls/redhat8.sls
+++ b/saltstack/final/salt/cis-controls/redhat8.sls
@@ -80,22 +80,16 @@ deny_nobody:
     - name: /etc/ssh/sshd_config
     - text: "DenyUsers nobody"
 
-ignore_system_wide_crypto_policy_for_ssh::
-  cmd.run:
-    - name: echo "CRYPTO_POLICY=" | sudo tee -a /etc/sysconfig/sshd
-
+#
 create_subpolicy_remove_cbc_cipher_for_ssh:
   file.append:
     - name: /etc/crypto-policies/policies/modules/DISABLE-CBC.pmod
     - text: "ssh_cipher = -AES-128-CBC -AES-256-CBC"
 
-subpolicy_for_disable_sha1_for_ssh:
-  cmd.run:
-    - name: sudo cp /usr/share/crypto-policies/policies/modules/NO-SHA1.pmod /etc/crypto-policies/policies/modules/
-
+#
 update_crypto_policies:
   cmd.run:
-    - name: sudo update-crypto-policies --set DEFAULT:DISABLE-CBC:NO-SHA1
+    - name: sudo update-crypto-policies --set DEFAULT:DISABLE-CBC
 
 sshd_harden_ApprovedCiphers:
   file.replace:

--- a/saltstack/final/salt/cis-controls/scripts/cis_control.sh
+++ b/saltstack/final/salt/cis-controls/scripts/cis_control.sh
@@ -25,7 +25,7 @@ if [ "${STIG_ENABLED}" == "True" ]; then
     #    SKIP_TAGS+=",service_httpd_disabled"
     #fi
 else
-    SKIP_TAGS="package_firewalld_installed,service_firewalld_enabled,package_openldap-clients_removed,configure_crypto_policy,configure_ssh_crypto_policy"
+    SKIP_TAGS="package_firewalld_installed,service_firewalld_enabled,package_openldap-clients_removed"
     EXTRA_VARS="sshd_idle_timeout_value=180"
 
     if [ "${IMAGE_BASE_NAME}" == "freeipa" ] ; then


### PR DESCRIPTION
Reverts hortonworks/cloudbreak-images#1132

This might be temporary and we'll probably re-introduce these changes once it is sorted out how we should deal with CCMv1.