### PR TITLE
CB-30382: Updated ARM64 FreeIPA Artifacts

### DIFF
--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -93,7 +93,7 @@ packer_in_container() {
   if ! [[ $FREEIPA_PLUGIN_RPM_URL =~ ^http.*rpm$ ]]; then
     if [[ "$OS" == "redhat8" ]]; then
       if [[ "$ARCHITECTURE" == "arm64" ]]; then
-        export FREEIPA_PLUGIN_RPM_URL="https://cloudera-build-2-us-west-2.vpc.cloudera.com/s3/build/68651539/thunderhead/1.x/redhat8/yum/cdp-hashed-pwd-1.1.0.3-b801.aarch64.rpm"
+        export FREEIPA_PLUGIN_RPM_URL="https://cloudera-build-2-us-west-2.vpc.cloudera.com/s3/build/70158318/thunderhead/1.x/redhat8/yum/cdp-hashed-pwd-1.1.0.3-b1407.aarch64.rpm"
       else
         export FREEIPA_PLUGIN_RPM_URL="https://archive.cloudera.com/cdp-freeipa-artifacts/cdp-hashed-pwd-1.1-b847.el8.x86_64.rpm"
       fi
@@ -104,7 +104,7 @@ packer_in_container() {
   if ! [[ $FREEIPA_HEALTH_AGENT_RPM_URL =~ ^http.*rpm$ ]]; then
     if [[ "$OS" == "redhat8" ]]; then
       if [[ "$ARCHITECTURE" == "arm64" ]]; then
-        export FREEIPA_HEALTH_AGENT_RPM_URL="https://cloudera-build-2-us-west-2.vpc.cloudera.com/s3/build/68651539/thunderhead/1.x/redhat8/yum/freeipa-health-agent-3.1.0.3-b801.aarch64.rpm"
+        export FREEIPA_HEALTH_AGENT_RPM_URL="https://cloudera-build-2-us-west-2.vpc.cloudera.com/s3/build/70158318/thunderhead/1.x/redhat8/yum/freeipa-health-agent-3.1.0.3-b1407.aarch64.rpm"
       else
         export FREEIPA_HEALTH_AGENT_RPM_URL="https://archive.cloudera.com/cdp-freeipa-artifacts/freeipa-health-agent-2.1.0.2-b2228.x86_64.rpm"
       fi


### PR DESCRIPTION
## Description

This is just a refresh, the RPMs are the same as they were, but they have been rebuilt because build cache only retains them for a few weeks. The URLs are correct, so no special testing is needed.

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.