### PR TITLE
CB-30236: Updated origin images to RHEL 9.6 on AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ endif
 ifeq ($(CLOUD_PROVIDER),AWS)
 	ifeq ($(OS),redhat9)
 		ifeq ($(ARCHITECTURE),arm64)
-			AWS_SOURCE_AMI ?= ami-02b88e379f3080bba
+			AWS_SOURCE_AMI ?= ami-06f1805217126b0d0
 			AWS_INSTANCE_TYPE ?= r7gd.2xlarge
 		else
-			AWS_SOURCE_AMI ?= ami-0e2dd07dc70f88b3a
+			AWS_SOURCE_AMI ?= ami-08a3a46b7bf22015a
 			AWS_INSTANCE_TYPE ?= t3.2xlarge
 		endif
 	else ifeq ($(OS),redhat8)


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider) - covered by base images
- [x] Runtime image validation (per provider) - covered by base images
- [x] FreeIPA image burning (per provider) - covered by base images
- [x] FreeIPA image validation (per provider) - covered by base images
- [x] Base image burning
  - AWS x86 - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8545/
  - AWS ARM64 - will be fixed later, see RELENG-31151
  - Azure - will be fixed later - apparently there's no RHEL 9.6 origin image for Azure
  - GCP - not affected, it's already on RHEL 9.6
- [ ] Base image validation - RHEL 9.6 validation is still blocked

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.