### PR TITLE
CB-29337: Added Make and Packer opts for RHEL9

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -225,6 +225,64 @@
       "vpc_id": "{{ user `vpc_id`}}"
     },
     {
+      "name": "aws-redhat9",
+      "type": "amazon-ebs",
+      "region": "us-west-1",
+      "ssh_pty": true,
+      "source_ami": "{{ user `aws_source_ami` }}",
+      "instance_type": "{{ user `aws_instance_type` }}",
+      "ssh_username": "ec2-user",
+      "ena_support": true,
+      "skip_region_validation": true,
+      "tags": {
+        "builder": "packer",
+        "version": "{{user `version`}}",
+        "cb-creation-timestamp": "{{timestamp}}",
+        "owner": "{{ user `image_owner` }}",
+        "Customer Delivered": "{{user `tag_customer_delivered`}}",
+        "Name": "{{ user `image_name`}}"
+      },
+      "run_tags": {
+        "owner": "{{ user `image_owner` }}",
+        "Name": "Packer Builder"
+      },
+      "snapshot_users": "{{ user `aws_snapshot_users` }}",
+      "snapshot_groups": "{{ user `aws_snapshot_groups` }}",
+      "ami_groups": "{{ user `aws_ami_groups` }}",
+      "ami_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "{{user `image_size`}}"
+        },
+        {
+          "device_name": "/dev/sda2",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "50",
+          "no_device": true
+        }
+      ],
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "{{user `image_size`}}"
+        },
+        {
+          "device_name": "/dev/sda2",
+          "volume_type": "gp2",
+          "delete_on_termination": true,
+          "volume_size": "50"
+        }
+      ],
+      "ami_name": "{{ user `image_name`}}",
+      "subnet_id": "{{ user `subnet_id`}}",
+      "vpc_id": "{{ user `vpc_id`}}"
+    },
+    {
       "name": "aws-gov-redhat8",
       "type": "amazon-ebs",
       "region": "us-gov-west-1",
@@ -432,6 +490,49 @@
       }
     },
     {
+      "name": "arm-redhat9",
+      "type": "azure-arm",
+      "communicator": "ssh",
+      "client_id": "{{user `client_id`}}",
+      "client_secret": "{{user `client_secret`}}",
+      "subscription_id": "{{user `subscription_id`}}",
+      "tenant_id": "{{user `tenant_id`}}",
+      "resource_group_name": "{{user `resource_group_name`}}",
+      "storage_account": "{{user `storage_account`}}",
+      "build_resource_group_name": "{{user `build_resource_group_name`}}",
+      "capture_container_name": "packer",
+      "capture_name_prefix": "{{user `image_name`}}",
+      "image_url": "{{ user `azure_image_vhd` }}",
+      "image_publisher": "{{user `azure_image_publisher`}}",
+      "image_offer": "{{user `azure_image_offer`}}",
+      "image_sku": "{{user `azure_image_sku`}}",
+      "image_version": "{{user `azure_image_version`}}",
+      "ssh_pty": "true",
+      "username": "{{user `os_user`}}",
+      "os_type": "Linux",
+      "ssh_username": "centos",
+      "ssh_password": "{{user `ssh_password`}}",
+      "location": "{{user `arm_build_region`}}",
+      "vm_size": "{{ user `azure_instance_type` }}",
+      "os_disk_size_gb": "{{user `image_size`}}",
+      "virtual_network_resource_group_name":"{{user `virtual_network_resource_group_name`}}",
+      "virtual_network_name": "{{user `vpc_id`}}",
+      "virtual_network_subnet_name": "{{user `subnet_id`}}",
+      "private_virtual_network_with_public_ip": "{{user `private_virtual_network_with_public_ip`}}",
+      "azure_tags": {
+        "builder": "packer",
+        "version": "{{user `version`}}",
+        "cb-creation-timestamp": "{{timestamp}}",
+        "Owner": "{{ user `image_owner` }}",
+        "Customer Delivered": "{{user `tag_customer_delivered`}}"
+      },
+      "plan_info": {
+        "plan_name": "{{user `azure_image_sku`}}",
+        "plan_product": "{{user `azure_image_offer`}}",
+        "plan_publisher": "redhat"
+      }
+    },
+    {
       "name": "gc-centos7",
       "type": "googlecompute",
       "disable_default_service_account" : true,
@@ -463,6 +564,44 @@
     },
     {
       "name": "gc-redhat8",
+      "type": "googlecompute",
+      "disable_default_service_account" : true,
+      "account_file": "{{user `gcp_account_file`}}",
+      "source_image": "{{user `gcp_source_image`}}",
+      "source_image_project_id": "rhel-byos-cloud",
+      "zone": "us-west2-a",
+      "project_id": "gcp-cdp-cb-images",
+      "network_project_id": "gcp-eng-network-enterprise",
+      "ssh_username": "centos",
+      "ssh_pty": "true",
+      "machine_type": "{{ user `gcp_instance_type` }}",
+      "preemptible": false,
+      "omit_external_ip": "true",
+      "use_internal_ip": "true",
+      "network": "{{user `vpc_id`}}",
+      "subnetwork": "{{user `subnet_id`}}",
+      "image_name": "{{user `image_name`}}",
+      "disk_size": "{{user `image_size`}}",
+      "state_timeout": "15m",
+      "disk_attachment": [
+        {
+          "volume_size": 50,
+          "volume_type": "pd-standard",
+          "device_name": "tmp"
+        }
+      ],
+      "tags": [
+        "builder--packer",
+        "cb-creation-timestamp--{{timestamp}}",
+        "owner--{{ user `image_owner` | clean_resource_name }}",
+        "customer-delivered--{{user `tag_customer_delivered` | clean_resource_name}}",
+        "gcp-dev-cloudbreak-ingress-internet-deny",
+        "gcp-dev-cloudbreak-egress-internet-allow",
+        "gcp-dev-cloudbreak-ingress-rfc1918-allow"
+      ]
+    },
+    {
+      "name": "gc-redhat9",
       "type": "googlecompute",
       "disable_default_service_account" : true,
       "account_file": "{{user `gcp_account_file`}}",


### PR DESCRIPTION
This is just the basics, it can be safely merged as it has zero effect on existing RHEL 8 image burning.

Image burning can be started with this, but it's not enough to have full RHEL 9 support. Example:

http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/7955/console
