### PR TITLE
CB-32147 update node-exporter because of CVE-2022-46146 and CVE-2022-27664

### DIFF
--- a/saltstack/base/salt/monitoring/node-exporter.sls
+++ b/saltstack/base/salt/monitoring/node-exporter.sls
@@ -1,4 +1,4 @@
-{% set version = '1.3.1' %}
+{% set version = '1.7.0' %}
 {% set path = 'https://github.com/prometheus/node_exporter/releases/download/v' ~ version %}
 {% set architecture = 'arm64' if salt['environ.get']('ARCHITECTURE') == 'arm64' else 'amd64' %}
 {% set url = path ~ '/node_exporter-' ~ version ~ '.linux-' ~ architecture ~ '.tar.gz' %}


### PR DESCRIPTION
CB-32147 update node-exporter because of CVE-2022-46146 and CVE-2022-27664

## Description

as highlighted in OBS-10738: Node-exporter vulnerabilities to resolve in the next FreeIPA image release, there are known vulnerabilities in the 1.3.0 node-exporter version we use

the ask in this ticket is to try to update to a later version

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.