### PR TITLE
CB-32599 copy-image fix following transition to managed images and updating az cli base image

### DIFF
--- a/scripts/azure-copy.sh
+++ b/scripts/azure-copy.sh
@@ -28,13 +28,13 @@ docker run -i --rm \
     -e AZURE_STORAGE_ACCOUNTS="$AZURE_STORAGE_ACCOUNTS" \
     -e AZURE_IMAGE_NAME="$AZURE_IMAGE_NAME" \
     --entrypoint azure-copy \
-    docker-sandbox.infra.cloudera.com/cloudbreak-tools/cloudbreak-azure-cli-tools:1.26.0
+    docker-sandbox.infra.cloudera.com/cloudbreak-tools/cloudbreak-azure-cli-tools:dev
 
 docker run -i --rm \
     -v $PWD:/work \
     -w /work \
     --entrypoint pollprogress \
-    docker-sandbox.infra.cloudera.com/cloudbreak-tools/cloudbreak-azure-cli-tools:1.26.0 \
+    docker-sandbox.infra.cloudera.com/cloudbreak-tools/cloudbreak-azure-cli-tools:dev \
     checks.yml
 
 : "${AZURE_STORAGE_ACCOUNTS:?Storage account list must be provided}"

--- a/scripts/azure-copy.sh
+++ b/scripts/azure-copy.sh
@@ -28,13 +28,13 @@ docker run -i --rm \
     -e AZURE_STORAGE_ACCOUNTS="$AZURE_STORAGE_ACCOUNTS" \
     -e AZURE_IMAGE_NAME="$AZURE_IMAGE_NAME" \
     --entrypoint azure-copy \
-    docker-sandbox.infra.cloudera.com/cloudbreak-tools/cloudbreak-azure-cli-tools:dev
+    docker-sandbox.infra.cloudera.com/cloudbreak-tools/cloudbreak-azure-cli-tools:1.27.0
 
 docker run -i --rm \
     -v $PWD:/work \
     -w /work \
     --entrypoint pollprogress \
-    docker-sandbox.infra.cloudera.com/cloudbreak-tools/cloudbreak-azure-cli-tools:dev \
+    docker-sandbox.infra.cloudera.com/cloudbreak-tools/cloudbreak-azure-cli-tools:1.27.0 \
     checks.yml
 
 : "${AZURE_STORAGE_ACCOUNTS:?Storage account list must be provided}"


### PR DESCRIPTION
## Description
**This can be reviewed now; switched to tag 1.27.0.**
This is just container image tag update for testing (switched azure cli tools to `dev` tag).
If review is ok and new tag (1.27.0) will be created then this PR will switch to that tag and then it can be merged.
See https://github.com/hortonworks/cloudbreak-azure-cli-tools/pull/29 for the real changes.

## How Has This Been Tested?
See the other PR for functionality related jobs.
Test job for the 1.27.0 tag: https://build.eng.cloudera.com/job/cloudbreak-copy-image/552