### PR TITLE
CDPAM-6608 | update jumpgate agent RPM to 3.15.0

### DIFF
--- a/docker/redhat8/Dockerfile
+++ b/docker/redhat8/Dockerfile
@@ -106,7 +106,7 @@ ENV INCLUDE_FLUENT="Yes"
 ENV INCLUDE_CDP_TELEMETRY="Yes"
 ENV FREEIPA_PLUGIN_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/49070467/thunderhead/1.x/redhat8/yum/cdp-hashed-pwd-1.0-20240109061814git4230396.el8.x86_64.rpm"
 ENV FREEIPA_LDAP_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/49050621/thunderhead/1.x/redhat8/yum/freeipa-ldap-agent-1.0.0-b12325.x86_64.rpm"
-ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.14.0/jumpgate-agent.rpm"
+ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.15.0/jumpgate-agent.rpm"
 
 #we build logic on the existance of this directory, please DO NOT REMOVE
 RUN mkdir /yarn-private

--- a/docker/redhat9.6/Dockerfile
+++ b/docker/redhat9.6/Dockerfile
@@ -108,7 +108,7 @@ ENV INCLUDE_FLUENT="Yes"
 ENV INCLUDE_CDP_TELEMETRY="Yes"
 ENV FREEIPA_PLUGIN_RPM_URL="https://archive.cloudera.com/cdp-freeipa-artifacts/cdp-hashed-pwd-1.1-b847.el7.x86_64.rpm"
 ENV FREEIPA_LDAP_AGENT_RPM_URL="https://archive.cloudera.com/cdp-freeipa-artifacts/freeipa-ldap-agent-1.1.0.3-b525.x86_64.rpm"
-ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.14.0/jumpgate-agent.rpm"
+ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.15.0/jumpgate-agent.rpm"
 #we build logic on the existance of this directory, please DO NOT REMOVE
 RUN mkdir /yarn-private
 

--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -59,7 +59,7 @@ packer_in_container() {
     if [[ "$ARCHITECTURE" == "arm64" ]]; then
       export JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.13.0/jumpgate-agent.aarch64.rpm"
     else
-      export JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.14.0/jumpgate-agent.rpm"
+      export JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.15.0/jumpgate-agent.rpm"
     fi
   fi
 


### PR DESCRIPTION
## Description

This updates the jumpgate agent RPM version that needs to be baked with the  freeIPA images to the latest one.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.