### PR TITLE
CB-30646: Simplify the value of clouder usage type tag

### DIFF
--- a/scripts/get-cloudera-usage-type-tag.sh
+++ b/scripts/get-cloudera-usage-type-tag.sh
@@ -23,4 +23,4 @@ if [[ -n $RELEASE_ID_TAG ]]; then
   fi
 fi
 
-echo "cloudbreak-imagetracking-$RELEASE_ID_TAG-$IMAGE_OWNER_TAG"
+echo "cb-images-$RELEASE_ID_TAG-$IMAGE_OWNER_TAG"


### PR DESCRIPTION
## Description

We need to simplify the value of the mentioned tag because the GCP allows max 61 character, so the original idea was too long.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.