### PR TITLE
CB-30121 Noexec tmp for CDP feature breaks AWS images

### DIFF
--- a/saltstack/final/salt/cis-controls/redhat8.sls
+++ b/saltstack/final/salt/cis-controls/redhat8.sls
@@ -126,7 +126,7 @@ add_cis_control_sh:
     - source: salt://cis-controls/scripts/cis_control.sh
     - template: jinja
     - defaults:
-{% if salt['environ.get']('IMAGE_BURNING_TYPE') == 'prewarm' or salt['environ.get']('STACK_VERSION').split('.') | map('int') | list >= '7.3.1'.split('.') | map('int') | list %}
+{% if salt['environ.get']('IMAGE_BURNING_TYPE') == 'prewarm' and salt['environ.get']('STACK_VERSION').split('.') | map('int') | list <= '7.3.1'.split('.') | map('int') | list %}
         additional_tags: ",mount_option_tmp_noexec"
 {% else %}
         additional_tags: ""

--- a/saltstack/final/salt/cis-controls/scripts/cis_control.sh
+++ b/saltstack/final/salt/cis-controls/scripts/cis_control.sh
@@ -38,9 +38,9 @@ if [ "${CLOUD_PROVIDER}" == "Azure" ]; then
     if [ "${STIG_ENABLED}" != "True" ]; then
         SKIP_TAGS+=",kernel_module_udf_disabled"
     fi
-    # disable tmp noexec as CM fails to start REGIONSERVER. Can be removed when CM side fix is done by OPSAPS-68448
-    SKIP_TAGS+="{{ additional_tags }}"
 fi
+
+SKIP_TAGS+="{{ additional_tags }}"
 
 #Install and download what we need for the hardening
 python3 -m virtualenv --python="/usr/bin/python3.8" $ANSIBLE_PATH


### PR DESCRIPTION
## Description

**Noexec tmp for CDP feature breaks AWS images**
This feature should be valid only for images >= 7.3.1 version. Currently it is valid on all aws images as the SKIP tag for noexec skipping is not assigned.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ x] Runtime image burning (per provider)
- [ x] Runtime image validation (per provider)
- [ -] FreeIPA image burning (per provider)
- [ -] FreeIPA image validation (per provider)
- [ -] Base image burning
- [ -] Base image validation

7.3.1.500 GCP:
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8012/ :white_check_mark:
5b2ebe94-fe82-4e92-822b-e76b42e04fe4
Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3678/ :white_check_mark:
Extended:
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3686/  :white_check_mark:
7.3.1.500 Azure:
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8013/ :white_check_mark:
6060af51-9b66-4bc1-8207-7fb1629701e0
Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3674/ :white_check_mark:
Extended:
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3682/ :white_check_mark:
7.3.2.0 GCP:
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8014/ :white_check_mark:
98b151c7-a389-48be-8011-8ca14ff7f522
Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3675/ :white_check_mark:
Extended:
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3681/ :white_check_mark:
7.3.2.0 Azure:
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8015/ :white_check_mark:
cfe22a99-358d-4748-9274-7e87ba0379b5
Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3673/ :gitlab_fail_triggered:
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3677/ :white_check_mark:
Extended:
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3685/ :white_check_mark: (edited) 