### PR TITLE
CB-30169: Cleaned up Geoclue2 removal code (RHEL9 only)

### DIFF
--- a/saltstack/base/salt/prerequisites/geoclue.sls
+++ b/saltstack/base/salt/prerequisites/geoclue.sls
@@ -2,23 +2,6 @@ disable_geoclue_service:
   service.masked:
     - name: geoclue
 
-echo_geoclue_user_and_group:
-  cmd.run:
-    - name: |
-        id -u geoclue
-        id -g geoclue
-# move_geoclue_user_and_group:
-#   cmd.run:
-#     - name: |
-#        usermod -u 10002 geoclue
-#        groupmod -g 10002 geoclue
-#        find / -not -path "/proc/*" -user 987 -exec chown -h geoclue {} \;
-#        find / -not -path "/proc/*" -group 987  -exec chgrp -h geoclue {} \;
-
-geoclue_info:
-  cmd.run:
-    - name: dnf repoquery --alldeps --recursive --whatrequires geoclue2
-
 remove_geoclue:
   pkg.removed:
     - name: geoclue2


### PR DESCRIPTION
## Description

Cleans up some leftover trash code from https://github.com/hortonworks/cloudbreak-images/pull/1172

## How Has This Been Tested?

Zero. Zilch. Nada. :) This is just a code cleanup, basically it removes a bunch of echos and comments.

Okay, okay... I might have tested it here just to make it sure: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8096/

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.