### PR TITLE
CB-30176 Avoid installing PostgreSQL 11 on RHEL 9 images

### DIFF
--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -33,21 +33,36 @@ disable-pg16:
   pkgrepo.absent:
     - name: pgdg16
 
-install-postgres:
+disable-postgresql-module:
   cmd.run:
     - name: |
         dnf module -y disable postgresql
         dnf clean all
-{% if pillar['subtype'] != 'Docker' %}
-        dnf -y install postgresql11-server postgresql11 postgresql11-devel {{ postgres_install_flags }}
-{% else %}
-        dnf -y remove postgresql11-server postgresql11 postgresql11-devel
-{% endif %}
-        dnf -y install postgresql14-server postgresql14 postgresql14-devel {{ postgres_install_flags }}
-{% if (pillar['OS'] == 'redhat8' and salt['environ.get']('RHEL_VERSION') == '8.10') or pillar['OS'] == 'redhat9' %}
-        dnf -y install postgresql17-server postgresql17 postgresql17-devel {{ postgres_install_flags }}
-{% endif %}
     - failhard: True
+
+{% if pillar['subtype'] == 'Docker' or pillar['OS'] == 'redhat9' %}
+remove-postgres11:
+  cmd.run:
+    - name: dnf -y remove postgresql11-server postgresql11 postgresql11-devel
+    - failhard: True
+{% else %}
+install-postgres11:
+  cmd.run:
+    - name: dnf -y install postgresql11-server postgresql11 postgresql11-devel {{ postgres_install_flags }}
+    - failhard: True
+{% endif %}
+
+install-postgres14:
+  cmd.run:
+    - name: dnf -y install postgresql14-server postgresql14 postgresql14-devel {{ postgres_install_flags }}
+    - failhard: True
+
+{% if (pillar['OS'] == 'redhat8' and salt['environ.get']('RHEL_VERSION') == '8.10') or pillar['OS'] == 'redhat9' %}
+install-postgres17:
+  cmd.run:
+    - name: dnf -y install postgresql17-server postgresql17 postgresql17-devel {{ postgres_install_flags }}
+    - failhard: True
+{% endif %}
 
 {% if pillar['subtype'] == 'Docker' %}
 timeoutstop-postgres-ycloud:


### PR DESCRIPTION
## Description

Make sure psql11 is not installed on rhel9, and refactor pg installations to separate steps for better error messages in case of failures

## How Has This Been Tested?

A single GCP base image burning was started but it failed on pg14 install which has a follow up in https://cloudera.atlassian.net/browse/RELENG-30791 