### PR TITLE
CB-30183: Fixed broken GPG verification

### DIFF
--- a/saltstack/final/salt/cis-controls/init.sls
+++ b/saltstack/final/salt/cis-controls/init.sls
@@ -1,6 +1,8 @@
 include:
   - {{ slspath }}.common
-{% if pillar['OS'] == 'redhat8' %}
+{% if pillar['OS'] == 'redhat9' %}
+  - {{ slspath }}.redhat9
+{% elif pillar['OS'] == 'redhat8' %}
   - {{ slspath }}.redhat8
 {% elif pillar['OS'] == 'centos7' %}
   - {{ slspath }}.centos7

--- a/saltstack/final/salt/cis-controls/redhat9.sls
+++ b/saltstack/final/salt/cis-controls/redhat9.sls
@@ -1,0 +1,12 @@
+# This is just a minimalist placeholder file that barely does anything besides forcing GPG checks on,
+# so verify.sls passes.
+#
+# TODO: We'll need a proper implementation of enforcing CIS controls - see https://cloudera.atlassian.net/browse/CB-29427
+
+gpgcheck_dump:
+  cmd.run:
+    - name: cat /etc/yum.repos.d/*
+
+gpgcheck_enforce:
+  cmd.run:
+    - name: sed -i 's/^gpgcheck=0/gpgcheck=1/' /etc/yum.repos.d/*.repo


### PR DESCRIPTION
## Description

This PR is related to RHEL9 Base image production only and it has no effect on CentOS 7 and RHEL 8 images.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider)
- [x] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [x] Base image burning
- [x] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.