### PR TITLE
CB-29496: Fix cloudera-scm uid/gid for RHEL9

### DIFF
--- a/saltstack/base/salt/prerequisites/user_uid.sls
+++ b/saltstack/base/salt/prerequisites/user_uid.sls
@@ -3,6 +3,16 @@
   'cloudera_scm_group': '988',
 } %}
 
+{% if (salt['environ.get']('CLOUD_PROVIDER') == 'AWS' or salt['environ.get']('CLOUD_PROVIDER') == 'GCP') and pillar['OS'] == 'redhat9' %}
+
+# pesign has the needed uid/gid for cloudera-scm so it has to be modified
+change_pesign_uid:
+  cmd.run:
+    - name: |
+        usermod -u 10001 pesign
+        find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h pesign {} \;
+{% endif %}
+
 {% if salt['environ.get']('CLOUD_PROVIDER') == 'Azure' %}
 
 {% set ids = {
@@ -10,9 +20,8 @@
   'cloudera_scm_group': '987',
 } %}
 
-{% if pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
+{% if pillar['OS'] == 'redhat8' %}
 # sssd has the needed uid/gid for cloudera-scm so it has to be modified
-
 change_sssd_ids:
   cmd.run:
     - name: |
@@ -20,7 +29,27 @@ change_sssd_ids:
         groupmod -g 10001 sssd
         find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h sssd {} \;
         find / -not -path "/proc/*" -group {{ ids.cloudera_scm_group }}  -exec chgrp -h sssd {} \;
+
+{% elif pillar['OS'] == 'redhat9' %}
+
+# pipewire has the needed gid for cloudera-scm so it has to be modified
+change_pipewire_ids:
+  cmd.run:
+    - name: |
+        groupmod -g 10001 pipewire
+        find / -not -path "/proc/*" -group {{ ids.cloudera_scm_group }} -exec chgrp -h pipewire {} \; ; exit 0
+
+# libstoragemgmt has the needed uid for cloudera-scm so it has to be removed
+remove_libstoragemgmt:
+  pkg.removed:
+    - name: libstoragemgmt
+
+remove_libstoragemgmt_user:
+  user.absent:
+    - name: libstoragemgmt
+
 {% endif %}
+
 {% endif %}
 
 create_cloudera_scm_group:


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

This PR has absolutely ZERO effect on any of the CentOS 7 and RHEL 8 images, so it's pointless to test them.

- [x] Runtime image burning (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] Runtime image validation (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] FreeIPA image burning (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] FreeIPA image validation (per provider) - for now, our RHEL 9 image burning is limited to base images
- [x] Base image burning
  - AWS x86: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8101/ - ✅ 
  - AWS ARM: RHEL 9 ARM internal mirror is broken, so ARM64 image burning is blocked by RELENG-29558
  - Azure: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8108/
  - GCP: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8109/ - ✅ 
- [x] Base image validation - for now, we only validate that the PRs solve image burning bugs as we're yet to reach the validation phase, which is currently blocked by these bugs.

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.