### PR TITLE
CB-33083 Disable ephemeral disk format and mount on Azure during cloud-init

### DIFF
--- a/saltstack/base/salt/cloud-init/etc/cloud/cloud.cfg.d/51_azure-disable-ephemeral-disk.cfg
+++ b/saltstack/base/salt/cloud-init/etc/cloud/cloud.cfg.d/51_azure-disable-ephemeral-disk.cfg
@@ -1,0 +1,9 @@
+# CB-30533: Prevent cloud-init from formatting/mounting the Azure ephemeral resource disk.
+# Complements waagent ResourceDisk.Format/EnableSwap/MountPoint settings.
+mounts:
+  - [ephemeral0, null]
+  - [ephemeral0.1, null]
+
+disk_setup:
+  ephemeral0:
+    layout: false

--- a/saltstack/base/salt/cloud-init/init.sls
+++ b/saltstack/base/salt/cloud-init/init.sls
@@ -69,3 +69,13 @@ create_cloud-init_service_files:
         network_interface: {{ pillar['network_interface'] }}
 {% endif %}
 
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'Azure' %}
+disable_azure_ephemeral_disk_cloud_init:
+  file.managed:
+    - name: /etc/cloud/cloud.cfg.d/51_azure-disable-ephemeral-disk.cfg
+    - source: salt://{{ slspath }}/etc/cloud/cloud.cfg.d/51_azure-disable-ephemeral-disk.cfg
+    - user: root
+    - group: root
+    - mode: '0644'
+    - onlyif: test -x /usr/bin/cloud-init
+{% endif %}

--- a/saltstack/final/salt/cleanup/fstab.sls
+++ b/saltstack/final/salt/cleanup/fstab.sls
@@ -4,3 +4,8 @@ fstab_remove_xvdb:
     - mode: delete
     - content: "/dev/xvdb"
     - onlyif: ls /etc/fstab
+
+fstab_remove_azure_resource:
+  cmd.run:
+    - name: sed -i '/azure_resource-part[0-9][0-9]*/d' /etc/fstab
+    - onlyif: grep -qE 'azure_resource-part[0-9]+' /etc/fstab


### PR DESCRIPTION


## Description

Disable ephemeral disk format and mount on Azure during cloud-init in cloudbreak-images project.

Earlier task was to disable it in waagent.conf:

CB-30533: CB - image - edit /etc/waagent.conf to prevent waagent from mounting ephemeral volumes 
Resolved
 

But it seems that cloud-init will do the format and mounting, so we need to disable it in cloud-init as well.

The following configuration change is needed to disable it:

New config file with the following content is needed: (/etc/cloud/cloud.cfg.d/99-disable-resource-disk.cfg)



mounts:
  - [ ephemeral0, null ]


## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [X] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [X] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation
https://build.eng.cloudera.com/job/cloudbreak-image-burn-salt-v3-public/190/
https://build.eng.cloudera.com/job/cloudbreak-image-burn-salt-v3-public/192/
https://build.eng.cloudera.com/job/cloudbreak-image-burn-salt-v3-public/193/

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.