### PR TITLE
CB-30376 Change the default Postgres version to 17 on 7.3.2 images

### DIFF
--- a/saltstack/base/salt/postgresql/init.sls
+++ b/saltstack/base/salt/postgresql/init.sls
@@ -55,7 +55,12 @@ timeoutstop-postgres-ycloud:
     - name: mkdir /etc/systemd/system/postgresql-14.service.d  && echo $'[Service]\nTimeoutStopSec=120s' > /etc/systemd/system/postgresql-14.service.d/timeout.conf && mkdir /etc/systemd/system/postgresql-17.service.d && echo $'[Service]\nTimeoutStopSec=120s' > /etc/systemd/system/postgresql-17.service.d/timeout.conf
 {% endif %}
 
-{% set pg_default_version = '14' %}
+{% set version = salt['environ.get']('STACK_VERSION') %}
+{% if version and version.split('.') | map('int') | list >= [7, 3, 2] %}
+  {% set pg_default_version = '17' %}
+{% else %}
+  {% set pg_default_version = '14' %}
+{% endif %}
 
 {% elif pillar['OS'] == 'centos7' %}
 


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.