### PR TITLE
CB-29499: Create /etc/init.d for backward comp.

### DIFF
--- a/saltstack/base/salt/performance/thp.sls
+++ b/saltstack/base/salt/performance/thp.sls
@@ -1,3 +1,8 @@
+/etc/init.d:
+  file.directory:
+    - makedirs: True
+    - mode: 0755
+
 /etc/init.d/disable-thp:
   file.managed:
     - source:


### PR DESCRIPTION
## Description

The folder itself is part of a backward-compatibility mechanism that makes it possible to use the same script on older (CentOS 6, Ubuntu 15, etc.) and newer (RHEL 8+, etc). Linux versions alike regardless if they have upstart or systemd as a service bootstrapper mechanism. On RHEL 9 this folder is not only deprecated, but removed altogether which breaks the code. On the other hand, putting it back makes no harm at all and it already exists on CentOS 7 / RHEL 8, making this change essentially a NoOp on those two OSes.

## How Has This Been Tested?

It's a harmless changes, tested on RHEL 9 to see if it's syntactically correct and gets triggered properly - as described above, it's being ignored on CentOS 7 / RHEL 8 anyway.