### PR TITLE
CB-29390 Add script and systemd unit file drop in to clean up entries added by GCP from /etc/host

### DIFF
--- a/saltstack/base/salt/hostname/etc/systemd/system/google-guest-agent.service.d/override.conf
+++ b/saltstack/base/salt/hostname/etc/systemd/system/google-guest-agent.service.d/override.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPost=/usr/local/bin/cleanup-hosts.sh
+ExecStartPost=/usr/local/bin/restore-hosts.sh

--- a/saltstack/base/salt/hostname/etc/systemd/system/google-guest-agent.service.d/override.conf
+++ b/saltstack/base/salt/hostname/etc/systemd/system/google-guest-agent.service.d/override.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStartPost=/usr/local/bin/restore-hosts.sh
+ExecStartPost=/usr/local/bin/cleanup-hosts.sh

--- a/saltstack/base/salt/hostname/etc/systemd/system/google-guest-agent.service.d/override.conf
+++ b/saltstack/base/salt/hostname/etc/systemd/system/google-guest-agent.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=/usr/local/bin/restore-hosts.sh

--- a/saltstack/base/salt/hostname/init.sls
+++ b/saltstack/base/salt/hostname/init.sls
@@ -27,7 +27,7 @@ add_cleanup_hosts_sh:
     - name: /usr/local/bin/cleanup-hosts.sh
     - source:
       - salt://{{ slspath }}/usr/local/bin/cleanup-hosts.sh
-    - mode: 0644
+    - mode: 0755
     - require:
       - file: create_google_guest_agent_override_dir
 

--- a/saltstack/base/salt/hostname/init.sls
+++ b/saltstack/base/salt/hostname/init.sls
@@ -6,3 +6,33 @@ remove-gcp-NetworkManager-hostname-override:
 remove-gcp-dhcp-hostname-override:
   file.absent:
     - name: /etc/dhcp/dhclient.d/google_hostname.sh
+
+create_google_guest_agent_override_dir:
+  file.directory:
+    - name: /etc/systemd/system/google-guest-agent.service.d
+    - makedirs: True
+    - mode: 0755
+
+add_google_guest_agent_override:
+  file.managed:
+    - name: /etc/systemd/system/google-guest-agent.service.d/override.conf
+    - source:
+      - salt://{{ slspath }}/etc/systemd/system/google-guest-agent.service.d/override.conf
+    - mode: 0644
+    - require:
+      - file: create_google_guest_agent_override_dir
+
+add_cleanup_hosts_sh:
+  file.managed:
+    - name: /usr/local/bin/cleanup-hosts.sh
+    - source:
+      - salt://{{ slspath }}/usr/local/bin/cleanup-hosts.sh
+    - mode: 0644
+    - require:
+      - file: create_google_guest_agent_override_dir
+
+reload_systemd:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - require:
+      - file: add_google_guest_agent_override

--- a/saltstack/base/salt/hostname/init.sls
+++ b/saltstack/base/salt/hostname/init.sls
@@ -1,3 +1,4 @@
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'GCP' %}
 # GCP overrides the hostname each time the network goes up (e.g. startup) and this messes up our hostname confifuration so it should be removed
 remove-gcp-NetworkManager-hostname-override:
   file.absent:
@@ -36,3 +37,4 @@ reload_systemd:
     - name: systemctl daemon-reload
     - require:
       - file: add_google_guest_agent_override
+{% endif %}

--- a/saltstack/base/salt/hostname/usr/local/bin/cleanup-hosts.sh
+++ b/saltstack/base/salt/hostname/usr/local/bin/cleanup-hosts.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Backup original file
+cp /etc/hosts /etc/hosts.bak
+
+# Remove lines marked as "Added by Google"
+grep -v '# Added by Google' /etc/hosts.bak > /etc/hosts
+
+echo "Removed Google-added lines from /etc/hosts. Backup saved as /etc/hosts.bak."

--- a/saltstack/base/salt/hostname/usr/local/bin/cleanup-hosts.sh
+++ b/saltstack/base/salt/hostname/usr/local/bin/cleanup-hosts.sh
@@ -3,7 +3,7 @@
 # Backup original file
 cp /etc/hosts /etc/hosts.bak
 
-# Remove lines marked as "Added by Google"
-grep -v '# Added by Google' /etc/hosts.bak > /etc/hosts
+# Remove lines marked as "Added by Google" and avoid blank lines
+grep -v '# Added by Google' /etc/hosts.bak | sed '/^$/d' > /etc/hosts
 
 echo "Removed Google-added lines from /etc/hosts. Backup saved as /etc/hosts.bak."


### PR DESCRIPTION
CB-29390 Add script and systemd unit file drop in to clean up entries added by GCP from /etc/hosts

test img burning: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7050/console

validator run: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3126/console