### PR TITLE
CB-29572 - Create SELinux policy for user-data-helper.sh

### DIFF
--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -108,8 +108,6 @@ signKey: |-
  -----END PUBLIC KEY-----
 EOF
   chmod 600 /etc/salt-bootstrap/security-config.yml
-  # TODO Remove once CB-29572 is done
-  restorecon -R -v -i /etc/salt-bootstrap
 }
 
 create_certificates_certm() {
@@ -130,8 +128,6 @@ create_cert_for_saltboot_tls() {
   certm -d $CERT_ROOT_PATH ca generate -o=saltboot --overwrite
   certm -d $CERT_ROOT_PATH server generate -o=saltboot --cert $CERT_ROOT_PATH/saltboot.pem --key $CERT_ROOT_PATH/saltboot-key.pem --overwrite
   rm $CERT_ROOT_PATH/ca-key.pem
-  # TODO Remove once CB-29572 is done
-  restorecon -R -v -i $CERT_ROOT_PATH
 }
 
 start_nginx() {

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.fc
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.fc
@@ -1,0 +1,5 @@
+# Exec
+/usr/bin/user-data-helper.sh            --  gen_context(system_u:object_r:cdp_user_data_helper_exec_t,s0)
+
+# Log
+/var/log/user-data.log                  --  gen_context(system_u:object_r:cdp_user_data_helper_log_t,s0)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.restorecon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.restorecon
@@ -1,0 +1,1 @@
+/usr/bin/user-data-helper.sh

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.te
@@ -1,0 +1,37 @@
+policy_module(cdp-user-data-helper, 1.0.0)
+
+# Define the domain and its entry point
+type cdp_user_data_helper_t;
+type cdp_user_data_helper_exec_t;
+domain_type(cdp_user_data_helper_t)
+domain_entry_file(cdp_user_data_helper_t, cdp_user_data_helper_exec_t)
+
+# Allow system_r to use the cdp_user_data_helper_t domain and transition to it when executing a cdp_user_data_helper_exec_t file
+gen_require(`
+    role system_r;
+    role unconfined_r;
+')
+role system_r types cdp_user_data_helper_t;
+role_transition unconfined_r cdp_user_data_helper_exec_t system_r;
+
+# Allow the unconfined_t domain to automatically transition to the cdp_user_data_helper_t domain
+gen_require(`
+    type unconfined_t;
+')
+domtrans_pattern(unconfined_t, cdp_user_data_helper_exec_t, cdp_user_data_helper_t)
+
+type cdp_user_data_helper_log_t;
+logging_log_file(cdp_user_data_helper_log_t)
+
+gen_require(`
+    type cloud_init_t, var_log_t;
+    type cdp_salt_bootstrap_etc_t, cdp_salt_bootstrap_cert_t, etc_t;
+')
+
+filetrans_pattern(cloud_init_t, var_log_t, cdp_user_data_helper_log_t, file, "user-data.log")
+filetrans_pattern(cloud_init_t, etc_t, cdp_salt_bootstrap_etc_t, dir, "salt-bootstrap")
+filetrans_pattern(cloud_init_t, cdp_salt_bootstrap_etc_t, cdp_salt_bootstrap_etc_t, file, "security-config.yml")
+filetrans_pattern(cloud_init_t, cdp_salt_bootstrap_etc_t, cdp_salt_bootstrap_cert_t, dir, "certs")
+filetrans_pattern(cloud_init_t, cdp_salt_bootstrap_cert_t, cdp_salt_bootstrap_cert_t, file, "ca.pem")
+filetrans_pattern(cloud_init_t, cdp_salt_bootstrap_cert_t, cdp_salt_bootstrap_cert_t, file, "saltboot-key.pem")
+filetrans_pattern(cloud_init_t, cdp_salt_bootstrap_cert_t, cdp_salt_bootstrap_cert_t, file, "saltboot.pem")

--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -108,6 +108,33 @@
     - mode: 644
     - makedirs: True
 
+/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.fc:
+  file.managed:
+    - name: /etc/selinux/cdp/user-data-helper/cdp-user-data-helper.fc
+    - source: salt://{{ slspath }}/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.fc
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.restorecon:
+  file.managed:
+    - name: /etc/selinux/cdp/user-data-helper/cdp-user-data-helper.restorecon
+    - source: salt://{{ slspath }}/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.restorecon
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.te:
+  file.managed:
+    - name: /etc/selinux/cdp/user-data-helper/cdp-user-data-helper.te
+    - source: salt://{{ slspath }}/etc/selinux/cdp/user-data-helper/cdp-user-data-helper.te
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+
 /etc/selinux/cdp/install-cdp-policies.sh:
   file.managed:
     - name: /etc/selinux/cdp/install-cdp-policies.sh


### PR DESCRIPTION
## Description

Based on the obversation of [this commit](https://github.com/hortonworks/cloudbreak-images/commit/0055cda3700cba81c7014984487ea8e7b1943b86#diff-a32984e3bc0b3bc6386e001507f51eb3b2116f7cd9266a61ff1d9ffaa62be817): this script is currently run unconfined, hence most of the files it produces have incorrect file contexts. As an interim solution, execute `restorecon` for `/etc/salt-bootstrap/` and `/etc/salt-bootstrap/certs/` explicitly. This workaround can later be removed once the above ticket gets fixed.

Files that are created by this script and get bad context:

/var/log/user-data.log

/etc/salt-bootstrap/security-config.yml

/etc/salt-bootstrap/certs/ca.pem

/etc/salt-bootstrap/certs/saltboot-key.pem

/etc/salt-bootstrap/certs/saltboot.pem

## How Has This Been Tested?

The freeIPA and prewarm image have both been manually tested in Enforcing mode by starting a freeIPA, a datalake and a datahub.

- [x] Runtime image burning (per provider)
        AWS: [http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7701](http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7701)
- [x] Runtime image validation (per provider)
        AWS: [http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3515](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3515)
- [x] FreeIPA image burning (per provider)
        AWS: [http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7700](http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7700)
- [x] FreeIPA image validation (per provider)
        AWS: [http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3513](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3513)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.