### PR TITLE
CB-1: Remove the file context rule for `/etc/krb5.conf` on RHEL9

### DIFF
--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -58,6 +58,14 @@
     - file_mode: 644
     - template: jinja
 
+{%- if pillar['OS'] == 'redhat9' %}
+remove_krb5_conf_file_context_rule:
+  file.line:
+    - name: /etc/selinux/cdp/kerberos/cdp-kerberos.fc
+    - match: '/etc/krb5\\\.conf\s+--\s+gen_context\(system_u:object_r:krb5_conf_t,s0\)'
+    - mode: delete
+{%- endif %}
+
 {%- if salt['environ.get']('CUSTOM_IMAGE_TYPE') != 'freeipa' %}
 /etc/selinux/cdp/postgresql/:
   file.recurse:


### PR DESCRIPTION
## Description

The built-in policy already includes this rule on RHEL9, so it conflicts when we try to define it ourselves.

## How Has This Been Tested?

Ran an image burning with the fix based on top of the `rhel9_azure_testing` branch: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8194/

Cherry-picked the fix back to this branch.

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.