### PR TITLE
CB-30062: More space required for 7.3.1 on AWS Gov

### DIFF
--- a/scripts/get-image-size.sh
+++ b/scripts/get-image-size.sh
@@ -18,7 +18,9 @@ else
     # runtime image
     compare_version $STACK_VERSION 7.2.18
     COMP_RESULT=$?
-    if [[ "$CLOUD_PROVIDER" == "Azure" ]]; then
+    if [[ "$CLOUD_PROVIDER" == "AWS_GOV" ]]; then
+      IMAGE_SIZE=72
+    elif [[ "$CLOUD_PROVIDER" == "Azure" ]]; then
       IMAGE_SIZE=75
     elif [[ $COMP_RESULT -lt 2 ]]; then
       # stack version >= 7.2.18


### PR DESCRIPTION
This is for AWS Gov 7.3.1.x POC only. Validation fails at the moment, but that is expected. Burning is successful though: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7937/