### PR TITLE
CB-32147 Update node-exporter to 1.7.0

### DIFF
--- a/saltstack/base/salt/monitoring/node-exporter.sls
+++ b/saltstack/base/salt/monitoring/node-exporter.sls
@@ -1,4 +1,4 @@
-{% set version = '1.3.1' %}
+{% set version = '1.7.0' %}
 {% set path = 'https://github.com/prometheus/node_exporter/releases/download/v' ~ version %}
 {% set architecture = 'arm64' if salt['environ.get']('ARCHITECTURE') == 'arm64' else 'amd64' %}
 {% set url = path ~ '/node_exporter-' ~ version ~ '.linux-' ~ architecture ~ '.tar.gz' %}


### PR DESCRIPTION
## Description

As per OBS-10738 Node-exporter vulnerabilities to resolve in the next FreeIPA image release, we need to update the nodex-exporter version because of some CVEs.

## How Has This Been Tested?

- [ ] Runtime image burning (per provider)
AWS: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1569/
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
AWS: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1568/
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation