### PR TITLE
CB-30572 fixing docker repository url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ ifeq ($(CLOUD_PROVIDER),GCP)
 	endif
 endif
 
-DOCKER_REPOSITORY ?= docker-sandbox.eng.cloudera.com
+DOCKER_REPOSITORY ?= docker-sandbox.infra.cloudera.com
 DOCKER_REPO_USERNAME ?= ""
 DOCKER_REPO_PASSWORD ?= ""
 


### PR DESCRIPTION
## Description

wrong docker registry url for yarn images