### PR TITLE
CB-30650: Add cloudera usage type lable to gcp images

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -567,15 +567,21 @@
       "disk_size": "{{user `image_size`}}",
       "state_timeout": "15m",
       "tags": [
-        "builder--packer",
-        "cb-creation-timestamp--{{timestamp}}",
-        "owner--{{ user `owner_tag` | clean_resource_name }}",
-        "cloudera-usage-type--{{ user `cloudera_usage_type_tag` | clean_resource_name }}",
         "customer-delivered--{{user `tag_customer_delivered` | clean_resource_name}}",
         "gcp-dev-cloudbreak-ingress-internet-deny",
         "gcp-dev-cloudbreak-egress-internet-allow",
         "gcp-dev-cloudbreak-ingress-rfc1918-allow"
-      ]
+      ],
+      "image_labels": {
+        "builder": "packer",
+        "cb-creation-timestamp": "{{timestamp}}",
+        "owner": "{{ user `owner_tag` | clean_resource_name }}",
+        "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      },
+      "labels": {
+        "owner": "{{ user `owner_tag` | clean_resource_name }}",
+        "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      }
     },
     {
       "name": "gc-redhat8",
@@ -606,15 +612,21 @@
         }
       ],
       "tags": [
-        "builder--packer",
-        "cb-creation-timestamp--{{timestamp}}",
-        "owner--{{ user `owner_tag` | clean_resource_name }}",
-        "cloudera-usage-type--{{ user `cloudera_usage_type_tag` | clean_resource_name }}",
         "customer-delivered--{{user `tag_customer_delivered` | clean_resource_name}}",
         "gcp-dev-cloudbreak-ingress-internet-deny",
         "gcp-dev-cloudbreak-egress-internet-allow",
         "gcp-dev-cloudbreak-ingress-rfc1918-allow"
-      ]
+      ],
+      "image_labels": {
+        "builder": "packer",
+        "cb-creation-timestamp": "{{timestamp}}",
+        "owner": "{{ user `owner_tag` | clean_resource_name }}",
+        "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      },
+      "labels": {
+        "owner": "{{ user `owner_tag` | clean_resource_name }}",
+        "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      }
     },
     {
       "name": "gc-redhat9",
@@ -645,15 +657,21 @@
         }
       ],
       "tags": [
-        "builder--packer",
-        "cb-creation-timestamp--{{timestamp}}",
-        "owner--{{ user `owner_tag` | clean_resource_name }}",
-        "cloudera-usage-type--{{ user `cloudera_usage_type_tag` | clean_resource_name }}",
         "customer-delivered--{{user `tag_customer_delivered` | clean_resource_name}}",
         "gcp-dev-cloudbreak-ingress-internet-deny",
         "gcp-dev-cloudbreak-egress-internet-allow",
         "gcp-dev-cloudbreak-ingress-rfc1918-allow"
-      ]
+      ],
+      "image_labels": {
+        "builder": "packer",
+        "cb-creation-timestamp": "{{timestamp}}",
+        "owner": "{{ user `owner_tag` | clean_resource_name }}",
+        "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      },
+      "labels": {
+        "owner": "{{ user `owner_tag` | clean_resource_name }}",
+        "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      }
     }
   ],
   "provisioners": [


### PR DESCRIPTION
## Description

Label cloudera-usage-type was added to the GCP images with new packer structure (instead of 'tags') because of the parameters in the tag structure are not passed to the image.

## How Has This Been Tested?

- [x] Runtime image burning (GCP) https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/1912

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.