### PR TITLE
CB-30405: Py3+RHEL9 fixes, read the commit msg

### DIFF
--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -386,49 +386,71 @@ psycopg2-rhel8-py38-hue-link-2:
     - name: ln -s /usr/local/lib64/python3.8/site-packages/psycopg2-2.9.3-py3.8.egg-info /usr/lib64/python3.8/site-packages/psycopg2-2.9.3-py3.8.egg-info
     - onlyif: ls -la /usr/local/lib64/python3.8/site-packages/psycopg2-2.9.3-py3.8.egg-info
 
-# RHEL 8 + Python 3.9
-psycopg2-rhel8-py39:
+# RHEL 8 / 9 + Python 3.9
+psycopg2-rhel89-py39:
   pip.installed:
     - name: psycopg2==2.9.3
     - bin_env: /usr/local/bin/pip3.9
     - onlyif: ls -la /usr/lib64/python3.9/site-packages
 
-psycopg2-rhel8-py39-verify:
+psycopg2-rhel89-py39-verify:
   cmd.run:
     - name: /usr/local/bin/pip3.9 show psycopg2
     - onlyif: ls -la /usr/lib64/python3.9/site-packages
 
-psycopg2-rhel8-py39-hue-link:
+psycopg2-rhel89-py39-hue-link:
   cmd.run:
     - name: ln -s /usr/local/lib64/python3.9/site-packages/psycopg2 /usr/lib64/python3.9/site-packages/psycopg2
     - onlyif: ls -la /usr/local/lib64/python3.9/site-packages/psycopg2
 
-psycopg2-rhel8-py39-hue-link-2:
+psycopg2-rhel89-py39-hue-link-2:
   cmd.run:
     - name: ln -s /usr/local/lib64/python3.9/site-packages/psycopg2-2.9.3-py3.9.egg-info /usr/lib64/python3.9/site-packages/psycopg2-2.9.3-py3.9.egg-info
     - onlyif: ls -la /usr/local/lib64/python3.9/site-packages/psycopg2-2.9.3-py3.9.egg-info
 
-# RHEL 8 + Python 3.11
-psycopg2-rhel8-py311:
+# RHEL 8 / 9 + Python 3.11
+psycopg2-rhel89-py311:
   pip.installed:
     - name: psycopg2==2.9.3
     - bin_env: /usr/local/bin/pip3.11
     - onlyif: ls -la /usr/lib64/python3.11/site-packages
 
-psycopg2-rhel8-py311-verify:
+psycopg2-rhel89-py311-verify:
   cmd.run:
     - name: /usr/local/bin/pip3.11 show psycopg2
     - onlyif: ls -la /usr/lib64/python3.11/site-packages
 
-psycopg2-rhel8-py311-hue-link:
+psycopg2-rhel89-py311-hue-link:
   cmd.run:
     - name: ln -s /usr/local/lib64/python3.11/site-packages/psycopg2 /usr/lib64/python3.11/site-packages/psycopg2
     - onlyif: ls -la /usr/local/lib64/python3.11/site-packages/psycopg2
 
-psycopg2-rhel8-py311-hue-link-2:
+psycopg2-rhel89-py311-hue-link-2:
   cmd.run:
     - name: ln -s /usr/local/lib64/python3.11/site-packages/psycopg2-2.9.3-py3.11.egg-info /usr/lib64/python3.11/site-packages/psycopg2-2.9.3-py3.11.egg-info
     - onlyif: ls -la /usr/local/lib64/python3.11/site-packages/psycopg2-2.9.3-py3.11.egg-info
+
+# RHEL 8 / 9 + Python 3.12
+psycopg2-rhel89-py312:
+  pip.installed:
+    - name: psycopg2==2.9.3
+    - bin_env: /usr/local/bin/pip3.12
+    - onlyif: ls -la /usr/lib64/python3.12/site-packages
+
+psycopg2-rhel89-py312-verify:
+  cmd.run:
+    - name: /usr/local/bin/pip3.12 show psycopg2
+    - onlyif: ls -la /usr/lib64/python3.12/site-packages
+
+psycopg2-rhel89-py312-hue-link:
+  cmd.run:
+    - name: ln -s /usr/local/lib64/python3.12/site-packages/psycopg2 /usr/lib64/python3.12/site-packages/psycopg2
+    - onlyif: ls -la /usr/local/lib64/python3.12/site-packages/psycopg2
+
+psycopg2-rhel89-py312-hue-link-2:
+  cmd.run:
+    - name: ln -s /usr/local/lib64/python3.12/site-packages/psycopg2-2.9.3-py3.12.egg-info /usr/lib64/python3.12/site-packages/psycopg2-2.9.3-py3.12.egg-info
+    - onlyif: ls -la /usr/local/lib64/python3.12/site-packages/psycopg2-2.9.3-py3.12.egg-info
 
 # CentOS 7 + Python 3.8
 psycopg2-centos7-py38:


### PR DESCRIPTION
## Description

This commit fixes the following Python3 related bugs:

CB-30405 - The default "pip3" now points to Python 3.9's pip3 installation rather than 3.12's, so it will be in sync with the default system Python version which is also 3.9

CB-30416 - The way we need to query the exact Python 3.9 version is slightly different on the AWS images compared to Azure and GCP. This has been fixed.

CB-30422 - PsycoPg2 library needs to be separately installed for all Python versions supported on the image. This has been missing for Python 3.12

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider)
  - AWS x86 RHEL 9 7.3.2: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8478/
  - Azure RHEL 9 7.3.2: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8479/
  - GCP RHEL 9 7.3.2: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8476/
  - AWS ARM RHEL 8 7.3.1: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8480/
- [x] Runtime image validation (per provider)
  - RHEL 9 validation is still failing
  - AWS ARM64 RHEL 8 7.3.1: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3998/
- [x] FreeIPA image burning (per provider)
  - Azure x86 RHEL 8: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8481/
  - AWS ARM64 RHEL 8: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8482/
- [x] FreeIPA image validation (per provider)
  - Azure x86 RHEL 8: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3996/
  - AWS ARM64 RHEL 8: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/3997/
- [x] Base image burning
  - Fully covered by Runtime images
- [x] Base image validation
  - Fully covered by Runtime images

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.