### PR TITLE
CB-29843: Create a separate unconfined domain for customer recipes to run in

### DIFF
--- a/saltstack/base/salt/selinux/etc/selinux/cdp/common/cdp-common.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/common/cdp-common.te
@@ -86,6 +86,19 @@ role system_r types cdp_ipa_management_t;
 
 ########################################
 #
+# recipes
+#
+type cdp_recipes_unconfined_t;
+type cdp_recipes_exec_t;
+
+domain_type(cdp_recipes_unconfined_t)
+unconfined_domain(cdp_recipes_unconfined_t)
+domain_entry_file(cdp_recipes_unconfined_t, cdp_recipes_exec_t)
+role system_r types cdp_recipes_unconfined_t;
+
+
+########################################
+#
 # TEMPORARILY PERMISSIVE DOMAINS
 #
 # These domains are made permissive until sufficient testing has been done and most possible denies have been resolved.

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/recipes/cdp-recipes.fc
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/recipes/cdp-recipes.fc
@@ -1,0 +1,19 @@
+/opt/scripts/recipe-runner\.sh                          --      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+
+/opt/scripts/post-cloudera-manager-start(/.*)?          --      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+/opt/scripts/post-cloudera-manager-start(/.*)?          -d      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+
+/opt/scripts/post-cluster-install(/.*)?                 --      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+/opt/scripts/post-cluster-install(/.*)?                 -d      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+
+/opt/scripts/post-service-deployment(/.*)?              --      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+/opt/scripts/post-service-deployment(/.*)?              -d      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+
+/opt/scripts/pre-cloudera-manager-start(/.*)?           --      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+/opt/scripts/pre-cloudera-manager-start(/.*)?           -d      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+
+/opt/scripts/pre-service-deployment(/.*)?               --      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+/opt/scripts/pre-service-deployment(/.*)?               -d      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+
+/opt/scripts/pre-termination(/.*)?                      --      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)
+/opt/scripts/pre-termination(/.*)?                      -d      gen_context(system_u:object_r:cdp_recipes_exec_t,s0)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/recipes/cdp-recipes.restorecon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/recipes/cdp-recipes.restorecon
@@ -1,0 +1,7 @@
+/opt/scripts/recipe-runner.sh
+/opt/scripts/post-cloudera-manager-start/
+/opt/scripts/post-cluster-install/
+/opt/scripts/post-service-deployment/
+/opt/scripts/pre-cloudera-manager-start/
+/opt/scripts/pre-service-deployment/
+/opt/scripts/pre-termination/

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/recipes/cdp-recipes.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/recipes/cdp-recipes.te
@@ -1,0 +1,22 @@
+policy_module(cdp-recipes, 1.0.0)
+
+gen_require(`
+    type cdp_recipes_unconfined_t;
+    type cdp_recipes_exec_t;
+')
+
+# Transition from salt domain to recipes domain when executing cdp_recipes_exec_t
+domtrans_pattern(cdp_salt_t, cdp_recipes_exec_t, cdp_recipes_unconfined_t)
+
+# file transitions
+gen_require(`
+    type cdp_salt_t;
+    type usr_t;
+')
+filetrans_pattern(cdp_salt_t, usr_t, cdp_recipes_exec_t, file, "recipe-runner.sh")
+filetrans_pattern(cdp_salt_t, usr_t, cdp_recipes_exec_t, dir, "post-cloudera-manager-start")
+filetrans_pattern(cdp_salt_t, usr_t, cdp_recipes_exec_t, dir, "post-cluster-install")
+filetrans_pattern(cdp_salt_t, usr_t, cdp_recipes_exec_t, dir, "post-service-deployment")
+filetrans_pattern(cdp_salt_t, usr_t, cdp_recipes_exec_t, dir, "pre-cloudera-manager-start")
+filetrans_pattern(cdp_salt_t, usr_t, cdp_recipes_exec_t, dir, "pre-service-deployment")
+filetrans_pattern(cdp_salt_t, usr_t, cdp_recipes_exec_t, dir, "pre-termination")

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.te
@@ -203,6 +203,12 @@ auth_manage_faillog(cdp_salt_t)
 auth_rw_lastlog(cdp_salt_t)
 setattr_files_pattern(cdp_salt_t, shadow_t, shadow_t)
 
+# cdp-recipes
+gen_require(`
+    type cdp_recipes_exec_t;
+')
+cdp_manage_pattern(cdp_salt_t, cdp_recipes_exec_t, cdp_recipes_exec_t)
+
 # cdp-salt-bootstrap
 gen_require(`
     type cdp_salt_bootstrap_etc_t;

--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -78,6 +78,16 @@ remove_krb5_conf_file_context_rule:
     - template: jinja
 {%- endif %}
 
+/etc/selinux/cdp/recipes/:
+  file.recurse:
+    - name: /etc/selinux/cdp/recipes/
+    - source: salt://{{ slspath }}/etc/selinux/cdp/recipes/
+    - user: root
+    - group: root
+    - dir_mode: 755
+    - file_mode: 644
+    - template: jinja
+
 /etc/selinux/cdp/salt/:
   file.recurse:
     - name: /etc/selinux/cdp/salt/

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -317,5 +317,6 @@ esac
 ## Useful for SELinux policy development. Uncomment if needed.
 ##echo "-a always,exit -F arch=b64 -S openat,open,creat,rename,renameat -F success=1 -k all_file_ops" >> /etc/audit/rules.d/audit.rules  # This one is really heavy, so use with caution
 #echo "-a always,exit -F arch=b64 -S mkdir,mkdirat -k directory_creation" >> /etc/audit/rules.d/audit.rules
+#echo "-a always,exit -F arch=b64 -S openat,open,creat,rename,renameat -F dir=/opt -F success=1 -k opt_ops" >> /etc/audit/rules.d/audit.rules
 #echo "max_log_file_action = ignore" | tee -a /etc/audit/auditd.conf
 #service auditd restart


### PR DESCRIPTION
## Description

The customer recipes will run in the `cdp_recipes_unconfined_t` domain, which has unrestricted access.

## How Has This Been Tested?

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation