### PR TITLE
CB-29713: Allow the `cdp_salt_bootstrap_t` SELinux domain to read and write its own TCP sockets and reload systemd services

### DIFF
--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt-bootstrap/cdp-salt-bootstrap.te
@@ -44,10 +44,10 @@ miscfiles_read_localization(cdp_salt_bootstrap_t)
 #
 require {
     type cdp_salt_bootstrap_port_t;
-	class tcp_socket { accept bind connect create getattr getopt listen name_bind name_connect setopt };
+	class tcp_socket { accept bind connect create getattr getopt listen name_bind name_connect read setopt write };
 }
 allow cdp_salt_bootstrap_t cdp_salt_bootstrap_port_t:tcp_socket { name_bind name_connect };
-allow cdp_salt_bootstrap_t self:tcp_socket { accept bind connect create getattr getopt listen setopt };
+allow cdp_salt_bootstrap_t self:tcp_socket { accept bind connect create getattr getopt listen read setopt write };
 corenet_tcp_bind_generic_node(cdp_salt_bootstrap_t)
 corenet_tcp_bind_all_ephemeral_ports(cdp_salt_bootstrap_t)
 corenet_tcp_connect_all_ephemeral_ports(cdp_salt_bootstrap_t)
@@ -77,6 +77,7 @@ systemd_systemctl_domain(cdp_salt_bootstrap)
 fs_getattr_xattr_fs(cdp_salt_bootstrap_systemctl_t)
 kernel_read_proc_files(cdp_salt_bootstrap_systemctl_t)
 systemd_config_generic_services(cdp_salt_bootstrap_systemctl_t)
+init_reload_services(cdp_salt_bootstrap_systemctl_t)
 
 ########################################
 #


### PR DESCRIPTION
## Description

Fix a similar issue that was previously assumed to be fixed by #1155.
The previous issue reappeared in the E2E tests.

## How Has This Been Tested?

The affected E2E test was locally run using the below images.
The change only affects RHEL8 in SELinux enforcing mode, so running the validator for each provider is redundant, as the validator runs in permissive mode.

- [x] Runtime image burning (per provider)
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7549/
- [x] Runtime image validation (per provider)
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3439/
- [x] FreeIPA image burning (per provider)
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7543/
- [x] FreeIPA image validation (per provider)
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3436/
- [ ] Base image burning
- [ ] Base image validation

