### PR TITLE
CB-28624 CB-29106 CB-29108 Create SELinux policy for `salt-bootstrap`

### DIFF
--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -108,6 +108,8 @@ signKey: |-
  -----END PUBLIC KEY-----
 EOF
   chmod 600 /etc/salt-bootstrap/security-config.yml
+  # TODO Remove once CB-29572 is done
+  restorecon -R -v -i /etc/salt-bootstrap
 }
 
 create_certificates_certm() {
@@ -128,6 +130,8 @@ create_cert_for_saltboot_tls() {
   certm -d $CERT_ROOT_PATH ca generate -o=saltboot --overwrite
   certm -d $CERT_ROOT_PATH server generate -o=saltboot --cert $CERT_ROOT_PATH/saltboot.pem --key $CERT_ROOT_PATH/saltboot-key.pem --overwrite
   rm $CERT_ROOT_PATH/ca-key.pem
+  # TODO Remove once CB-29572 is done
+  restorecon -R -v -i $CERT_ROOT_PATH
 }
 
 start_nginx() {

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/common/cdp-common.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/common/cdp-common.te
@@ -1,0 +1,38 @@
+policy_module(cdp-common, 1.0.0)
+
+########################################
+#
+# Salt
+#
+type cdp_salt_etc_t;
+files_type(cdp_salt_etc_t)
+
+type cdp_salt_cert_t;
+miscfiles_cert_type(cdp_salt_cert_t)
+
+type cdp_salt_srv_t;
+files_type(cdp_salt_srv_t)
+
+########################################
+#
+# salt-bootstrap
+#
+type cdp_salt_bootstrap_t;
+type cdp_salt_bootstrap_exec_t;
+
+type cdp_salt_bootstrap_etc_t;
+files_type(cdp_salt_bootstrap_etc_t)
+
+type cdp_salt_bootstrap_log_t;
+logging_log_file(cdp_salt_bootstrap_log_t)
+
+require {
+    attribute port_type, defined_port_type, unreserved_port_type;
+}
+type cdp_salt_bootstrap_port_t, port_type, defined_port_type;
+typeattribute cdp_salt_bootstrap_port_t unreserved_port_type;
+
+type cdp_salt_bootstrap_unconfined_t;
+
+type cdp_salt_bootstrap_cert_t;
+miscfiles_cert_type(cdp_salt_bootstrap_cert_t)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.fc
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.fc
@@ -1,0 +1,9 @@
+# Configuration, certificates
+/etc/salt-bootstrap(/.*)?           gen_context(system_u:object_r:cdp_salt_bootstrap_etc_t,s0)
+/etc/salt-bootstrap/certs(/.*)?     gen_context(system_u:object_r:cdp_salt_bootstrap_cert_t,s0)
+
+# Executable
+/usr/sbin/salt-bootstrap    --      gen_context(system_u:object_r:cdp_salt_bootstrap_exec_t,s0)
+
+# Log
+/var/log/saltboot.log       --      gen_context(system_u:object_r:cdp_salt_bootstrap_log_t,s0)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.portcon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.portcon
@@ -1,0 +1,2 @@
+cdp_salt_bootstrap_port_t tcp 7070
+cdp_salt_bootstrap_port_t tcp 7071

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.restorecon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.restorecon
@@ -1,0 +1,3 @@
+/etc/salt-bootstrap
+/usr/sbin/salt-bootstrap
+/var/log/saltboot.log

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te
@@ -1,0 +1,167 @@
+policy_module(cdp-salt-bootstrap, 1.0.0)
+
+########################################
+#
+# Declarations, domain setup
+#
+
+require {
+    type cdp_salt_bootstrap_t, cdp_salt_bootstrap_exec_t;
+}
+init_daemon_domain(cdp_salt_bootstrap_t, cdp_salt_bootstrap_exec_t)
+
+########################################
+#
+# cdp-salt-bootstrap local policy
+#
+allow cdp_salt_bootstrap_t self:fifo_file rw_fifo_file_perms;
+allow cdp_salt_bootstrap_t self:unix_stream_socket create_stream_socket_perms;
+
+require {
+    type cdp_salt_bootstrap_etc_t, cdp_salt_bootstrap_cert_t;
+}
+search_dirs_pattern(cdp_salt_bootstrap_t, cdp_salt_bootstrap_etc_t, cdp_salt_bootstrap_etc_t)
+search_dirs_pattern(cdp_salt_bootstrap_t, cdp_salt_bootstrap_cert_t, cdp_salt_bootstrap_cert_t)
+read_files_pattern(cdp_salt_bootstrap_t, cdp_salt_bootstrap_etc_t, cdp_salt_bootstrap_etc_t)
+read_files_pattern(cdp_salt_bootstrap_t, cdp_salt_bootstrap_cert_t, cdp_salt_bootstrap_cert_t)
+
+require {
+    type cdp_salt_bootstrap_log_t, var_log_t;
+}
+manage_dirs_pattern(cdp_salt_bootstrap_t, var_log_t, cdp_salt_bootstrap_log_t)
+manage_files_pattern(cdp_salt_bootstrap_t, var_log_t, cdp_salt_bootstrap_log_t)
+logging_log_filetrans(cdp_salt_bootstrap_t, cdp_salt_bootstrap_log_t, file)
+
+domain_use_interactive_fds(cdp_salt_bootstrap_t)
+
+files_read_etc_files(cdp_salt_bootstrap_t)
+
+miscfiles_read_localization(cdp_salt_bootstrap_t)
+
+########################################
+#
+# cdp_salt_bootstrap_port_t, networking
+#
+require {
+    type cdp_salt_bootstrap_port_t;
+	class tcp_socket { accept bind connect create getattr getopt listen name_bind name_connect setopt };
+}
+allow cdp_salt_bootstrap_t cdp_salt_bootstrap_port_t:tcp_socket { name_bind name_connect };
+allow cdp_salt_bootstrap_t self:tcp_socket { accept bind connect create getattr getopt listen setopt };
+corenet_tcp_bind_generic_node(cdp_salt_bootstrap_t)
+dev_read_sysfs(cdp_salt_bootstrap_t)
+kernel_read_net_sysctls(cdp_salt_bootstrap_t)
+kernel_search_network_sysctl(cdp_salt_bootstrap_t)
+
+########################################
+#
+# Child processes: chage
+#
+usermanage_domtrans_passwd(cdp_salt_bootstrap_t)
+
+########################################
+#
+# Child processes: useradd
+#
+usermanage_check_exec_useradd(cdp_salt_bootstrap_t)
+usermanage_domtrans_useradd(cdp_salt_bootstrap_t)
+
+########################################
+#
+# Child processes: systemctl (and implicit definition of domain cdp_salt_bootstrap_systemctl_t)
+#
+systemd_systemctl_domain(cdp_salt_bootstrap)
+
+fs_getattr_xattr_fs(cdp_salt_bootstrap_systemctl_t)
+kernel_read_proc_files(cdp_salt_bootstrap_systemctl_t)
+systemd_config_generic_services(cdp_salt_bootstrap_systemctl_t)
+
+########################################
+#
+# Child processes: cp, grep, mv, ps (all executed in the domain cdp_salt_bootstrap_unconfined_t)
+#
+require {
+    type cdp_salt_bootstrap_unconfined_t;
+}
+role system_r types cdp_salt_bootstrap_unconfined_t;
+domain_type(cdp_salt_bootstrap_unconfined_t)
+unconfined_domain(cdp_salt_bootstrap_unconfined_t)
+
+corecmd_bin_domtrans(cdp_salt_bootstrap_t, cdp_salt_bootstrap_unconfined_t)
+corecmd_bin_entry_type(cdp_salt_bootstrap_unconfined_t)
+
+########################################
+#
+# Child processes: hostname
+#
+hostname_domtrans(cdp_salt_bootstrap_t)
+
+########################################
+#
+# Child processes: sss_cache
+#
+require {
+    type sssd_t;
+}
+allow sssd_t cdp_salt_bootstrap_t:fifo_file write;
+
+########################################
+#
+# Child processes: /etc/shadow.backup (accessed from the domain cdp_salt_bootstrap_unconfined_t)
+#
+auth_etc_filetrans_shadow(cdp_salt_bootstrap_unconfined_t, "shadow.backup")
+
+########################################
+#
+# /etc/shadow, /etc/shadow.new
+#
+auth_etc_filetrans_shadow(cdp_salt_bootstrap_t, "shadow.new")
+auth_manage_shadow(cdp_salt_bootstrap_t)
+
+########################################
+#
+# Salt related files
+#
+require {
+    type cdp_salt_etc_t, cdp_salt_cert_t, cdp_salt_srv_t;
+    class capability { dac_override dac_read_search };
+}
+manage_dirs_pattern(cdp_salt_bootstrap_t, cdp_salt_etc_t, cdp_salt_etc_t)
+manage_dirs_pattern(cdp_salt_bootstrap_t, cdp_salt_cert_t, cdp_salt_cert_t)
+manage_dirs_pattern(cdp_salt_bootstrap_t, cdp_salt_srv_t, cdp_salt_srv_t)
+manage_files_pattern(cdp_salt_bootstrap_t, cdp_salt_etc_t, cdp_salt_etc_t)
+manage_files_pattern(cdp_salt_bootstrap_t, cdp_salt_cert_t, cdp_salt_cert_t)
+manage_files_pattern(cdp_salt_bootstrap_t, cdp_salt_srv_t, cdp_salt_srv_t)
+files_etc_filetrans(cdp_salt_bootstrap_t, cdp_salt_etc_t, dir, "salt")
+filetrans_pattern(cdp_salt_bootstrap_t, cdp_salt_etc_t, cdp_salt_cert_t, dir, "pki")
+files_var_filetrans(cdp_salt_bootstrap_t, cdp_salt_srv_t, file, "errormessages.yaml")
+files_var_filetrans(cdp_salt_bootstrap_t, cdp_salt_srv_t, dir, "pillar")
+files_var_filetrans(cdp_salt_bootstrap_t, cdp_salt_srv_t, dir, "salt")
+files_var_filetrans(cdp_salt_bootstrap_t, cdp_salt_srv_t, file, "salt-state-updater.sh")
+files_var_filetrans(cdp_salt_bootstrap_t, cdp_salt_srv_t, file, "stderrcommands.yaml")
+allow cdp_salt_bootstrap_t self:capability { dac_override dac_read_search };
+
+########################################
+#
+# /etc/hostname
+#
+systemd_hostnamed_manage_config(cdp_salt_bootstrap_t)
+
+########################################
+#
+# /etc/hosts
+#
+sysnet_read_config(cdp_salt_bootstrap_t)
+sysnet_write_config(cdp_salt_bootstrap_t)
+
+########################################
+#
+# /etc/sysconfig/network
+#
+files_rw_etc_files(cdp_salt_bootstrap_t)
+
+########################################
+#
+# /tmp/*.zip (and possibly its contents unpacked)
+#
+files_manage_generic_tmp_files(cdp_salt_bootstrap_t)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.fc
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.fc
@@ -1,0 +1,10 @@
+# Configuration, certificates
+/etc/salt(/.*)?                 gen_context(system_u:object_r:cdp_salt_etc_t,s0)
+/etc/salt/pki(/.*)?             gen_context(system_u:object_r:cdp_salt_cert_t,s0)
+
+# Pillars, states and miscellaneous supporting files
+/srv/errormessages.yaml         gen_context(system_u:object_r:cdp_salt_srv_t,s0)
+/srv/pillar(/.*)?               gen_context(system_u:object_r:cdp_salt_srv_t,s0)
+/srv/salt(/.*)?                 gen_context(system_u:object_r:cdp_salt_srv_t,s0)
+/srv/salt-state-updater.sh      gen_context(system_u:object_r:cdp_salt_srv_t,s0)
+/srv/stderrcommands.yaml        gen_context(system_u:object_r:cdp_salt_srv_t,s0)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.restorecon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.restorecon
@@ -1,0 +1,6 @@
+/etc/salt
+/srv/errormessages.yaml
+/srv/pillar
+/srv/salt
+/srv/salt-state-updater.sh
+/srv/stderrcommands.yaml

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.te
@@ -1,0 +1,10 @@
+policy_module(cdp-salt, 1.0.0)
+
+gen_require(`
+    type cdp_salt_etc_t, cdp_salt_cert_t, cdp_salt_srv_t;
+')
+
+########################################
+#
+# cdp-salt customized policy
+#

--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -27,10 +27,82 @@
     - makedirs: True
 {% endif %}
 
+/etc/selinux/cdp/common/cdp-common.te:
+  file.managed:
+    - name: /etc/selinux/cdp/common/cdp-common.te
+    - source: salt://{{ slspath }}/etc/selinux/cdp/common/cdp-common.te
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
 /etc/selinux/cdp/hostname/cdp-hostname.te:
   file.managed:
     - name: /etc/selinux/cdp/hostname/cdp-hostname.te
     - source: salt://{{ slspath }}/etc/selinux/cdp/hostname/cdp-hostname.te
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/salt/cdp-salt.fc:
+  file.managed:
+    - name: /etc/selinux/cdp/salt/cdp-salt.fc
+    - source: salt://{{ slspath }}/etc/selinux/cdp/salt/cdp-salt.fc
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/salt/cdp-salt.restorecon:
+  file.managed:
+    - name: /etc/selinux/cdp/salt/cdp-salt.restorecon
+    - source: salt://{{ slspath }}/etc/selinux/cdp/salt/cdp-salt.restorecon
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/salt/cdp-salt.te:
+  file.managed:
+    - name: /etc/selinux/cdp/salt/cdp-salt.te
+    - source: salt://{{ slspath }}/etc/selinux/cdp/salt/cdp-salt.te
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.fc:
+  file.managed:
+    - name: /etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.fc
+    - source: salt://{{ slspath }}/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.fc
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.portcon:
+  file.managed:
+    - name: /etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.portcon
+    - source: salt://{{ slspath }}/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.portcon
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.restorecon:
+  file.managed:
+    - name: /etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.restorecon
+    - source: salt://{{ slspath }}/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.restorecon
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te:
+  file.managed:
+    - name: /etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te
+    - source: salt://{{ slspath }}/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te
     - user: root
     - group: root
     - mode: 644

--- a/saltstack/final/salt/cis-controls/playbooks/selinux.yml
+++ b/saltstack/final/salt/cis-controls/playbooks/selinux.yml
@@ -13,9 +13,8 @@
         - selinux
         - CB-27855
 
-    - name: Allow httpd_t (e.g nginx) to connect to port 7070
+    - name: Allow httpd_t (e.g nginx) to connect to downstream service ports
       shell: | 
-        semanage port -a -t http_port_t -p tcp 7070
         setsebool -P httpd_can_network_connect on
       tags:
         - selinux


### PR DESCRIPTION
* In general, to be consistent with the `cdp-xyz` convention of SELinux policy module names, all custom types have the `cdp_` prefix.
* Add SELinux policy module `cdp-common`:
  * Certain types specific to CDP services need to be referenced in multiple places. This inherently introduces an ordering dependency between two or more modules.
  * To make the said types available to all CDP-specific modules, while also keeping the implementation simple, `cdp-common` gets introduced. The only purpose of this module is to host the definitions of any types (along with their type attributes) that would be otherwise placed in some other CDP-specific module.
  * Only the `.te` file is provided, and the types provided cover both `cdp-salt` and `cdp-salt-bootstrap`.
* Add SELinux policy module `cdp-salt`:
  * Skeletal implementation for Salt services.
  * The following types are introduced:
    * `cdp_salt_cert_t`: Certificate files (and their private keys) in `/etc/salt/pki/`.
    * `cdp_salt_etc_t`: Config files in `/etc/salt/`.
    * `cdp_salt_srv_t`: All the files deployed into `/srv/` (e.g., pillars, states and some supporting files).
  * Besides a barebones `.te`, both a `.fc` and `.restorecon` file are provided.
* Add SELinux policy module `cdp-salt-bootstrap`:
  * Implicitly depends on `cdp-common` and `cdp-salt`.
  * The following types are introduced:
    * `cdp_salt_bootstrap_t`: Daemon process domain.
    * `cdp_salt_bootstrap_cert_t`: Certificate files (and their private keys) in `/etc/salt-bootstrap/certs/`.
    * `cdp_salt_bootstrap_etc_t`: Config files in `/etc/salt-bootstrap/`.
    * `cdp_salt_bootstrap_exec_t`: Executable file type for `/usr/sbin/salt-bootstrap`.
    * `cdp_salt_bootstrap_log_t`: Log file `/var/log/saltboot.log`.
    * `cdp_salt_bootstrap_port_t`: Port context type for TCP 7070 (plain HTTP) and TCP 7071 (HTTPS).
    * `cdp_salt_bootstrap_systemctl_t`: Dedicated domain for `systemctl` child processes.
    * `cdp_salt_bootstrap_unconfined_t`: Dedicated unconfined domain for certain child processes.
  * The first ~40 lines of the `.te` file was adapted from the `sepolicy generate` output (with some tweaks to properly restrict dir & file accesses). The rest is mostly handcrafted, with some help from `audit2allow`.
  * Whenever possible, child processes are launched in appropriate confined domains (via domain transitions). In particular, this is currently applicable to the following ones: `chage`, `hostname`, `sss_cache` (transitively launched by `chage` and `useradd`), `systemctl`, `useradd`.
  * Some executables are not labeled and confined by default, hence the associated child processes will be launched into the dedicated `cdp_salt_bootstrap_unconfined_t` domain (which is a variant of the built-in `unconfined_t`). This affects the following tools: `cp`, `grep`, `mv`, `ps`.
  * Close attention is paid to enable the correct labeling of all dirs & files created by `cdp_salt_bootstrap_t` or `cdp_salt_bootstrap_unconfined_t` (via appropriate file type transitions).
  * File access permissions are minimized whenever feasible. Notable exceptions are `/etc/sysconfig/network` that is not labeled properly (inhering `etc_t` of its parent `/etc/`), as well as the temporary files deployed into `/tmp/`.
  * Besides the `.te` file, `.fc`, `.portcon` and `.restorecon` ones are also provided.
* `install-cdp-policies.sh`:
  * Narrow the scope of some (environment) variables that are meant to be `local`.
  * Add handling of `.portcon` files (that are also optional, quite like `.restorecon` ones). Since `portcon` statements are not permitted in policy modules, port labeling is performed via `semanage port`.
  * Module `cdp-common` is now handled specially: It is assumed to always exist, and compiled & installed as the very first module among CDP-specific ones.
* `user-data-helper.sh`:
  * As noted in [CB-29572](https://cloudera.atlassian.net/browse/CB-29572), this script is currently run unconfined, hence most of the files it produces have incorrect file contexts.
  * As an interim solution, execute `restorecon` for `/etc/salt-bootstrap/` and `/etc/salt-bootstrap/certs/` explicitly. This workaround can later be removed once the above ticket gets fixed.
* `cis-controls/playbooks/selinux.yml`: Remove TCP 7070 (`salt-bootstrap` plain HTTP) from `http_port_t`. This port is now labeled as `cdp_salt_bootstrap_port_t`.
