### PR TITLE
CB-29006,CB-29210: Apply correct SELinux file contexts to PostgreSQL related locations and refactor host name policy installation

### DIFF
--- a/saltstack/base/salt/prerequisites/selinux.sls
+++ b/saltstack/base/salt/prerequisites/selinux.sls
@@ -4,6 +4,7 @@ install_selinux_module_dependecies:
   pkg.installed:
     - pkgs:
       - policycoreutils
+      - selinux-policy-devel
 {% if pillar['OS'] == 'redhat8' %}
       - policycoreutils-python-utils
 {% else %}

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/hostname/cdp-hostname.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/hostname/cdp-hostname.te
@@ -1,10 +1,10 @@
-module hostname_policy 1.0;
+policy_module(cdp-hostname, 1.0.0)
 
-require {
+gen_require(`
 	type hostname_etc_t;
 	type hostname_t;
 	class file open;
-}
+')
 
 #============= hostname_t ==============
 allow hostname_t hostname_etc_t:file open;

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/install-cdp-policies.sh
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/install-cdp-policies.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+SELINUX_CDP_DIR=/etc/selinux/cdp
+
+log() {
+  echo "$(date +"%F-%T") $*"
+}
+
+install_policy() {
+  local dir_abs_path="$1"
+  local policy_name="$2"
+
+  if ! semodule -l | grep -q "$policy_name"; then
+    log "Installing CDP SELinux policy '$policy_name' from $dir_abs_path"
+    make -f /usr/share/selinux/devel/Makefile "$policy_name.pp" -C "$dir_abs_path"
+    log "Compiled CDP SELinux policy '$policy_name'"
+    semodule -i "$dir_abs_path/$policy_name.pp"
+    log "Installed CDP SELinux policy '$policy_name'"
+  else
+    log "CDP SELinux policy '$policy_name' already installed. Skipping installation."
+  fi
+}
+
+apply_file_contexts() {
+  local dir_abs_path="$1"
+  local policy_name="$2"
+
+  if [[ -f "$dir_abs_path/$policy_name.restorecon" ]]; then
+    log "Applying file contexts for CDP SELinux policy '$policy_name'"
+    mapfile -t paths < <(grep -v '^[[:space:]]*$' "$dir_abs_path/$policy_name.restorecon")
+    for path in "${paths[@]}"; do
+      log "Applying file contexts to path '$path'"
+      restorecon -R -v -i "$path"
+    done
+    log "Applied file contexts for CDP SELinux policy '$policy_name'"
+  else
+    log "No restorecon file found for CDP SELinux policy '$policy_name'. Skipping file context application."
+  fi
+}
+
+main() {
+  # Collect the directories containing CDP SELinux policy files
+  mapfile -t CDP_POLICY_DIRS < <(find "$SELINUX_CDP_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+  log "Found CDP SELinux policy directories: ${CDP_POLICY_DIRS[*]}"
+
+  for dir in "${CDP_POLICY_DIRS[@]}"; do
+    local POLICY_NAME="cdp-$dir"
+
+    install_policy "$SELINUX_CDP_DIR/$dir" "$POLICY_NAME"
+    apply_file_contexts "$SELINUX_CDP_DIR/$dir" "$POLICY_NAME"
+  done
+}
+
+main "$@"

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/install-hostname-policy.sh
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/install-hostname-policy.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-SELINUX_CDP_DIR=/etc/selinux/cdp
-
-checkmodule -M -m -o $SELINUX_CDP_DIR/hostname_policy.mod $SELINUX_CDP_DIR/hostname_policy.te
-semodule_package -o $SELINUX_CDP_DIR/hostname_policy.pp -m $SELINUX_CDP_DIR/hostname_policy.mod
-semodule -i $SELINUX_CDP_DIR/hostname_policy.pp

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/postgresql/cdp-postgresql.fc
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/postgresql/cdp-postgresql.fc
@@ -1,0 +1,19 @@
+# PostgreSQL binary files (the directory is not labeled, only the files)
+/usr/pgsql-11/bin(/.*)?                --      gen_context(system_u:object_r:postgresql_exec_t,s0)
+/usr/pgsql-14/bin(/.*)?                --      gen_context(system_u:object_r:postgresql_exec_t,s0)
+/usr/pgsql-17/bin(/.*)?                --      gen_context(system_u:object_r:postgresql_exec_t,s0)
+
+# PostgreSQL data directories
+/dbfs/pgsql/data(/.*)?                 --      gen_context(system_u:object_r:postgresql_db_t,s0)
+/dbfs/pgsql/data(/.*)?                 -d      gen_context(system_u:object_r:postgresql_db_t,s0)
+/dbfs/pgsql/certs(/.*)?                --      gen_context(system_u:object_r:postgresql_db_t,s0)
+/dbfs/pgsql/certs(/.*)?                -d      gen_context(system_u:object_r:postgresql_db_t,s0)
+
+# PostgreSQL log directories
+/dbfs/pgsql/log(/.*)?                  --      gen_context(system_u:object_r:postgresql_log_t,s0)
+/dbfs/pgsql/log(/.*)?                  -d      gen_context(system_u:object_r:postgresql_log_t,s0)
+/dbfs/pgsql/[^/]*\.log                 --      gen_context(system_u:object_r:postgresql_log_t,s0)
+
+# PostgreSQL script directories
+/dbfs/pgsql/scripts(/.*)?              --      gen_context(system_u:object_r:postgresql_exec_t,s0)
+/dbfs/pgsql/scripts(/.*)?              -d      gen_context(system_u:object_r:postgresql_exec_t,s0)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/postgresql/cdp-postgresql.restorecon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/postgresql/cdp-postgresql.restorecon
@@ -1,0 +1,4 @@
+/usr/pgsql-11/bin
+/usr/pgsql-14/bin
+/usr/pgsql-17/bin
+/dbfs/pgsql

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/postgresql/cdp-postgresql.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/postgresql/cdp-postgresql.te
@@ -1,0 +1,13 @@
+policy_module(cdp-postgresql, 1.0.0)
+
+gen_require(`
+    type postgresql_t;
+    type postgresql_exec_t;
+    type postgresql_db_t;
+    type postgresql_log_t;
+')
+
+########################################
+#
+# cdp-postgresql customized policy
+#

--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -1,24 +1,52 @@
-/etc/selinux/cdp/hostname_policy.te:
+{% if salt['environ.get']('CUSTOM_IMAGE_TYPE') != 'freeipa' %}
+/etc/selinux/cdp/postgresql/cdp-postgresql.fc:
   file.managed:
-    - name: /etc/selinux/cdp/hostname_policy.te
-    - source: salt://{{ slspath }}/etc/selinux/cdp/hostname_policy.te
+    - name: /etc/selinux/cdp/postgresql/cdp-postgresql.fc
+    - source: salt://{{ slspath }}/etc/selinux/cdp/postgresql/cdp-postgresql.fc
     - user: root
     - group: root
     - mode: 644
     - makedirs: True
 
-/etc/selinux/cdp/install-hostname-policy.sh:
+/etc/selinux/cdp/postgresql/cdp-postgresql.restorecon:
   file.managed:
-    - name: /etc/selinux/cdp/install-hostname-policy.sh
-    - source: salt://{{ slspath }}/etc/selinux/cdp/install-hostname-policy.sh
+    - name: /etc/selinux/cdp/postgresql/cdp-postgresql.restorecon
+    - source: salt://{{ slspath }}/etc/selinux/cdp/postgresql/cdp-postgresql.restorecon
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/postgresql/cdp-postgresql.te:
+  file.managed:
+    - name: /etc/selinux/cdp/postgresql/cdp-postgresql.te
+    - source: salt://{{ slspath }}/etc/selinux/cdp/postgresql/cdp-postgresql.te
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+{% endif %}
+
+/etc/selinux/cdp/hostname/cdp-hostname.te:
+  file.managed:
+    - name: /etc/selinux/cdp/hostname/cdp-hostname.te
+    - source: salt://{{ slspath }}/etc/selinux/cdp/hostname/cdp-hostname.te
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/install-cdp-policies.sh:
+  file.managed:
+    - name: /etc/selinux/cdp/install-cdp-policies.sh
+    - source: salt://{{ slspath }}/etc/selinux/cdp/install-cdp-policies.sh
     - user: root
     - group: root
     - mode: 755
     - makedirs: True
 
-run_install_hostname_policy.sh:
+run_install-cdp-policies.sh:
   cmd.run:
-    - name: /etc/selinux/cdp/install-hostname-policy.sh
+    - name: /etc/selinux/cdp/install-cdp-policies.sh 2>&1 | tee /var/log/install-cdp-policies.log && exit ${PIPESTATUS[0]}
     - require:
-      - file: /etc/selinux/cdp/hostname_policy.te
-      - file: /etc/selinux/cdp/install-hostname-policy.sh
+      - file: /etc/selinux/cdp/install-cdp-policies.sh

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -9,6 +9,9 @@ base:
     - python3
     - salt-bootstrap
     - salt
+{% if pillar['subtype'] != 'Docker' and pillar['OS'] == 'redhat8' %}
+    - selinux
+{% endif %}
 {% if salt['environ.get']('CUSTOM_IMAGE_TYPE') != 'freeipa' %}
     - postgresql
 {% endif %}
@@ -25,7 +28,4 @@ base:
 {% endif %}
 {% if pillar['subtype'] != 'Docker' or pillar['OS'] == 'redhat8' %}
     - chrony
-{% endif %}
-{% if pillar['subtype'] != 'Docker' and pillar['OS'] == 'redhat8' %}
-    - selinux
 {% endif %}


### PR DESCRIPTION
- Each custom policy's files should be placed in a separate subdirectory under `/etc/selinux/cdp/`. The directory should have the same name as the module, but without the `cdp-` prefix. The directory contains the necessary `.te`, `.fc` and `.if` files for the custom policy, with each file having the same name as the module's name.
- The policies are installed by the `install-cdp-policies.sh` script located in `/etc/selinux/cdp/`
- The directory can also contain a file with the `.restorecon` extension and the same name as the module's name. For each of the paths listed in this file the following command will be called by the `install-cdp-policies.sh` script: `restorecon -Rv <path>`. This ensures the file context rules defined by the cus
tom policy are applied to existing files matching the rule.

See example directory structure in the commit description!

- [x] https://github.infra.cloudera.com/cloudbreak/cloudbreak/pull/3943 is needed