### PR TITLE
CB-1: chmod selinux logs, so that packer can download them

### DIFF
--- a/saltstack/base/salt/selinux/init.sls
+++ b/saltstack/base/salt/selinux/init.sls
@@ -257,6 +257,10 @@ run_install-cdp-policies.sh:
       - file: /etc/selinux/cdp/install-cdp-policies.sh
       - file: /etc/selinux/cdp/policy-install-utils.sh
 
+chmod_selinux_logs:
+  cmd.run:
+    - name: chmod 644 /var/log/selinux/*.log
+
 ## Useful SELinux policy development. Uncomment if needed.
 #disable_dontaudit_rules:
 #  cmd.run:


### PR DESCRIPTION
## Description

Make SELinux logs readable by non root users, so that Packer can download the policy install logs.

## How Has This Been Tested?

http://build.eng.hortonworks.com/job/cloudbreak-multi-packer-image-builder-salt-v3/8846/