### PR TITLE
CB-33549 Remove unbound-local-root.conf on all RHEL9 providers

### DIFF
--- a/saltstack/hortonworks/salt/unbound/init.sls
+++ b/saltstack/hortonworks/salt/unbound/init.sls
@@ -13,11 +13,14 @@ config_unbound_server:
     - source: salt://{{ slspath }}/etc/unbound/unbound.conf
     - mode: 644
 
-# This is needed because of CB-30897
-{% if salt['environ.get']('OS') == 'redhat9' and salt['environ.get']('CLOUD_PROVIDER') == 'GCP' %}
-config_unbound_for_rhel9_on_gcp:
-  cmd.run:
-    - name: rm /etc/unbound/conf.d/unbound-local-root.conf
+# CB-30897 / CB-33549: RHEL 9 unbound ships unbound-local-root.conf which activates an
+# auth-zone "." (local root copy). auth-zone outranks our forward-zones, so the node-local
+# caching forwarder answers root queries locally instead of forwarding to the VPC resolver,
+# breaking resolution of internal-only TLDs. Affects all cloud providers on RHEL 9, not just GCP.
+{% if salt['environ.get']('OS') == 'redhat9' %}
+config_unbound_for_rhel9:
+  file.absent:
+    - name: /etc/unbound/conf.d/unbound-local-root.conf
 {% endif %}
 
 {% if grains['init'] == 'systemd' %}


### PR DESCRIPTION
RHEL 9's unbound ships unbound-local-root.conf, activating an auth-zone "." (local root copy) that outranks our forward-zones. The node-local caching forwarder then answers root queries locally instead of forwarding to the VPC resolver, so internal-only TLDs (e.g. .internal) return NXDOMAIN and break getent, applications, and Kerberos hostname resolution.

CB-30897 removed the file but gated it to GCP only; AWS and Azure RHEL 9 images are still affected (ENGESC-33723). Drop the CLOUD_PROVIDER == 'GCP' condition so the removal applies to all providers on RHEL 9, using file.absent (idempotent, and correctly removes the package-shipped symlink).

## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [X] Runtime image burning (per provider)
AWS: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2256/
Azure: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2257/
GCP: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2258/
- [X] Runtime image validation (per provider)
AWS: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5898/
Azure: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5899/
GCP: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5900/
- [ ] FreeIPA image burning (per provider) 
Not relevant for freeipa
- [ ] FreeIPA image validation (per provider) 
Not relevant for freeipa
- [ ] Base image burning 
Not relevant
- [ ] Base image validation 
Not relevant

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.