### PR TITLE
Cb 29975

### DIFF
--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -83,6 +83,11 @@ packer_in_container() {
     JUMPGATE_AGENT_GBN=$(curl -Ls "https://release.infra.cloudera.com/hwre-api/latestcompiledbuild?stack=JUMPGATE&release=$JUMPGATE_AGENT_VERSION" --fail | jq -r '.gbn')
   fi
 
+  # Fallback needed because apparently the fact something's on archive doesn't mean it has a proper GBN in the builddb...
+  if [ -z "$JUMPGATE_AGENT_GBN" ]; then
+    JUMPGATE_AGENT_GBN="1234567890"
+  fi
+
   if ! [[ $METERING_AGENT_RPM_URL =~ ^http.*rpm$ ]]; then
     export METERING_AGENT_RPM_URL=$DEFAULT_METERING_AGENT_RPM_URL
   fi

--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -66,11 +66,9 @@ packer_in_container() {
       exit 1
     fi
 
-    # FIXME when arm64 builds on archive are available
-    export DEFAULT_JUMPGATE_AGENT_RPM_URL="http://cloudera-build-2-us-west-2.vpc.cloudera.com/s3/build/68456815/jumpgate/3.x/redhat8/yum/jumpgate-agent-3.13.0-b38.aarch64.rpm"
-    # FIXME: This is needed because right now we're adding an unofficial release of jumpgate agent to arm64 images
-    JUMPGATE_AGENT_GBN="1234567890"
+    export DEFAULT_JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.13.0/jumpgate-agent.aarch64.rpm"
 
+    # FIXME when arm64 builds on archive are available
     export DEFAULT_METERING_AGENT_RPM_URL=""
   fi
 
@@ -82,6 +80,7 @@ packer_in_container() {
     ## Download the jumpgate-agent rpm, get the version and call REDB to lookup the GBN
     wget $JUMPGATE_AGENT_RPM_URL
     JUMPGATE_AGENT_VERSION=$(rpm -qp --queryformat '%{VERSION}' ${JUMPGATE_AGENT_RPM_URL##*/})
+    JUMPGATE_AGENT_GBN=$(curl -Ls "https://release.infra.cloudera.com/hwre-api/latestcompiledbuild?stack=JUMPGATE&release=$JUMPGATE_AGENT_VERSION" --fail | jq -r '.gbn')
   fi
 
   if ! [[ $METERING_AGENT_RPM_URL =~ ^http.*rpm$ ]]; then


### PR DESCRIPTION
Without this commit, ARM builds currently fail like this:

http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7796/console

with this, they won't.