### PR TITLE
CB-30423: Removed the hardcoded override of cdp-request-signer on RHEL 9

### DIFF
--- a/saltstack/base/salt/telemetry/init.sls
+++ b/saltstack/base/salt/telemetry/init.sls
@@ -45,7 +45,9 @@ override_cdp_request_signer:
         dnf -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat8arm64/yum/cdp_request_signer-1.3.7_b2.rpm
 {% elif pillar['OS'] == 'redhat8' %}
         dnf -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat8/yum/cdp_request_signer-1.3.7_b2.rpm
-{% else %}
+{% elif pillar['OS'] == 'centos7' %}
         yum -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat7/yum/cdp_request_signer-1.3.7_b2.rpm
+{% else %}
+        echo "No override for RHEL 9."
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Only tested on AWS just to see the RPM is correct and version numbers look good. This is for RHEL 9 only (for now) and for RHEL 9, the validation is still broken on mow-dev and unavailable on mow-int.

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [x] Base image burning
 - AWS - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8492/
- [] Base image validation

