### PR TITLE
CB-30181 Assume JDK 17 as the default on RHEL 9

### DIFF
--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -50,6 +50,10 @@ packer_in_container() {
   if [[ "$ARCHITECTURE" == "arm64" ]]; then
     export DEFAULT_JAVA_MAJOR_VERSION=17
   fi
+  # RHEL 9 has no support for JDK 8, not even for base images
+  if [[ "$OS" == "redhat9" ]]; then
+    export DEFAULT_JAVA_MAJOR_VERSION=17
+  fi
 
   if [[ "$ENABLE_POSTPROCESSORS" ]]; then
     echo "Postprocessors are enabled"


### PR DESCRIPTION
## Description

This PR is related to RHEL9 Base image production only and it has no effect on CentOS 7 and RHEL 8 images.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [x] Base image burning
- [x] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.