### PR TITLE
CB-32314 Fix SELinux denies coming from E2E tests as of 2026.03.20.

### DIFF
--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipa/cdp-ipa.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipa/cdp-ipa.te
@@ -90,6 +90,7 @@ gnome_search_gconf_data_dir(cdp_ipa_management_t)
 gen_require(`
     type gssproxy_t;
 ')
+gssproxy_systemctl(cdp_ipa_management_t)
 getattr_files_pattern(gssproxy_t, cdp_ipa_management_exec_t, cdp_ipa_management_exec_t)
 
 # hostname

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/ipahealthagent/cdp-ipahealthagent.te
@@ -44,6 +44,9 @@ manage_dirs_pattern(cdp_ipahealthagent_t, default_t, default_t)
 manage_files_pattern(cdp_ipahealthagent_t, default_t, default_t)
 exec_files_pattern(cdp_ipahealthagent_t, default_t, default_t)
 
+dirsrv_manage_config(cdp_ipahealthagent_t)
+dirsrv_read_share(cdp_ipahealthagent_t)
+
 logging_create_devlog_dev(cdp_ipahealthagent_t)
 
 gnome_search_gconf(cdp_ipahealthagent_t)

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/logging-agent/cdp-logging-agent.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/logging-agent/cdp-logging-agent.te
@@ -70,6 +70,12 @@ gnome_manage_home_config(cdp_logging_agent_t)
 gnome_manage_home_config_dirs(cdp_logging_agent_t)
 gnome_search_gconf(cdp_logging_agent_t)
 
+# Read sysfs files
+gen_require(`
+    type sysfs_t;
+')
+read_files_pattern(cdp_logging_agent_t, sysfs_t, sysfs_t)
+
 # Read and search even if DAC does not allow it
 allow cdp_logging_agent_t self:capability { dac_read_search };
 

--- a/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.te
+++ b/saltstack/base/salt/selinux/etc/selinux/cdp/salt/cdp-salt.te
@@ -469,10 +469,12 @@ relabel_files_pattern(cdp_salt_t, named_conf_t, named_conf_t)
 
 # networkmanager
 gen_require(`
+    type NetworkManager_etc_t;
     type NetworkManager_initrc_exec_t;
 ')
 networkmanager_read_conf(cdp_salt_t)
 list_dirs_pattern(cdp_salt_t, NetworkManager_initrc_exec_t, NetworkManager_initrc_exec_t)
+cdp_manage_pattern(cdp_salt_t, NetworkManager_etc_t, NetworkManager_etc_t)
 
 # opendnssec
 opendnssec_read_config(cdp_salt_t)
@@ -577,6 +579,7 @@ gen_require(`
     type games_exec_t;
     type lib_t;
     type root_t;
+    type sysfs_t;
     type tmp_t;
     type user_home_dir_t;
     type usr_t;
@@ -628,6 +631,7 @@ setattr_dirs_pattern(cdp_salt_t, user_home_dir_t, user_home_dir_t)
 cdp_manage_pattern(cdp_salt_t, bin_t, bin_t)
 cdp_manage_pattern(cdp_salt_t, lib_t, lib_t)
 cdp_manage_pattern(cdp_salt_t, self, self)
+cdp_manage_pattern(cdp_salt_t, sysfs_t, sysfs_t)
 cdp_manage_pattern(cdp_salt_t, usr_t, usr_t)
 cdp_manage_pattern(cdp_salt_t, var_lib_t, var_lib_t)
 


### PR DESCRIPTION
- RedHat 8 freeipa: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1814/
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5635/

- RedHat 8 prewarm: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1815/
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5641/

- RedHat 9 freeipa: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1816/
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5634/

- RedHat 9 prewarm: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1817/
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5636/