### PR TITLE
CB-29713: Allow the `cdp_salt_bootstrap_t` SELinux domain to bind and connect to ephemeral ports (>32768)

### DIFF
--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te
@@ -49,6 +49,8 @@ require {
 allow cdp_salt_bootstrap_t cdp_salt_bootstrap_port_t:tcp_socket { name_bind name_connect };
 allow cdp_salt_bootstrap_t self:tcp_socket { accept bind connect create getattr getopt listen setopt };
 corenet_tcp_bind_generic_node(cdp_salt_bootstrap_t)
+corenet_tcp_bind_all_ephemeral_ports(cdp_salt_bootstrap_t)
+corenet_tcp_connect_all_ephemeral_ports(cdp_salt_bootstrap_t)
 dev_read_sysfs(cdp_salt_bootstrap_t)
 kernel_read_net_sysctls(cdp_salt_bootstrap_t)
 kernel_search_network_sysctl(cdp_salt_bootstrap_t)


### PR DESCRIPTION
## Description

The saltboot SELinux policy didn't allow the saltboot SELinux domain access to the ephemeral ports. This issue was missed because port related denies are not captured in the audit logs, and the issue only came up in an E2E test with SELinux in Enforcing mode. The two added lines to the policy allow the domain to bind and connect to ephemeral port types.

## How Has This Been Tested?

The freeipa and prewarm image have both been manually tested in Enforcing mode. In Permissive mode, the issue described in the ticket, does not come up.

- [x] Runtime image burning (per provider)
AWS: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7422/
- [x] Runtime image validation (per provider)
AWS: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3375/
- [x] FreeIPA image burning (per provider)
AWS: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7421/
- [x] FreeIPA image validation (per provider)
AWS: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3374/
- [ ] Base image burning
- [ ] Base image validation

I did not burn images and run the validator for each provider, as these changes should not have any effect in Permissive mode. There should be no difference in the libraries, which install the policy itself, between the providers, so it is probably redundant to burn an image for each, but let me know if it is still desired!
