### PR TITLE
CB-29497: Disabled attempting to install iptables on RHEL 9

### DIFF
--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -42,7 +42,9 @@ packages_install:
       - ntp
       - deltarpm
   {% endif %}
+  {% if pillar['OS'] != 'redhat9' %}
       - iptables
+  {% endif %}
       - ruby
   {% if grains['os_family'] == 'RedHat' %}
       - snappy


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

This PR has absolutely ZERO effect on any of the CentOS 7 and RHEL 8 images, so it's pointless to test them.

- [x] Runtime image burning (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] Runtime image validation (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] FreeIPA image burning (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] FreeIPA image validation (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] Base image burning
  - AWS x86: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8095/
  - AWS ARM: RHEL 9 ARM internal mirror is broken, so ARM64 image burning is blocked by RELENG-29558
  - Azure: there's nothing Azure-specific in this PR
  - GCP: there's nothing GCP-specific in this PR
- [x] Base image validation - for now, we only validate that the PRs solve image burning bugs as we're yet to reach the validation phase, which is currently blocked by these bugs.

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.