### PR TITLE
CB-32879 Forced usage of the RHEL 9.6 EUS repo part2

### DIFF
--- a/scripts/repo-setup.sh
+++ b/scripts/repo-setup.sh
@@ -28,8 +28,9 @@ function update_yum_repos() {
       rm /etc/yum.repos.d/*.repo -f
     fi
 
-    if [ "${RHEL_VERSION}" == "9.6" ]; then
+    if [ "${RHEL_VERSION}" == "9.6" && "${ARCHITECTURE}" == "x86_64" ]; then
 
+      # For now, this makes no sense, because excluded arm64 above - RE is still waiting for RedHat to give us the arm64 repos
       case "$ARCHITECTURE" in
         "arm64") basearch="aarch64" ;;
         *) basearch="x86_64" ;;


### PR DESCRIPTION
## Description

This is just a quick fix to exclude the arm64 repo - it's not ready yet, but we need the support for EUS merged already.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.