### PR TITLE
CB-29338: Fix default value of release-id tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OSCAP_SCAN_ENABLED ?= false
 CUSTOM_IMAGE_TYPE ?= "hortonworks"
 OWNER_TAG ?= "cloudbreak-dev"
 IMAGE_OWNER_TAG ?= "cloudbreak-dev"
-RELEASE_ID_TAG ?= ""
+RELEASE_ID_TAG ?= "none"
 OPTIONAL_STATES ?= ""
 # for splitting image copy (test and prod phases)
 IMAGE_COPY_PHASE ?= ""


### PR DESCRIPTION
## Description

Fix the default (empty) value of release-id tag

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation