### PR TITLE
CB-33272 Blocked GCE project SSH keys via Packer

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -581,6 +581,9 @@
       "labels": {
         "owner": "{{ user `owner_tag` | clean_resource_name }}",
         "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      },
+      "metadata": {
+        "block-project-ssh-keys": "true"
       }
     },
     {
@@ -626,6 +629,9 @@
       "labels": {
         "owner": "{{ user `owner_tag` | clean_resource_name }}",
         "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      },
+      "metadata": {
+        "block-project-ssh-keys": "true"
       }
     },
     {
@@ -671,6 +677,9 @@
       "labels": {
         "owner": "{{ user `owner_tag` | clean_resource_name }}",
         "cloudera-usage-type": "{{ user `cloudera_usage_type_tag` | clean_resource_name }}"
+      },
+      "metadata": {
+        "block-project-ssh-keys": "true"
       }
     }
   ],


### PR DESCRIPTION
## Description

This change tells Packer to add extra configuration via metadata to GCE when it creates a VM. Since before this, during VM creation project-wide users along with their public keys have been imported into the VM, they stayed on the image that has been created from the given VM. The configuration we've added disables importing these users and keys.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider)
 - GCP RHEL9 - https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2032/
- [x] Runtime image validation (per provider) - not needed, this change has only removes an unwanted user and its home folder
- [x] FreeIPA image burning (per provider) - not needed, this change has the same effect on all images
- [x] FreeIPA image validation (per provider) - not needed
- [x] Base image burning - not needed
- [x] Base image validation - not needed

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.