### PR TITLE
CB-30533 - This change is to prevent waagent from mounting ephemeral volumes in Azure.

### DIFF
--- a/saltstack/final/salt/waagent/init.sls
+++ b/saltstack/final/salt/waagent/init.sls
@@ -19,6 +19,30 @@ set_waagent_execute_user_data:
     - repl: "Provisioning.ExecuteCustomData=y"
     - onlyif: ls /etc/waagent.conf
 
+set_waagent_resourcedisk_format:
+  file.replace:
+    - name: /etc/waagent.conf
+    - pattern: "ResourceDisk.Format.*"
+    - repl: "ResourceDisk.Format=n"
+    - append_if_not_found: True
+    - onlyif: ls /etc/waagent.conf
+
+set_waagent_resourcedisk_swap:
+  file.replace:
+    - name: /etc/waagent.conf
+    - pattern: "ResourceDisk.EnableSwap.*"
+    - repl: "ResourceDisk.EnableSwap=n"
+    - append_if_not_found: True
+    - onlyif: ls /etc/waagent.conf
+
+set_waagent_resourcedisk_mount:
+  file.replace:
+    - name: /etc/waagent.conf
+    - pattern: "ResourceDisk.MountPoint.*"
+    - repl: "ResourceDisk.MountPoint="
+    - append_if_not_found: True
+    - onlyif: ls /etc/waagent.conf
+
 deprovision_waagent:
   cmd.run:
     - name: waagent -deprovision -force -verbose


### PR DESCRIPTION
This change is to prevent waagent from mounting ephemeral volumes in Azure.

1.  ResourceDisk.Format is the setting name that is related to formatting the ephemeral disk. Setting this to n will prevent Azure Linux agent from automatically formatting ephemeral disks.
2.  ResourceDisk.EnableSwap is the setting name that is related to creating and configuring a swap file on the ephemeral disk. Setting this to n will disable swap file on ephemeral disks.
3.  ResourceDisk.MountPoint is the setting name that is used to specify the mount point for the ephemeral disks. Setting this to empty will inform Azure Linux agent to not mount ephemeral disks.

## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.