### PR TITLE
CB-30421: Allow `httpd_t` to execute `cdp_ipa_management_exec_t` to be able to use `ipa-getkeytab`

### DIFF
--- a/saltstack/base/salt/selinux/etc/selinux/cdp/httpd/cdp-httpd.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/httpd/cdp-httpd.te
@@ -4,9 +4,11 @@ gen_require(`
     type httpd_sys_script_t;
     type httpd_t;
     type cdp_httpd_cert_t;
+    type cdp_ipa_management_exec_t;
 ')
 
 apache_search_config(httpd_sys_script_t)
+can_exec(httpd_t, cdp_ipa_management_exec_t)
 init_ioctl_stream_sockets(httpd_sys_script_t)
 search_dirs_pattern(httpd_t, cdp_httpd_cert_t, cdp_httpd_cert_t)
 read_files_pattern(httpd_t, cdp_httpd_cert_t, cdp_httpd_cert_t)


### PR DESCRIPTION
## Description

Needed because `httpd_t` executes `ipa-getkeytab` during cluster creation.

## How Has This Been Tested?

Manually provisioned a FreeIPA and DataLake in ENFORCING mode, and verified that the DL is able to get keytab from the FreeIPA.

- [x] Runtime image burning (per provider)
  - Only affects freeipa images
- [x] Runtime image validation (per provider)
  - Only affects freeipa images
- [x] FreeIPA image burning (per provider)
  -  AWS: http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8500/
- [x] FreeIPA image validation (per provider)
  - AWS: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/4012/
- [x] Base image burning
  - Only affects freeipa images
- [x] Base image validation
  - Only affects freeipa images
