### PR TITLE
CB-30276: Fix SELinux policy install on arm

### DIFF
--- a/saltstack/base/salt/selinux/etc/selinux/cdp/kerberos/cdp-kerberos.fc
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/kerberos/cdp-kerberos.fc
@@ -1,2 +1,1 @@
-/etc/krb5\.conf         --      gen_context(system_u:object_r:krb5_conf_t,s0)
 /etc/krb5\.conf\.d      -d      gen_context(system_u:object_r:krb5_conf_t,s0)

--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -58,14 +58,6 @@
     - file_mode: 644
     - template: jinja
 
-{%- if pillar['OS'] == 'redhat9' %}
-remove_krb5_conf_file_context_rule:
-  file.line:
-    - name: /etc/selinux/cdp/kerberos/cdp-kerberos.fc
-    - match: '/etc/krb5\\\.conf\s+--\s+gen_context\(system_u:object_r:krb5_conf_t,s0\)'
-    - mode: delete
-{%- endif %}
-
 {%- if salt['environ.get']('CUSTOM_IMAGE_TYPE') != 'freeipa' %}
 /etc/selinux/cdp/postgresql/:
   file.recurse:


### PR DESCRIPTION
## Description

The krb5.conf file context rule was a duplicate which caused the filecon db post processing to fail every time.
The RHEL8 policycoreutils package is quite old. The semodule provided by this package version doesn't detect this conflict. On RHEL9, this conflict could be identified as the verbose log stated it. Also, for some reason the x86 version doesn't detect the conflict, but also doesn't cause the later semodule calls to fail.

Removed the file context rule. It was originally included because the file didn't seem to have the correct file context. Removing it shouldn't change anything and even if it did, since our domains are permissive, in the worst case this results in deny logs in the audit log, but no actual permission denied error.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
  - AWS arm64: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8350/
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
  - AWS arm64: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8349/
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.