### PR TITLE
CB-29599: Investigate ipahealthagent in SELinux enforced mode & CB-29600: Investigate ipaldapagent in SELinux enforced mode

### DIFF
--- a/saltstack/base/salt/selinux/etc/selinux/cdp/common/cdp-common.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/common/cdp-common.te
@@ -105,6 +105,71 @@ role system_r types cdp_ipa_management_t;
 
 ########################################
 #
+# ipahealthagent
+#
+systemd_domain_template(cdp_ipahealthagent)
+systemd_systemctl_domain(cdp_ipahealthagent)
+
+type cdp_ipahealthagent_cert_t;
+miscfiles_cert_type(cdp_ipahealthagent_cert_t)
+
+type cdp_ipahealthagent_etc_t;
+files_config_file(cdp_ipahealthagent_etc_t)
+
+type cdp_ipahealthagent_log_t;
+logging_log_file(cdp_ipahealthagent_log_t)
+
+type cdp_ipahealthagent_bin_t;
+files_type(cdp_ipahealthagent_bin_t)
+
+type cdp_ipahealthagent_lib_t;
+files_type(cdp_ipahealthagent_lib_t)
+
+type cdp_ipahealthagent_systemd_unit_file_t;
+systemd_unit_file(cdp_ipahealthagent_systemd_unit_file_t)
+
+gen_require(`
+    attribute defined_port_type;
+    attribute port_type;
+    attribute unreserved_port_type;
+')
+type cdp_ipahealthagent_port_t, port_type, defined_port_type;
+typeattribute cdp_ipahealthagent_port_t unreserved_port_type;
+
+
+########################################
+#
+# ipaldapagent
+#
+systemd_domain_template(cdp_ipaldapagent)
+systemd_systemctl_domain(cdp_ipaldapagent)
+
+type cdp_ipaldapagent_etc_t;
+files_config_file(cdp_ipaldapagent_etc_t)
+
+type cdp_ipaldapagent_log_t;
+logging_log_file(cdp_ipaldapagent_log_t)
+
+type cdp_ipaldapagent_bin_t;
+files_type(cdp_ipaldapagent_bin_t)
+
+type cdp_ipaldapagent_lib_t;
+files_type(cdp_ipaldapagent_lib_t)
+
+type cdp_ipaldapagent_systemd_unit_file_t;
+systemd_unit_file(cdp_ipaldapagent_systemd_unit_file_t)
+
+gen_require(`
+    attribute defined_port_type;
+    attribute port_type;
+    attribute unreserved_port_type;
+')
+type cdp_ipaldapagent_port_t, port_type, defined_port_type;
+typeattribute cdp_ipaldapagent_port_t unreserved_port_type;
+
+
+########################################
+#
 # jumpgate
 #
 systemd_domain_template(cdp_jumpgate_agent)
@@ -245,6 +310,8 @@ typeattribute cdp_request_signer_port_t unreserved_port_type;
 #
 permissive cdp_blackbox_exporter_t;
 permissive cdp_ipa_management_t;
+permissive cdp_ipahealthagent_t;
+permissive cdp_ipaldapagent_t;
 permissive cdp_jumpgate_agent_t;
 permissive cdp_logging_agent_t;
 permissive cdp_node_exporter_t;

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/init/cdp-init.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/init/cdp-init.te
@@ -3,7 +3,10 @@ policy_module(cdp-init, 1.0.0)
 gen_require(`
     type cdp_ipa_management_exec_t;
     type cdp_ipa_management_t;
+    type cdp_ipahealthagent_lib_t;
+    type cdp_ipahealthagent_t;
     type init_t;
 ')
 
 domtrans_pattern(init_t, cdp_ipa_management_exec_t, cdp_ipa_management_t)
+domtrans_pattern(init_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_t)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent-python-wrapper.sh
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent-python-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This script is a wrapper for the Python interpreter used with ipahealthagent so that we can run ipahealthagent processes the correct SELinux domain
+
+exec /usr/bin/env python3 "$@"

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.fc
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.fc
@@ -1,0 +1,14 @@
+/usr/lib/systemd/system/cdp-freeipa-healthagent\.service     --      gen_context(system_u:object_r:cdp_ipahealthagent_systemd_unit_file_t,s0)
+/etc/selinux/cdp/ipahealthagent-python-wrapper\.sh           --      gen_context(system_u:object_r:cdp_ipahealthagent_exec_t,s0)
+/opt/salt/scripts/freeipa_healthagent_setup\.sh              --      gen_context(system_u:object_r:cdp_ipahealthagent_exec_t,s0)
+
+/cdp/ipahealthagent/ipahealthagent(/.*)?                     --      gen_context(system_u:object_r:cdp_ipahealthagent_bin_t,s0)
+/cdp/ipahealthagent/ipahealthagent(/.*)?                     -d      gen_context(system_u:object_r:cdp_ipahealthagent_bin_t,s0)
+
+/cdp/ipahealthagent/cdp-freeipa-healthagent                  --      gen_context(system_u:object_r:cdp_ipahealthagent_exec_t,s0)
+/cdp/ipahealthagent/wsgi\.py                                 --      gen_context(system_u:object_r:cdp_ipahealthagent_exec_t,s0)
+
+/cdp/ipahealthagent/config\.yaml                             --      gen_context(system_u:object_r:cdp_ipahealthagent_etc_t,s0)
+/cdp/ipahealthagent/requirements\.txt                        --      gen_context(system_u:object_r:cdp_ipahealthagent_etc_t,s0)
+
+/cdp/ipahealthagent(/.*)?                                    -d      gen_context(system_u:object_r:cdp_ipahealthagent_lib_t,s0)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.portcon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.portcon
@@ -1,0 +1,1 @@
+-a cdp_ipahealthagent_port_t tcp 5080

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.restorecon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.restorecon
@@ -1,0 +1,4 @@
+/usr/lib/systemd/system/cdp-freeipa-healthagent.service
+/etc/selinux/cdp/ipahealthagent-python-wrapper.sh
+/opt/salt/scripts/freeipa_healthagent_setup.sh
+/cdp/ipahealthagent

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.te
@@ -1,0 +1,127 @@
+policy_module(cdp-ipahealthagent, 1.0.0)
+
+gen_require(`
+    type cdp_ipahealthagent_t;
+    type cdp_ipahealthagent_exec_t;
+    type cdp_ipahealthagent_bin_t;
+    type cdp_ipahealthagent_cert_t;
+    type cdp_ipahealthagent_etc_t;
+    type cdp_ipahealthagent_lib_t;
+    type cdp_ipahealthagent_systemctl_t;
+    type cdp_ipahealthagent_systemd_unit_file_t;
+    type cdp_ipahealthagent_log_t;
+')
+
+manage_dirs_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_bin_t, cdp_ipahealthagent_bin_t)
+manage_files_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_bin_t, cdp_ipahealthagent_bin_t)
+manage_dirs_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_lib_t)
+manage_files_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_lib_t)
+exec_files_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_lib_t)
+domain_entry_file(cdp_ipahealthagent_t, cdp_ipahealthagent_lib_t)
+manage_files_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_cert_t, cdp_ipahealthagent_cert_t)
+manage_files_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_log_t, cdp_ipahealthagent_log_t)
+
+gen_require(`
+    type bin_t;
+')
+exec_files_pattern(cdp_ipahealthagent_t, bin_t, bin_t)
+
+gen_require(`
+    type shell_exec_t;
+')
+exec_files_pattern(cdp_ipahealthagent_t, shell_exec_t, shell_exec_t)
+
+gen_require(`
+    type cron_log_t;
+')
+read_files_pattern(cdp_ipahealthagent_t, cron_log_t, cron_log_t)
+
+# TODO This block should be removed or investigated when CB-30035 is done. It has been introduced because some files did not get proper file context
+gen_require(`
+    type default_t;
+')
+manage_dirs_pattern(cdp_ipahealthagent_t, default_t, default_t)
+manage_files_pattern(cdp_ipahealthagent_t, default_t, default_t)
+exec_files_pattern(cdp_ipahealthagent_t, default_t, default_t)
+
+logging_create_devlog_dev(cdp_ipahealthagent_t)
+
+gnome_search_gconf(cdp_ipahealthagent_t)
+
+apache_search_config(cdp_ipahealthagent_t)
+corenet_tcp_connect_http_port(cdp_ipahealthagent_t)
+kernel_request_load_module(cdp_ipahealthagent_t)
+gen_require(`
+    type cron_log_t;
+')
+read_files_pattern(cdp_ipahealthagent_t, cron_log_t, cron_log_t)
+
+gen_require(`
+    type default_t;
+')
+manage_dirs_pattern(cdp_ipahealthagent_t, default_t, default_t)
+manage_files_pattern(cdp_ipahealthagent_t, default_t, default_t)
+
+gen_require(`
+    type devlog_t;
+')
+allow cdp_ipahealthagent_t devlog_t:lnk_file read;
+allow cdp_ipahealthagent_t devlog_t:sock_file write;
+
+gnome_search_gconf(cdp_ipahealthagent_t)
+
+apache_search_config(cdp_ipahealthagent_t)
+corenet_tcp_connect_http_port(cdp_ipahealthagent_t)
+kernel_request_load_module(cdp_ipahealthagent_t)
+
+kernel_dgram_send(cdp_ipahealthagent_t)
+kerberos_etc_filetrans_keytab(cdp_ipahealthagent_t)
+libs_exec_ldconfig(cdp_ipahealthagent_t)
+allow cdp_ipahealthagent_t self:netlink_tcpdiag_socket { bind create getattr nlmsg_read setopt };
+allow cdp_ipahealthagent_t self:tcp_socket { accept listen };
+corecmd_check_exec_shell(cdp_ipahealthagent_t)
+
+gen_require(`
+    type tmp_t;
+')
+manage_dirs_pattern(cdp_ipahealthagent_t, tmp_t, tmp_t)
+manage_files_pattern(cdp_ipahealthagent_t, tmp_t, tmp_t)
+
+gen_require(`
+    type ipa_var_lib_t;
+')
+read_files_pattern(cdp_ipahealthagent_t, ipa_var_lib_t, ipa_var_lib_t)
+
+gen_require(`
+    type var_log_t;
+')
+manage_dirs_pattern(cdp_ipahealthagent_t, var_log_t, var_log_t)
+manage_files_pattern(cdp_ipahealthagent_t, var_log_t, var_log_t)
+
+gen_require(`
+    type cdp_ipahealthagent_port_t;
+')
+allow cdp_ipahealthagent_t cdp_ipahealthagent_port_t:tcp_socket { name_bind name_connect };
+
+gen_require(`
+    type cdp_salt_t;
+    type usr_t;
+')
+
+# TODO CB-30035 This line can be removed when cdp/ipahealthagent/freeipa_healthagent_getcerts.sh gets cdp_ipahealthagent_exec_t file context
+filetrans_pattern(cdp_salt_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_exec_t, file, "freeipa_healthagent_getcerts.sh")
+
+# TODO CB-30035 This line can be removed when cdp/ipahealthagent/httpd-crt-tracking.sh gets cdp_ipahealthagent_exec_t file context
+filetrans_pattern(cdp_salt_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_exec_t, file, "httpd-crt-tracking.sh")
+
+# TODO CB-30035 This line can be removed when /opt/salt/scripts/freeipa_healthagent_setup.sh gets cdp_ipahealthagent_exec_t file context
+filetrans_pattern(cdp_salt_t, usr_t, cdp_ipahealthagent_exec_t, file, "freeipa_healthagent_setup.sh")
+
+filetrans_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_log_t, file, "ipahealthagent.log")
+filetrans_pattern(cdp_ipahealthagent_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_log_t, file, "ipahealthagent.log.1")
+
+# TODO CB-30035 This line can be removed when cdp/ipahealthagent/privateKey.pem gets cdp_ipahealthagent_cert_t file context
+filetrans_pattern(cdp_salt_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_cert_t, file, "privateKey.pem")
+
+# TODO CB-30035 This line can be removed when cdp/ipahealthagent/publicCert.pem gets cdp_ipahealthagent_cert_t file context
+filetrans_pattern(cdp_salt_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_cert_t, file, "publicCert.pem")

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent-python-wrapper.sh
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent-python-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This script is a wrapper for the Python interpreter used with ipaldaphagent so that we can run ipaldaphagent processes the correct SELinux domain
+
+exec /usr/bin/env python3 "$@"

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent/cdp-ipaldapagent.fc
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent/cdp-ipaldapagent.fc
@@ -1,0 +1,14 @@
+/usr/lib/systemd/system/cdp-freeipa-ldapagent\.service       --      gen_context(system_u:object_r:cdp_ipaldapagent_systemd_unit_file_t,s0)
+/etc/selinux/cdp/ipaldapagent-python-wrapper\.sh             --      gen_context(system_u:object_r:cdp_ipaldapagent_exec_t,s0)
+/cdp/ipaldapagent/ipaldapagent(/.*)?                         --      gen_context(system_u:object_r:cdp_ipaldapagent_bin_t,s0)
+/cdp/ipaldapagent/ipaldapagent(/.*)?                         -d      gen_context(system_u:object_r:cdp_ipaldapagent_bin_t,s0)
+/cdp/ipaldapagent/cdp-freeipa-ldapagent                      --      gen_context(system_u:object_r:cdp_ipaldapagent_exec_t,s0)
+
+/cdp/ipaldapagent/wsgi\.py                                   --      gen_context(system_u:object_r:cdp_ipaldapagent_exec_t,s0)
+/cdp/ipaldapagent/gunicorn\.conf\.py                         --      gen_context(system_u:object_r:cdp_ipaldapagent_etc_t,s0)
+/cdp/ipaldapagent/devserver\.log\.conf                       --      gen_context(system_u:object_r:cdp_ipaldapagent_etc_t,s0)
+/cdp/ipaldapagent/gunicorn\.log\.conf                        --      gen_context(system_u:object_r:cdp_ipaldapagent_etc_t,s0)
+/cdp/ipaldapagent/requirements\.txt                          --      gen_context(system_u:object_r:cdp_ipaldapagent_etc_t,s0)
+/cdp/ipaldapagent/NOTICE\.txt                                --      gen_context(system_u:object_r:cdp_ipaldapagent_etc_t,s0)
+
+/cdp/ipaldapagent(/.*)?                                      -d      gen_context(system_u:object_r:cdp_ipaldapagent_lib_t,s0)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent/cdp-ipaldapagent.portcon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent/cdp-ipaldapagent.portcon
@@ -1,0 +1,1 @@
+-a cdp_ipaldapagent_port_t tcp 6080

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent/cdp-ipaldapagent.restorecon
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent/cdp-ipaldapagent.restorecon
@@ -1,0 +1,3 @@
+/usr/lib/systemd/system/cdp-freeipa-ldapagent.service
+/etc/selinux/cdp/ipaldapagent-python-wrapper.sh
+/cdp/ipaldapagent

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent/cdp-ipaldapagent.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipaldapagent/cdp-ipaldapagent.te
@@ -1,0 +1,64 @@
+policy_module(cdp-ipaldapagent, 1.0.0)
+
+gen_require(`
+    type cdp_ipaldapagent_t;
+    type cdp_ipaldapagent_exec_t;
+    type cdp_ipaldapagent_bin_t;
+    type cdp_ipaldapagent_etc_t;
+    type cdp_ipaldapagent_lib_t;
+    type cdp_ipaldapagent_systemctl_t;
+    type cdp_ipaldapagent_systemd_unit_file_t;
+    type cdp_ipaldapagent_log_t;
+')
+
+manage_dirs_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_bin_t, cdp_ipaldapagent_bin_t)
+manage_files_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_bin_t, cdp_ipaldapagent_bin_t)
+manage_dirs_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_lib_t)
+manage_files_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_lib_t)
+exec_files_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_lib_t)
+manage_dirs_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_etc_t, cdp_ipaldapagent_etc_t)
+manage_files_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_etc_t, cdp_ipaldapagent_etc_t)
+manage_files_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_log_t, cdp_ipaldapagent_log_t)
+
+# TODO This block should be removed or investigated when CB-30035 is done. It has been introduced because some files did not get proper file context
+gen_require(`
+    type default_t;
+')
+manage_dirs_pattern(cdp_ipaldapagent_t, default_t, default_t)
+manage_files_pattern(cdp_ipaldapagent_t, default_t, default_t)
+exec_files_pattern(cdp_ipaldapagent_t, default_t, default_t)
+
+gnome_search_gconf(cdp_ipaldapagent_t)
+corenet_tcp_bind_geneve_port(cdp_ipaldapagent_t)
+apache_search_config(cdp_ipaldapagent_t)
+
+allow cdp_ipaldapagent_t self:tcp_socket { accept listen };
+corecmd_check_exec_shell(cdp_ipaldapagent_t)
+libs_exec_ldconfig(cdp_ipaldapagent_t)
+
+gen_require(`
+    type tmp_t;
+')
+manage_dirs_pattern(cdp_ipaldapagent_t, tmp_t, tmp_t)
+manage_files_pattern(cdp_ipaldapagent_t, tmp_t, tmp_t)
+
+gen_require(`
+    type bin_t;
+')
+exec_files_pattern(cdp_ipaldapagent_t, bin_t, bin_t)
+
+gen_require(`
+    type shell_exec_t;
+')
+exec_files_pattern(cdp_ipaldapagent_t, shell_exec_t, shell_exec_t)
+
+gen_require(`
+    type cdp_ipaldapagent_port_t;
+')
+allow cdp_ipaldapagent_t cdp_ipaldapagent_port_t:tcp_socket { name_bind name_connect };
+
+# TODO CB-30035 This line can be removed when cdp/ipaldapagent/config.yaml gets cdp_ipaldapagent_etc_t file context
+filetrans_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_etc_t, file, "config.yaml")
+
+filetrans_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_log_t, file, "access.log")
+filetrans_pattern(cdp_ipaldapagent_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_log_t, file, "error.log")

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/logging-agent/cdp-logging-agent.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/logging-agent/cdp-logging-agent.te
@@ -65,10 +65,20 @@ cdp_read_sysfs(cdp_logging_agent_t)
 # Read and search even if DAC does not allow it
 allow cdp_logging_agent_t self:capability { dac_read_search };
 
-###
-# TODO Remove this block when CB-29599 is done
 gen_require(`
-    type default_t;
+    type cdp_ipahealthagent_lib_t;
+    type cdp_ipahealthagent_log_t;
 ')
-allow cdp_logging_agent_t default_t:file { getattr ioctl open read };
-#
+list_dirs_pattern(cdp_logging_agent_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_lib_t)
+read_files_pattern(cdp_logging_agent_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_lib_t)
+list_dirs_pattern(cdp_logging_agent_t, cdp_ipahealthagent_log_t, cdp_ipahealthagent_log_t)
+read_files_pattern(cdp_logging_agent_t, cdp_ipahealthagent_log_t, cdp_ipahealthagent_log_t)
+
+gen_require(`
+    type cdp_ipaldapagent_lib_t;
+    type cdp_ipaldapagent_log_t;
+')
+list_dirs_pattern(cdp_logging_agent_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_lib_t)
+read_files_pattern(cdp_logging_agent_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_lib_t)
+list_dirs_pattern(cdp_logging_agent_t, cdp_ipaldapagent_log_t, cdp_ipaldapagent_log_t)
+read_files_pattern(cdp_logging_agent_t, cdp_ipaldapagent_log_t, cdp_ipaldapagent_log_t)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.te
@@ -210,6 +210,25 @@ gen_require(`
 manage_dirs_pattern(cdp_salt_t, cdp_blackbox_exporter_conf_t, cdp_blackbox_exporter_conf_t)
 manage_files_pattern(cdp_salt_t, cdp_blackbox_exporter_conf_t, cdp_blackbox_exporter_conf_t)
 
+# cdp-ipahealthagent
+gen_require(`
+    type cdp_ipahealthagent_cert_t;
+    type cdp_ipahealthagent_lib_t;
+')
+manage_files_pattern(cdp_salt_t, cdp_ipahealthagent_cert_t, cdp_ipahealthagent_cert_t)
+manage_files_pattern(cdp_salt_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_lib_t)
+exec_files_pattern(cdp_salt_t, cdp_ipahealthagent_lib_t, cdp_ipahealthagent_lib_t)
+
+# cdp-ipaldapagent
+gen_require(`
+    type cdp_ipaldapagent_exec_t;
+    type cdp_ipaldapagent_etc_t;
+    type cdp_ipaldapagent_lib_t;
+')
+getattr_files_pattern(cdp_salt_t, cdp_ipaldapagent_exec_t, cdp_ipaldapagent_exec_t)
+manage_files_pattern(cdp_salt_t, cdp_ipaldapagent_etc_t, cdp_ipaldapagent_etc_t)
+manage_files_pattern(cdp_salt_t, cdp_ipaldapagent_lib_t, cdp_ipaldapagent_lib_t)
+
 # cdp-jumpgate-agent
 gen_require(`
     type cdp_jumpgate_agent_etc_t;
@@ -573,16 +592,6 @@ gen_require(`
 manage_dirs_pattern(useradd_t, lib_t, lib_t)
 manage_files_pattern(useradd_t, lib_t, lib_t)
 manage_files_pattern(useradd_t, var_lib_t, var_lib_t)
-
-###
-# TODO Remove this block when CB-29600 is done
-gen_require(`
-    type default_t;
-    type init_t;
-')
-allow cdp_salt_t default_t:file { execute execute_no_trans };
-allow init_t default_t:file { execute execute_no_trans open read };
-###
 
 ###
 # TODO Remove this block when CB-30029 is done

--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -58,6 +58,46 @@
     - file_mode: 644
     - template: jinja
 
+/etc/selinux/cdp/ipahealthagent-python-wrapper.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+    - template: jinja
+    - name: /etc/selinux/cdp/ipahealthagent-python-wrapper.sh
+    - source: salt://{{ slspath }}/etc/selinux/cdp/ipahealthagent-python-wrapper.sh
+
+/etc/selinux/cdp/ipaldapagent-python-wrapper.sh:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+    - template: jinja
+    - name: /etc/selinux/cdp/ipaldapagent-python-wrapper.sh
+    - source: salt://{{ slspath }}/etc/selinux/cdp/ipaldapagent-python-wrapper.sh
+
+/etc/selinux/cdp/ipahealthagent:
+  file.recurse:
+    - name: /etc/selinux/cdp/ipahealthagent/
+    - source: salt://{{ slspath }}/etc/selinux/cdp/ipahealthagent/
+    - user: root
+    - group: root
+    - dir_mode: 755
+    - file_mode: 644
+    - makedirs: True
+
+/etc/selinux/cdp/ipaldapagent:
+  file.recurse:
+    - name: /etc/selinux/cdp/ipaldapagent/
+    - source: salt://{{ slspath }}/etc/selinux/cdp/ipaldapagent/
+    - user: root
+    - group: root
+    - dir_mode: 755
+    - file_mode: 644
+    - makedirs: True
+
 /etc/selinux/cdp/jumpgate-agent/:
   file.recurse:
     - name: /etc/selinux/cdp/jumpgate-agent/

--- a/saltstack/freeipa/salt/freeipa/init.sls
+++ b/saltstack/freeipa/salt/freeipa/init.sls
@@ -65,6 +65,31 @@ install_freeipa_healthagent_rpm:
     - skip_verify: True
     - require:
       - freeipa-install
+
+update_ipahealthagent_python_wrapper:
+  cmd.run:
+    - name: |
+        PYTHON_BIN=$(systemctl show cdp-freeipa-healthagent.service -p ExecStart --no-pager | sed -n 's/.*argv\[\]=\(.*\) \/cdp\/ipahealthagent.*/\1/p')
+        [[ ! -z "$PYTHON_BIN" ]] || exit 1
+        sed -i 's|^exec .* "\$@"|exec '"$PYTHON_BIN"' "$@"|g' /etc/selinux/cdp/ipahealthagent-python-wrapper.sh
+    - require:
+      - install_freeipa_healthagent_rpm
+    - onlyif: test -f /etc/selinux/cdp/ipahealthagent-python-wrapper.sh
+
+create_ipahealthagent_service_override:
+  cmd.run:
+    - name: |
+        EXEC_ARGS=$(systemctl show cdp-freeipa-healthagent.service -p ExecStart --no-pager | sed -n 's/.*\(\/cdp\/ipahealthagent\/libs\/bin\/gunicorn[^;]*\) ;.*/\1/p')
+        [[ ! -z "$EXEC_ARGS" ]] || exit 1
+        mkdir -p /etc/systemd/system/cdp-freeipa-healthagent.service.d/
+        cat > /etc/systemd/system/cdp-freeipa-healthagent.service.d/override.conf << EOF
+        [Service]
+        ExecStart=
+        ExecStart=/etc/selinux/cdp/ipahealthagent-python-wrapper.sh $EXEC_ARGS
+        EOF
+    - require:
+      - update_ipahealthagent_python_wrapper
+    - unless: test -f /etc/systemd/system/cdp-freeipa-healthagent.service.d/override.conf
 {% endif %}
 
 {% if freeipa_ldapagent_rpm_url %}
@@ -75,6 +100,31 @@ install_freeipa_ldapagent_rpm:
     - skip_verify: True
     - require:
       - freeipa-install
+
+update_ipaldapagent_python_wrapper:
+  cmd.run:
+    - name: |
+        PYTHON_BIN=$(systemctl show cdp-freeipa-ldapagent.service -p ExecStart --no-pager | sed -n 's/.*argv\[\]=\(.*\) \/cdp\/ipaldapagent.*/\1/p')
+        [[ ! -z "$PYTHON_BIN" ]] || exit 1
+        sed -i 's|^exec .* "\$@"|exec '"$PYTHON_BIN"' "$@"|g' /etc/selinux/cdp/ipahealthagent-python-wrapper.sh
+    - require:
+      - install_freeipa_ldapagent_rpm
+    - onlyif: test -f /etc/selinux/cdp/ipaldapagent-python-wrapper.sh
+
+create_ipaldapagent_service_override:
+  cmd.run:
+    - name: |
+        EXEC_ARGS=$(systemctl show cdp-freeipa-ldapagent.service -p ExecStart --no-pager | sed -n 's/.*\(\/cdp\/ipaldapagent\/libs\/bin\/gunicorn[^;]*\) ;.*/\1/p')
+        [[ ! -z "$EXEC_ARGS" ]] || exit 1
+        mkdir -p /etc/systemd/system/cdp-freeipa-ldapagent.service.d/
+        cat > /etc/systemd/system/cdp-freeipa-ldapagent.service.d/override.conf << EOF
+        [Service]
+        ExecStart=
+        ExecStart=/etc/selinux/cdp/ipaldapagent-python-wrapper.sh $EXEC_ARGS
+        EOF
+    - require:
+      - update_ipaldapagent_python_wrapper
+    - unless: test -f /etc/systemd/system/cdp-freeipa-ldapagent.service.d/override.conf
 {% endif %}
 
 net.ipv6.conf.lo.disable_ipv6:


### PR DESCRIPTION
CB-29599: Investigate ipahealthagent in SELinux enforced mode & CB-29600: Investigate ipaldapagent in SELinux enforced mode

## Description

Added the following new domains (all permissive):

- cdp_ipahealthagent_t
- cdp_ipaldapagent_t

Added the following port types:

- cdp_ipahealthagent_port_t: 5080
- cdp_ipaldapagent_port_t: 6080

## How Has This Been Tested?

Manually checked for denies on AWS FreeIPA instance created with the new image.
Also burned a RHEL9 Azure base image to make sure the policies don't conflict with the RHEL9 reference policy:
http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8690/

- [x] Runtime image burning (per provider)
- AWS: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8689/
- [x] Runtime image validation (per provider)
- AWS: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/4100/
- [x] FreeIPA image burning (per provider)
- AWS: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8688/
- [x] FreeIPA image validation (per provider)
- AWS: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/4099/
- [ ] Base image burning
- [ ] Base image validation