### PR TITLE
CB-29393: Use an RHEL9 compatible build of cdp-infra-tools on RHEL9 images

### DIFF
--- a/saltstack/base/salt/telemetry/init.sls
+++ b/saltstack/base/salt/telemetry/init.sls
@@ -3,10 +3,15 @@
   {% set platform = platform ~ 'arm64' %}
 {% endif %}
 
+# TODO: Get rid of the whole "internal repo file" as soon as the RHEL 9 builds of cdp-infra-tools are on archive
 add_cdp_infra_tools_repo:
   file.managed:
     - name: /etc/yum.repos.d/cdp-infra-tools.repo
+{% if pillar['OS'] == 'redhat9' %}
+    - source: salt://telemetry/yum/cdp-infra-tools-internal.repo.j2
+{% else %}
     - source: salt://telemetry/yum/cdp-infra-tools.repo.j2
+{% endif %}
     - template: jinja
     - platform: "{{ platform }}"
 
@@ -29,6 +34,7 @@ remove_cdp_infra_tools_repo:
   file.absent:
     - name: /etc/yum.repos.d/cdp-infra-tools.repo
 
+# TODO: Why do we need this override? Do we still need this?
 {% if salt['environ.get']('CLOUD_PROVIDER') != "AWS_GOV" %}
 override_cdp_request_signer:
   cmd.run:

--- a/saltstack/base/salt/telemetry/yum/cdp-infra-tools-internal.repo.j2
+++ b/saltstack/base/salt/telemetry/yum/cdp-infra-tools-internal.repo.j2
@@ -1,0 +1,7 @@
+[cdp-infra-tools]
+name=CDP Infra Tools
+baseurl=https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/69373518/cdp-infra-tools/0.x/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/69373518/cdp-infra-tools/0.x/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins


### PR DESCRIPTION
To test this, you'll need to first merge https://github.com/hortonworks/cloudbreak-images/pull/1176 to master, then update this branch (or create a new one and cherry-pick this commit onto it!) as the error that PR fixes blocks image burning before the code modified in this PR could get executed.