### PR TITLE
CB-29126: Separate saltboot cert generation from nginx cert generation

### DIFF
--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -117,9 +117,6 @@ create_certificates_certm() {
   mv $CERT_ROOT_PATH/server.pem $CERT_ROOT_PATH/cluster.pem
   cp $CERT_ROOT_PATH/cluster.pem /tmp/cluster.pem
   mv $CERT_ROOT_PATH/server-key.pem $CERT_ROOT_PATH/cluster-key.pem
-{% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
-  certm -d $CERT_ROOT_PATH server generate -o=saltboot --cert $CERT_ROOT_PATH/saltboot.pem --key $CERT_ROOT_PATH/saltboot-key.pem --overwrite
-{% endif %}
   rm $CERT_ROOT_PATH/ca-key.pem
   cp $CERT_ROOT_PATH/cluster.pem /etc/jumpgate/cluster.pem
   chmod 600 /etc/jumpgate/cluster.pem
@@ -127,8 +124,8 @@ create_certificates_certm() {
 }
 
 create_cert_for_saltboot_tls() {
-  CERT_ROOT_PATH=/etc/certs
-  certm -d $CERT_ROOT_PATH ca generate -o=saltboot
+  local CERT_ROOT_PATH=/etc/salt-bootstrap/certs
+  certm -d $CERT_ROOT_PATH ca generate -o=saltboot --overwrite
   certm -d $CERT_ROOT_PATH server generate -o=saltboot --cert $CERT_ROOT_PATH/saltboot.pem --key $CERT_ROOT_PATH/saltboot-key.pem --overwrite
   rm $CERT_ROOT_PATH/ca-key.pem
 }
@@ -288,11 +285,11 @@ main() {
         start_nginx
       fi
       create_saltapi_certificates
-{% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
-    else
-      create_cert_for_saltboot_tls
-{% endif %}
     fi
+
+{% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
+    create_cert_for_saltboot_tls
+{% endif %}
 
     INSTANCE_ID=
     if [[ "$CLOUD_PLATFORM" == "AWS" ]]; then

--- a/saltstack/base/salt/salt-bootstrap/etc/systemd/system/salt-bootstrap.service
+++ b/saltstack/base/salt/salt-bootstrap/etc/systemd/system/salt-bootstrap.service
@@ -21,7 +21,7 @@ Environment='SALTBOOT_PORT=7070'
 {% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
 Environment='SALTBOOT_HTTPS_PORT=7071'
 Environment='SALTBOOT_HTTPS_ENABLED=true'
-Environment='SALTBOOT_HTTPS_CERT_FILE=/etc/certs/saltboot.pem'
-Environment='SALTBOOT_HTTPS_KEY_FILE=/etc/certs/saltboot-key.pem'
-Environment='SALTBOOT_HTTPS_CACERT_FILE=/etc/certs/ca.pem'
+Environment='SALTBOOT_HTTPS_CERT_FILE=/etc/salt-bootstrap/certs/saltboot.pem'
+Environment='SALTBOOT_HTTPS_KEY_FILE=/etc/salt-bootstrap/certs/saltboot-key.pem'
+Environment='SALTBOOT_HTTPS_CACERT_FILE=/etc/salt-bootstrap/certs/ca.pem'
 {% endif %}


### PR DESCRIPTION
Saltboot certs are created in the `/etc/salt-bootstrap/certs/` directory.
The `salt-bootstrap.service` unit file was also updated to reflect this change.