### PR TITLE
CB-30391: Replaced mktorrent with py3createtorrent for RHEL 9

### DIFF
--- a/saltstack/hortonworks/salt/pre-warm/cdh.sls
+++ b/saltstack/hortonworks/salt/pre-warm/cdh.sls
@@ -1,7 +1,14 @@
+{% if pillar['OS'] == 'redhat9' %}
+install_py3createtorrent:
+  pip.installed:
+    - name: py3createtorrent
+    - bin_env: /usr/local/bin/pip3.11
+{% else %}
 install_mktorrent:
   pkg.installed:
     - pkgs:
       - mktorrent
+{% endif %}
 
 install_cdh:
   cmd.script:

--- a/saltstack/hortonworks/salt/pre-warm/cdh.sls
+++ b/saltstack/hortonworks/salt/pre-warm/cdh.sls
@@ -1,14 +1,7 @@
-{% if pillar['OS'] == 'redhat9' %}
 install_py3createtorrent:
   pip.installed:
     - name: py3createtorrent
     - bin_env: /usr/local/bin/pip3.11
-{% else %}
-install_mktorrent:
-  pkg.installed:
-    - pkgs:
-      - mktorrent
-{% endif %}
 
 install_cdh:
   cmd.script:

--- a/saltstack/hortonworks/salt/pre-warm/tmp/create_torrent.sh
+++ b/saltstack/hortonworks/salt/pre-warm/tmp/create_torrent.sh
@@ -10,7 +10,12 @@ for parcel in "${parcels[@]}"; do
 	if [[ -f "${parcel}.torrent" ]]; then
 		echo "$parcel torrent already exists, skip"
 	else
-		mktorrent -l 19 -v -p -a "" -o "${parcel}.torrent" "${parcel}"
+		if [[ "$OS" == "redhat9" ]]; then
+			#pip3 install py3createtorrent
+			/usr/local/bin/py3createtorrent "${parcel}" -v -P -o "${parcel}.torrent"
+		else
+			mktorrent -l 19 -v -p -a "" -o "${parcel}.torrent" "${parcel}"
+		fi
 		touch "${parcel}".skiphash
 		rm -f "${parcel}"
 		touch "${parcel}"

--- a/saltstack/hortonworks/salt/pre-warm/tmp/create_torrent.sh
+++ b/saltstack/hortonworks/salt/pre-warm/tmp/create_torrent.sh
@@ -10,12 +10,7 @@ for parcel in "${parcels[@]}"; do
 	if [[ -f "${parcel}.torrent" ]]; then
 		echo "$parcel torrent already exists, skip"
 	else
-		if [[ "$OS" == "redhat9" ]]; then
-			#pip3 install py3createtorrent
-			/usr/local/bin/py3createtorrent "${parcel}" -v -P -o "${parcel}.torrent"
-		else
-			mktorrent -l 19 -v -p -a "" -o "${parcel}.torrent" "${parcel}"
-		fi
+		/usr/local/bin/py3createtorrent "${parcel}" -v -P -o "${parcel}.torrent"
 		touch "${parcel}".skiphash
 		rm -f "${parcel}"
 		touch "${parcel}"

--- a/saltstack/hortonworks/salt/pre-warm/tmp/install_cdh.sh
+++ b/saltstack/hortonworks/salt/pre-warm/tmp/install_cdh.sh
@@ -68,7 +68,11 @@ extract_cdh_parcel() {
   parcels=("$PARCEL_ARCHIVE_PATH"/*.parcel)
   for tmp_parcel in "${parcels[@]}"; do
     parcel="$PARCEL_REPO/$(basename "$tmp_parcel")"
-    mktorrent -l 19 -v -p -a "" -o "${parcel}.torrent" "${tmp_parcel}"
+    if [[ "$OS" == "redhat9" ]]; then
+      /usr/local/bin/py3createtorrent "${tmp_parcel}" -v -P -o "${parcel}.torrent"
+    else
+      mktorrent -l 19 -v -p -a "" -o "${parcel}.torrent" "${tmp_parcel}"
+    fi
     touch "${parcel}" "${parcel}.skiphash"
     rm -f "${tmp_parcel}"
     ln "${parcel}" "/opt/cloudera/parcel-cache/$(basename "$parcel")"

--- a/saltstack/hortonworks/salt/pre-warm/tmp/install_cdh.sh
+++ b/saltstack/hortonworks/salt/pre-warm/tmp/install_cdh.sh
@@ -68,11 +68,7 @@ extract_cdh_parcel() {
   parcels=("$PARCEL_ARCHIVE_PATH"/*.parcel)
   for tmp_parcel in "${parcels[@]}"; do
     parcel="$PARCEL_REPO/$(basename "$tmp_parcel")"
-    if [[ "$OS" == "redhat9" ]]; then
-      /usr/local/bin/py3createtorrent "${tmp_parcel}" -v -P -o "${parcel}.torrent"
-    else
-      mktorrent -l 19 -v -p -a "" -o "${parcel}.torrent" "${tmp_parcel}"
-    fi
+    /usr/local/bin/py3createtorrent "${tmp_parcel}" -v -P -o "${parcel}.torrent"
     touch "${parcel}" "${parcel}.skiphash"
     rm -f "${tmp_parcel}"
     ln "${parcel}" "/opt/cloudera/parcel-cache/$(basename "$parcel")"


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider)
  - RHEL 9 AWS 7.3.2 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8461/
  - RHEL 8 AWS 7.3.1 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8460/
- [x] Runtime image validation (per provider)
  - RHEL 9 AWS 7.3.2 - http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3959/ (basic, int, failed)
  - RHEL 9 AWS 7.3.2 - http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3959/ (basic, dev, failed) 
  - RHEL 8 AWS 7.3.1 - http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3958/ (basic)
  - RHEL 8 AWS 7.3.1 - http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3964/ (extended)
- [x] FreeIPA images - not affected
- [x] Base images - not affected

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.