### PR TITLE
CB-33636 set specific vm.max_map_count on the host images

### DIFF
--- a/saltstack/base/salt/prerequisites/sysctl.sls
+++ b/saltstack/base/salt/prerequisites/sysctl.sls
@@ -53,3 +53,8 @@ vm.dirty_ratio:
 net.ipv4.tcp_retries2:
   sysctl.present:
     - value: 7
+
+vm.max_map_count:
+  sysctl.present:
+    - value: 1048576
+    - config: /etc/sysctl.d/99-opensearch.conf


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.