### PR TITLE
CB-33705 Remove condition so that cloud-init configs run on Azure

### DIFF
--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -2,7 +2,6 @@ base:
   '*':
     - prerequisites
     - cloud-init
-{% endif %}
     - hostname
     - nginx
     - python3

--- a/saltstack/base/salt/top.sls
+++ b/saltstack/base/salt/top.sls
@@ -1,7 +1,6 @@
 base:
   '*':
     - prerequisites
-{% if not salt['file.file_exists']('/etc/waagent.conf') %}
     - cloud-init
 {% endif %}
     - hostname


### PR DESCRIPTION
## Description

CB-33705 Remove condition so that cloud-init configs run on Azure

- [x] Runtime image burning (per provider) https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2401/console
- [x] Runtime image validation (per provider) http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5932/console
- [x] FreeIPA image burning (per provider) https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2402/console
- [x] FreeIPA image validation (per provider) http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5933/console
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.