### PR TITLE
CB-29975: Added fallback for malformed jumpgate agent version numbers

### DIFF
--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -79,13 +79,8 @@ packer_in_container() {
   if [ -n "$JUMPGATE_AGENT_RPM_URL" ]; then
     ## Download the jumpgate-agent rpm, get the version and call REDB to lookup the GBN
     wget $JUMPGATE_AGENT_RPM_URL
-    JUMPGATE_AGENT_VERSION=$(rpm -qp --queryformat '%{VERSION}' ${JUMPGATE_AGENT_RPM_URL##*/})
+    JUMPGATE_AGENT_VERSION=$(rpm -qp --queryformat '%{VERSION}' ${JUMPGATE_AGENT_RPM_URL##*/} | sed s/~/-/)
     JUMPGATE_AGENT_GBN=$(curl -Ls "https://release.infra.cloudera.com/hwre-api/latestcompiledbuild?stack=JUMPGATE&release=$JUMPGATE_AGENT_VERSION" --fail | jq -r '.gbn')
-  fi
-
-  # Fallback needed because apparently the fact something's on archive doesn't mean it has a proper GBN in the builddb...
-  if [ -z "$JUMPGATE_AGENT_GBN" ]; then
-    JUMPGATE_AGENT_GBN="1234567890"
   fi
 
   if ! [[ $METERING_AGENT_RPM_URL =~ ^http.*rpm$ ]]; then


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider)
  - Azure - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7805/
- [ ] Runtime image validation (per provider)
- [x] FreeIPA image burning (per provider)
  - AWS arm64 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7803/
  - AWS x86 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7804/
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.