### PR TITLE
CB-28239 ipa-healtcheck should be available on new rhel9 images

### DIFF
--- a/saltstack/freeipa/salt/freeipa/init.sls
+++ b/saltstack/freeipa/salt/freeipa/init.sls
@@ -48,6 +48,7 @@ freeipa-install:
         - ipa-server-trust-ad
         - bind-dyndb-ldap
         - samba-client
+        - ipa-healthcheck
 {% endif %}
 
 {% if freeipa_plugin_rpm_url %}


### PR DESCRIPTION
## Description

ipa-healthcheck is a RedHat tool to check and diagnose FreeIPA. This commit introduces the ipa-healthcheck packages on new rhel9 images. The packages is should only be installed on freeipa image types.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
NA, package is only installed on FreeIPA images
- [ ] Runtime image validation (per provider)
NA, package is only installed on FreeIPA images
- [x] FreeIPA image burning (per provider)
https://build.eng.cloudera.com/view/all/job/cloudbreak-multi-packer-image-builder-salt-v3/2000/
- [x] FreeIPA image validation (per provider)
http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5799/
- [ ] Base image burning
NA, package is only installed on FreeIPA images
- [ ] Base image validation
NA, package is only installed on FreeIPA images
