### PR TITLE
CB-29337: Enhancements needed for building base images with RHEL 9

### DIFF
--- a/saltstack/base/salt/chrony/init.sls
+++ b/saltstack/base/salt/chrony/init.sls
@@ -1,4 +1,4 @@
-{% if pillar['OS'] == 'redhat8' %}
+{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
 chronyReinstall:
   cmd.run:
     - name: dnf reinstall chrony -y

--- a/saltstack/base/salt/cloud-init/init.sls
+++ b/saltstack/base/salt/cloud-init/init.sls
@@ -56,7 +56,7 @@ create_cloud-init_service_files:
     - source: salt://{{ slspath }}/etc/systemd/system/cloud-init.service
 {% endif %}
 
-{% if salt['environ.get']('OS') == 'redhat8' %}
+{% if salt['environ.get']('OS') == 'redhat8' or salt['environ.get']('OS') == 'redhat9' %}
 /etc/cloud/cloud.cfg.d/99-disable-ipv6.cfg:
   file.managed:
     - user: root

--- a/saltstack/base/salt/mount/init.sls
+++ b/saltstack/base/salt/mount/init.sls
@@ -15,7 +15,7 @@ mount-nfs-sequentially-service-start:
     - reload: True
     - require:
       - file: mount-nfs-sequentially-service-file
-{% elif pillar['OS'] == 'redhat8' %}
+{% elif pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
 format-additional-disk:
   cmd.run:
     - name: mkfs.xfs /dev/nvme1n1

--- a/saltstack/base/salt/prerequisites/corkscrew.sls
+++ b/saltstack/base/salt/prerequisites/corkscrew.sls
@@ -19,7 +19,7 @@ create_corkscrew_softlink:
   cmd.run:
     - name: ln -s /usr/local/bin/corkscrew /usr/bin/corkscrew
 
-{% elif pillar['OS'] == 'redhat8' %}
+{% elif pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
 
 download_corkscrew_from_s3:
   cmd.run:

--- a/saltstack/base/salt/prerequisites/firewall.sls
+++ b/saltstack/base/salt/prerequisites/firewall.sls
@@ -1,4 +1,4 @@
-{% if pillar['OS'] == 'redhat7' or pillar['OS'] == 'redhat8' %}
+{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
 
 disable_firewalld_service:
 {% if pillar['subtype'] != 'Docker' %}

--- a/saltstack/base/salt/prerequisites/geoclue.sls
+++ b/saltstack/base/salt/prerequisites/geoclue.sls
@@ -1,0 +1,24 @@
+disable_geoclue_service:
+  service.masked:
+    - name: geoclue
+
+echo_geoclue_user_and_group:
+  cmd.run:
+    - name: |
+        id -u geoclue
+        id -g geoclue
+# move_geoclue_user_and_group:
+#   cmd.run:
+#     - name: |
+#        usermod -u 10002 geoclue
+#        groupmod -g 10002 geoclue
+#        find / -not -path "/proc/*" -user 987 -exec chown -h geoclue {} \;
+#        find / -not -path "/proc/*" -group 987  -exec chgrp -h geoclue {} \;
+
+geoclue_info:
+  cmd.run:
+    - name: dnf repoquery --alldeps --recursive --whatrequires geoclue2
+
+remove_geoclue:
+  pkg.removed:
+    - name: geoclue2

--- a/saltstack/base/salt/prerequisites/init.sls
+++ b/saltstack/base/salt/prerequisites/init.sls
@@ -1,6 +1,9 @@
 include:
   - {{ slspath }}.path
   - {{ slspath }}.setroubleshoot
+{% if pillar['OS'] == 'redhat9' %}
+  - {{ slspath }}.geoclue
+{% endif %}
   - {{ slspath }}.user_uid
   - {{ slspath }}.subscription-manager
   - {{ slspath }}.repository

--- a/saltstack/base/salt/prerequisites/jinja.sls
+++ b/saltstack/base/salt/prerequisites/jinja.sls
@@ -1,4 +1,4 @@
-{% if pillar['OS'] == 'redhat8' %}  
+{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}  
 install_jinja2:
   pip.installed:
     - name: jinja2

--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -15,8 +15,8 @@ remove_dead_repos_again:
     - name: sudo rm -rf /etc/yum.repos.d/CentOS*.repo
 {% endif %}
 
-{% if pillar['OS'] == 'redhat8' %}
-remove_unused_rhel8_packages:
+{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
+remove_unused_rhel_packages:
   pkg.removed:
     - pkgs:
       # Apparently we have this on Azure RHEL8 images by default and it causes problems...
@@ -38,7 +38,7 @@ packages_install:
       - curl
       - net-tools
       - git
-  {% if pillar['OS'] != 'redhat8' %}  
+  {% if pillar['OS'] != 'redhat8' and pillar['OS'] != 'redhat9' %}  
       - ntp
       - deltarpm
   {% endif %}
@@ -47,7 +47,7 @@ packages_install:
   {% if grains['os_family'] == 'RedHat' %}
       - snappy
       - cloud-utils-growpart
-    {% if pillar['OS'] != 'redhat7' and pillar['OS'] != 'redhat8' %}
+    {% if pillar['OS'] != 'redhat8' and pillar['OS'] != 'redhat9' %}
       - snappy-devel
     {% endif %}
       - bind-utils
@@ -57,7 +57,7 @@ packages_install:
     {% if pillar['OS'] == 'redhat8' and pillar['subtype'] == 'Docker' and salt['environ.get']('RHEL_VERSION') == '8.8' %}
       - NetworkManager
     {% endif %}
-    {% if pillar['OS'] == 'redhat8' %}
+    {% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
       - sos
       {% if pillar['subtype'] != 'Docker' %}
       - setools-console

--- a/saltstack/base/salt/prerequisites/repository.sls
+++ b/saltstack/base/salt/prerequisites/repository.sls
@@ -1,4 +1,4 @@
-{% if pillar['OS'] == 'redhat7' or pillar['OS'] == 'redhat8' %}
+{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
 
 remove_duplicates_from_yum_conf:
   cmd.run:

--- a/saltstack/base/salt/prerequisites/selinux.sls
+++ b/saltstack/base/salt/prerequisites/selinux.sls
@@ -5,7 +5,7 @@ install_selinux_module_dependecies:
     - pkgs:
       - policycoreutils
       - selinux-policy-devel
-{% if pillar['OS'] == 'redhat8' %}
+{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
       - policycoreutils-python-utils
 {% else %}
       - policycoreutils-python

--- a/saltstack/base/salt/prerequisites/setroubleshoot.sls
+++ b/saltstack/base/salt/prerequisites/setroubleshoot.sls
@@ -1,6 +1,6 @@
 # setroubleshoot breaks SCM group creation on Azure + it is unwanted for CIS compliance
 
-{% if salt['environ.get']('OS') == 'redhat8' and salt['environ.get']('RHEL_VERSION') == '8.10' and salt['environ.get']('CLOUD_PROVIDER') == 'Azure' %}
+{% if salt['environ.get']('OS') == 'redhat9' or (salt['environ.get']('OS') == 'redhat8' and salt['environ.get']('RHEL_VERSION') == '8.10') and salt['environ.get']('CLOUD_PROVIDER') == 'Azure' %}
 remove_setroubleshoot_packages:
   pkg.removed:
     - pkgs:

--- a/saltstack/base/salt/prerequisites/user_uid.sls
+++ b/saltstack/base/salt/prerequisites/user_uid.sls
@@ -10,7 +10,7 @@
   'cloudera_scm_group': '987',
 } %}
 
-{% if pillar['OS'] == 'redhat8' %}
+{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
 # sssd has the needed uid/gid for cloudera-scm so it has to be modified
 
 change_sssd_ids:

--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -253,7 +253,7 @@ resize_partitions() {
       lvextend -L35G -r /dev/mapper/rootvg-optlv
       lvextend -L12G -r /dev/mapper/rootvg-varlv
       lvextend -L12G -r /dev/mapper/rootvg-tmplv
-    elif [ $OS == "redhat8" ]; then
+    elif [ $OS == "redhat8" ] || [ $OS == "redhat9" ]; then
       PV_NAME=$(pvs --noheadings --rows | head -1 | tr -d '[:space:]')
       DISK=${PV_NAME//[0-9]/}
       PARTITION=${PV_NAME//[^0-9]/}

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -9,7 +9,7 @@ base:
     - python3
     - salt-bootstrap
     - salt
-{% if pillar['subtype'] != 'Docker' and pillar['OS'] == 'redhat8' %}
+{% if pillar['subtype'] != 'Docker' and (pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9') %}
     - selinux
 {% endif %}
 {% if salt['environ.get']('CUSTOM_IMAGE_TYPE') != 'freeipa' %}
@@ -26,6 +26,6 @@ base:
     - luks
     - userdata-secrets
 {% endif %}
-{% if pillar['subtype'] != 'Docker' or pillar['OS'] == 'redhat8' %}
+{% if pillar['subtype'] != 'Docker' or pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
     - chrony
 {% endif %}

--- a/saltstack/final/salt/cleanup/kernel.sls
+++ b/saltstack/final/salt/cleanup/kernel.sls
@@ -10,7 +10,7 @@ list_installed_kernels_before_cleanup:
 
 package_cleanup_oldkernels:
   cmd.run:
-{% if pillar['OS'] != 'redhat8' %}
+{% if pillar['OS'] != 'redhat8' and pillar['OS'] != 'redhat9' %}
     - name: package-cleanup --oldkernels --count=1 -y
 {% else %}
     - name: dnf -y remove --oldinstallonly --setopt installonly_limit=2 kernel

--- a/saltstack/final/salt/krb5/init.sls
+++ b/saltstack/final/salt/krb5/init.sls
@@ -1,6 +1,6 @@
-# Disable new kerberos caching behavior on RHEL8, 
+# Disable new kerberos caching behavior on RHEL 8/9, 
 # so the logic will be the same as it is on CentOS 7
-{% if pillar['OS'] == 'redhat8' %}
+{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
 disable_kcm_ccache:
   file.absent:
     - name: /etc/krb5.conf.d/kcm_default_ccache

--- a/saltstack/freeipa/salt/freeipa/init.sls
+++ b/saltstack/freeipa/salt/freeipa/init.sls
@@ -30,7 +30,7 @@ freeipa-cipa-venv-wrapper:
         deactivate
 
 freeipa-install:
-{% if pillar['OS'] != 'redhat8' %}  
+{% if pillar['OS'] != 'redhat8' and pillar['OS'] != 'redhat9' %}
   pkg.installed:
     - pkgs:
         - ntp

--- a/saltstack/hortonworks/pillar/java/init.sls
+++ b/saltstack/hortonworks/pillar/java/init.sls
@@ -8,7 +8,7 @@ openjdk_packages:
   - java-1.8.0-openjdk-devel
   - java-11-openjdk-headless
   - java-11-openjdk-devel
-{% elif salt['environ.get']('OS') == 'redhat8' %}
+{% elif salt['environ.get']('OS') == 'redhat8' or salt['environ.get']('OS') == 'redhat9' %}
   {% if salt['environ.get']('ARCHITECTURE') != 'arm64' %}
   - java-1.8.0-openjdk-headless
   - java-1.8.0-openjdk-devel

--- a/saltstack/hortonworks/salt/java/init.sls
+++ b/saltstack/hortonworks/salt/java/init.sls
@@ -73,7 +73,7 @@ delete_rhel8_repo:
 {% endif %}
 {% endif %}
 
-{% if salt['environ.get']('OS') == 'redhat8' %}
+{% if salt['environ.get']('OS') == 'redhat8' or salt['environ.get']('OS') == 'redhat9' %}
 {% if salt['environ.get']('DEFAULT_JAVA_MAJOR_VERSION') == '17' %}
 set_openjdk_version_17:
   cmd.run:

--- a/scripts/check-image-regions.sh
+++ b/scripts/check-image-regions.sh
@@ -54,6 +54,9 @@ case "$CLOUD_PROVIDER" in
       redhat8)
         ALL_REGIONS="default"
         ;;
+      redhat9)
+        ALL_REGIONS="default"
+        ;;
       *)
         echo "Unexpected OS: $OS"
         exit 1

--- a/scripts/generate-tags.sh
+++ b/scripts/generate-tags.sh
@@ -6,7 +6,7 @@ if [[ -z "$TAGS" ]]; then
     TAGS="{}"
 fi
 
-if [[ "$OS" == "redhat8" ]]; then
+if [[ "$OS" == "redhat8" || "$OS" == "redhat9" ]]; then
     FIPSMODE=enabled
     fips-mode-setup --is-enabled || FIPSMODE=disabled
 

--- a/scripts/repo_cleanup.sh
+++ b/scripts/repo_cleanup.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -xe
 
-if [[ "${OS}" == "redhat8" && "$CLOUD_PROVIDER" != "AWS_GOV" ]] ; then
-    if [[ "${IMAGE_BURNING_TYPE}" == "base" ]] ; then
-        RHEL_VERSION=$(cat /etc/redhat-release | grep -oP "[0-9\.]*")
-        RHEL_VERSION=${RHEL_VERSION/.0/}
-        REPO_FILE=rhel${RHEL_VERSION}_cldr_mirrors.repo
-        find /etc/yum.repos.d -type f ! -name $REPO_FILE -delete
-    else
-        find /etc/yum.repos.d -type f -delete
+if [[ "$CLOUD_PROVIDER" != "AWS_GOV" ]] ; then
+    if [[ "${OS}" == "redhat8" || "${OS}" == "redhat9" ]] ; then
+        if [[ "${IMAGE_BURNING_TYPE}" == "base" ]] ; then
+            RHEL_VERSION=$(cat /etc/redhat-release | grep -oP "[0-9\.]*")
+            RHEL_VERSION=${RHEL_VERSION/.0/}
+            REPO_FILE=rhel${RHEL_VERSION}_cldr_mirrors.repo
+            find /etc/yum.repos.d -type f ! -name $REPO_FILE -delete
+        else
+            find /etc/yum.repos.d -type f -delete
+        fi
     fi
 fi

--- a/scripts/salt-final.sh
+++ b/scripts/salt-final.sh
@@ -21,7 +21,7 @@ function highstate {
   ${SALT_PATH}/bin/salt-call --no-color --local state.highstate saltenv=${saltenv} -l info --log-file=/tmp/salt-build-${saltenv}.log --log-file-level=info --config-dir=/tmp/saltstack/config
 }
 
-if [ "${OS}" == "redhat8" ] ; then
+if [[ "${OS}" == "redhat8" || "${OS}" == "redhat9" ]] ; then
   RHEL_VERSION=$(cat /etc/redhat-release | grep -oP "[0-9\.]*")
   export RHEL_VERSION=${RHEL_VERSION/.0/}
 fi

--- a/scripts/salt-setup.sh
+++ b/scripts/salt-setup.sh
@@ -101,7 +101,7 @@ function add_prewarmed_roles {
   fi
 }
 
-if [ "${OS}" == "redhat8" ] ; then
+if [[ "${OS}" == "redhat8" || "${OS}" == "redhat9" ]] ; then
   RHEL_VERSION=$(cat /etc/redhat-release | grep -oP "[0-9\.]*")
   export RHEL_VERSION=${RHEL_VERSION/.0/}
 fi

--- a/scripts/storage_setup.sh
+++ b/scripts/storage_setup.sh
@@ -18,7 +18,7 @@ if [ "${CLOUD_PROVIDER}" == "Azure" ] ; then
     echo w # Write changes
     ) | fdisk /dev/sda
     reboot
-  elif [ "${OS}" == "redhat8" ] ; then
+  elif [[ "${OS}" == "redhat8" || "${OS}" == "redhat9" ]] ; then
     PV_NAME=$(pvs --noheadings --rows | head -1 | tr -d '[:space:]')
     DISK=${PV_NAME//[0-9]/}
     PARTITION=${PV_NAME//[^0-9]/}


### PR DESCRIPTION
## Description

These changes are required for RHEL 9 support. 

## How Has This Been Tested?

SInce some of the packages are still missing, we can't test for a full RHEL 9 support. Instead, what we CAN test is that the changes have no effect on RHEL 8 / CentOS 7 builds, so they can be safely merged.

- [x] Runtime image burning (per provider)
  - AWS 7.3.2: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8009/
  - Azure 7.3.2: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8019/
  - GCP 7.3.2: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8017/
- [x] Runtime image validation (per provider)
  - AWS 7.3.2 Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3669/
  - AWS 7.3.2 Extended: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3672/
  - Azure 7.3.2 Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3683/
  - Azure 7.3.2 Extended: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3688/
  - GCP 7.3.2 Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3676/
  - GCP 7.3.2 Extended: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3690/
- [x] FreeIPA image burning (per provider)
  - AWS: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8023/
  - Azure: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8025/
  - GCP: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8024/
- [x] FreeIPA image validation (per provider)
  - AWS Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3693/
  - Azure Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3691/
  - GCP Basic: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3692/
  - AWS Extended: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3699/
  - Azure Extended: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3702/
  - GCP Extended: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3701/
- [x] Base image burning - covered by the above
- [x] Base image validation - covered by the above

Note: FreeIPA extended validation has a known failure: the AWS one fails because of CB-30104

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.