### PR TITLE
CB-29299: Copy Azure images for internal releases to us-west-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,10 +264,7 @@ endif
 # Azure storage account definitions for the different states
 define AZURE_STORAGE_ACCOUNTS_TEST_PHASE
 West US:cldrwestus,\
-West US 2:cldrwestus2,\
-East US:cldreastus,\
-East US 2:cldreastus2,\
-Central US:cldrcentralus
+West US 2:cldrwestus2
 endef
 
 define AZURE_STORAGE_ACCOUNTS_ALL


### PR DESCRIPTION
we need to copy azure image to region us-west-2 too in case of internal flow, because the MP is not available. So we reduced the possible available regions are being copied, just the west us 2 kept. This change affects the Centos7 image burning as well.