### PR TITLE
[WIP] CB-30494 Add basic oscap CVE scan to the image burning & save the results to S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -745,6 +745,17 @@ ifdef UUID
 endif
 endif
 
+copy-cve-scan-results-to-s3-bucket:
+ifneq ($(CLOUD_PROVIDER),YARN)
+ifdef UUID
+	cp -- oscap_cve_results.xml "${UUID}_results.xml"
+	cp -- oscap_cve_report.html "${UUID}_report.html"
+	AWS_DEFAULT_REGION=eu-west-1
+	aws s3 cp "${UUID}_results.xml" s3://cloudbreak-imagecatalog/image-cve-scans/ --acl public-read
+	aws s3 cp "${UUID}_report.html" s3://cloudbreak-imagecatalog/image-cve-scans/ --acl public-read
+endif
+endif
+
 copy-changelog-to-s3-bucket:
 ifdef IMAGE_UUID_1
 ifdef IMAGE_UUID_2

--- a/packer.json
+++ b/packer.json
@@ -919,7 +919,7 @@
     },
     {
       "type": "file",
-      "source": "/tmp/cis/*",
+      "source": "/tmp/oscap/*",
       "destination": "./",
       "direction" : "download",
       "only": [

--- a/saltstack/final/salt/openscap/init.sls
+++ b/saltstack/final/salt/openscap/init.sls
@@ -1,27 +1,61 @@
-openscap_install:
-  cmd.run:
-    - name: yum install -y openscap-scanner
+oscap_scan:
+  pkg.installed:
+    - pkgs:
+      - wget
+      - bzip2
+      - openscap-scanner
+      - scap-security-guide
 
-openscap_security_guide:
-  cmd.run:
-    - name: yum install -y scap-security-guide
-    
+  file.directory:
+    - name: /tmp/oscap
+    - mode: 755
+
+{% if salt['environ.get']('STIG_ENABLED') == 'true' %}
 openscap_info:
   cmd.run:
     - name: oscap info /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml
+    - require:
+      - pkg: oscap_scan
 
 openscap_run_stig:
   cmd.run:
-    - name: sudo oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_stig --results /tmp/cis/oscap_stig_report.xml --report /tmp/cis/oscap_stig_report.html /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml | tee /tmp/cis/oscap_log.txt
+    - name: sudo oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_stig --results /tmp/oscap/oscap_stig_report.xml --report /tmp/oscap/oscap_stig_report.html /usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml | tee /tmp/oscap/oscap_log.txt
+    - require:
+      - pkg: oscap_scan
+      - file: oscap_scan
+{% endif %}
+
+{% set os_type = salt['environ.get']('OS_TYPE') %}
+{% if os_type == 'redhat9' %}
+  {% set oval_url = 'https://security.access.redhat.com/data/oval/v2/RHEL9/rhel-9.6-eus.oval.xml.bz2' %}
+  {% set oval_file = 'rhel-9.6-eus.oval.xml' %}
+{% else %}
+  {% set oval_url = 'https://security.access.redhat.com/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2' %}
+  {% set oval_file = 'rhel-8.oval.xml' %}
+{% endif %}
+
+openscap_cve_scan:
+  cmd.run:
+    - name: |
+        cd /tmp/oscap && \
+        wget -q -O {{ oval_file }}.bz2 {{ oval_url }} && \
+        bunzip2 -f {{ oval_file }}.bz2 && \
+        oscap oval eval --verbose INFO \
+          --results /tmp/oscap/oscap_cve_results.xml \
+          --report /tmp/oscap/oscap_cve_report.html \
+          /tmp/oscap/{{ oval_file }}
+    - require:
+      - pkg: oscap_scan
+      - file: oscap_scan
 
 openscap_log_and_report_chmod:
   cmd.run:
-    - name: chmod 777 /tmp/cis/oscap_log.txt /tmp/cis/oscap_stig_report.xml /tmp/cis/oscap_stig_report.html
+    - name: chmod 777 /tmp/oscap/oscap_*.txt /tmp/oscap/oscap_*.xml /tmp/oscap/oscap_*.html
+    - file: oscap_scan
 
-remove_security_guide:
-   cmd.run:
-    - name: yum remove -y scap-security-guide
-
-remove_openscap:
-   cmd.run:
-    - name: yum remove -y openscap-scanner
+oscap_scan_cleanup:
+  pkg.removed:
+    - pkgs:
+      - wget
+      - openscap-scanner
+      - scap-security-guide

--- a/saltstack/final/salt/top.sls
+++ b/saltstack/final/salt/top.sls
@@ -10,9 +10,7 @@ final:
     - metadata
 {% if pillar['subtype'] != 'Docker' %}
     - cis-controls
-{% if salt['environ.get']('STIG_ENABLED') == 'true' %}
+{% endif %}
     - openscap
-{% endif %}
-{% endif %}
     - cleanup
     - hacks-and-tweaks


### PR DESCRIPTION
CB-30494 Add basic oscap CVE scan to the image burning & save the results to S3

## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.