### PR TITLE
CB-32597 Update prometheus to 3.5.0

### DIFF
--- a/saltstack/base/salt/monitoring/cdp-prometheus.sls
+++ b/saltstack/base/salt/monitoring/cdp-prometheus.sls
@@ -1,4 +1,4 @@
-{% set version = '2.54.1' %}
+{% set version = '3.5.0' %}
 {% set path = 'https://github.com/prometheus/prometheus/releases/download/v' ~ version %}
 {% set architecture = 'arm64' if salt['environ.get']('ARCHITECTURE') == 'arm64' else 'amd64' %}
 {% set url = path ~ '/prometheus-' ~ version ~ '.linux-' ~ architecture ~ '.tar.gz' %}


### PR DESCRIPTION
## Description

As per OBS-10200 Prometheus has vulnerabilities which need to resolve in the next FreeIPA image release, we need to update the Prometheus version because of those CVEs.

## How Has This Been Tested?

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.