### PR TITLE
CB-30635: Don't print SELinux policy installation logs to standard out, only to write them to the log file

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -861,6 +861,12 @@
       "remote_folder": "/opt/provision-scripts"
     },
     {
+      "type": "file",
+      "source": "/var/log/selinux/install-cdp-policies-allout.log",
+      "destination": "selinux-install-cdp-policies-allout.log",
+      "direction" : "download",
+    },
+    {
       "type": "shell",
       "script": "scripts/generate-delta-package-list.sh",
       "environment_vars": [

--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -252,6 +252,7 @@ run_install-policy-installer-policy.sh:
 run_install-cdp-policies.sh:
   cmd.run:
     - name: /etc/selinux/cdp/install-cdp-policies.sh 2>&1 | tee /var/log/selinux/install-cdp-policies-allout.log && exit ${PIPESTATUS[0]}
+    - hide_output: True
     - require:
       - file: /etc/selinux/cdp/install-cdp-policies.sh
       - file: /etc/selinux/cdp/policy-install-utils.sh


### PR DESCRIPTION
## Description

With the `hide_output: True` parameter, the output of the salt state is not printed in the salt state apply output. The logs for SELinux policy installation are still available under `/var/log/selinux`.

## How Has This Been Tested?

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [x] FreeIPA image burning (per provider)
  - http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8754/
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation