### PR TITLE
CB-32487: Restored rebooting RHEL9 ARM64 VMs during image creation

### DIFF
--- a/saltstack/final/salt/metadata/generate-package-versions.sls
+++ b/saltstack/final/salt/metadata/generate-package-versions.sls
@@ -1,6 +1,6 @@
 add_generate_package_versions_script:
   file.managed:
-    - name: /tmp/generate-package-versions.sh
+    - name: /opt/provision-scripts/generate-package-versions.sh
     - source: salt://{{ slspath }}/tmp/generate-package-versions.sh
     - skip_verify: True
     - makedirs: True
@@ -8,7 +8,7 @@ add_generate_package_versions_script:
 
 run_generate_package_versions:
   cmd.run:
-    - name: /tmp/generate-package-versions.sh {{ salt['pillar.get']('package_versions', '') }} 2>&1 >>/tmp/package-versions.log
+    - name: /opt/provision-scripts/generate-package-versions.sh {{ salt['pillar.get']('package_versions', '') }} 2>&1 >>/tmp/package-versions.log
     - env:
       - CLOUD_PROVIDER: {{ salt['environ.get']('CLOUD_PROVIDER') }}
     - require:

--- a/scripts/reboot.sh
+++ b/scripts/reboot.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 
-# This reboot causes problems with RHEL 9 ARM64 images and right now, not sure why...
-# We need to see if we need it at all. For now, it is disabled for this combo, but further testing is required.
-if [[ "${OS}" != "redhat9" || "${ARCHITECTURE}" != "arm64" ]] ; then
-  echo "Rebooting before validation and cleanup"
-  reboot
-fi
+echo "Rebooting before validation and cleanup"
+reboot


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider)
 - AWS ARM64 RHEL9 7.3.2 - https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1556/
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

**Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.