### PR TITLE
CB-29393: Use an RHEL9 compatible build of cdp-infra-tools on RHEL9 images

### DIFF
--- a/saltstack/base/salt/telemetry/yum/cdp-infra-tools-internal.repo.j2
+++ b/saltstack/base/salt/telemetry/yum/cdp-infra-tools-internal.repo.j2
@@ -1,0 +1,7 @@
+[cdp-infra-tools]
+name=CDP Infra Tools
+baseurl=https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/69373518/cdp-infra-tools/0.x/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/69373518/cdp-infra-tools/0.x/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins


### PR DESCRIPTION
## Description

For now, we don't have RHEL 9 compatible builds of the cdp-infra-tools on archive, so an intermediate (or rather, "internal" :) ) solution is needed. Since the normal installation of these packages should handle RHEL9 properly, even with ARM, we'll be able to revert this whole thing once we've successfully tested the RHEL 9 build and it gets on Archive.

Note: this PR supersedes https://github.com/hortonworks/cloudbreak-images/pull/1177 

## How Has This Been Tested?

This PR has absolutely ZERO effect on any of the CentOS 7 and RHEL 8 images, so it's pointless to test them.

- [x] Runtime image burning (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] Runtime image validation (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] FreeIPA image burning (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] FreeIPA image validation (per provider) - for now, our RHEL 9 image burning is limited to base images
- [ ] Base image burning
  - AWS x86: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8094/
  - AWS ARM: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8093/ - RHEL 9 internal mirror is broken, so ARM64 image burning is blocked by RELENG-29558
  - Azure: there's nothing Azure-specific in this PR
  - GCP: there's nothing GCP-specific in this PR
- [x] Base image validation - for now, we only validate that the PRs solve image burning bugs as we're yet to reach the validation phase, which is currently blocked by these bugs.

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.