### PR TITLE
Update salt to 3006.27

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -762,6 +762,11 @@
     },
     {
       "type": "file",
+      "source": "scripts/salt_3006.27_requirements.txt",
+      "destination": "/tmp/salt_3006.27_requirements.txt"
+    },
+    {
+      "type": "file",
       "source": "scripts/rhel8_salt_fix.patch",
       "destination": "/tmp/rhel8_salt_fix.patch"
     },

--- a/scripts/get-salt-version.sh
+++ b/scripts/get-salt-version.sh
@@ -15,15 +15,15 @@ if [[ $BASE_NAME == "cb" ]]; then
     COMP_RESULT=$?
     # Runtime version >= 7.3.1
     if [[ $COMP_RESULT -lt 2 ]]; then
-      SALT_VERSION=3006.10
+      SALT_VERSION=3006.27
     fi
   # Base images
   else
-    SALT_VERSION=3006.10
+    SALT_VERSION=3006.27
   fi
 # FreeIPA images - TODO: we need to test this!
 else
-    SALT_VERSION=3006.10
+    SALT_VERSION=3006.27
 fi
 
 echo $SALT_VERSION

--- a/scripts/salt-install.sh
+++ b/scripts/salt-install.sh
@@ -5,6 +5,33 @@
 
 set -ex -o pipefail -o errexit
 
+function compare_version () {
+  if [[ $1 == $2 ]]; then
+    return 0
+  fi
+  local IFS=.
+  local i version1=($1) version2=($2)
+  # Fill empty fields in version1 with zeros
+  for ((i=${#version1[@]}; i<${#version2[@]}; i++))
+  do
+    version1[i]=0
+  done
+  for ((i=0; i<${#version1[@]}; i++))
+  do
+    # Fill empty fields in version2 with zeros
+    if [[ -z ${version2[i]} ]]; then
+      version2[i]=0
+    fi
+    if ((10#${version1[i]} > 10#${version2[i]})); then
+      return 1
+    fi
+    if ((10#${version1[i]} < 10#${version2[i]})); then
+      return 2
+    fi
+  done
+  return 0
+}
+
 function install_salt_with_pip3() {
 
   echo "Installing salt with version: $SALT_VERSION"
@@ -20,11 +47,17 @@ function install_salt_with_pip3() {
 
   # Anything installed after this point will end up Salt's venv
   mkdir ${SALT_PATH}
-  if [ "${SALT_VERSION}" == "3006.10" ] ; then
+
+  # Salt >= 3006.10 requires the Python 3.11 venv
+  set +e
+  compare_version "$SALT_VERSION" 3006.10; COMP_RESULT=$?
+  set -e
+  if (( COMP_RESULT == 0 || COMP_RESULT == 1 )); then
     python3.11 -m virtualenv ${SALT_PATH}
   else
     python3 -m virtualenv ${SALT_PATH}
   fi
+
   source ${SALT_PATH}/bin/activate
   python3 -m pip install --upgrade pip
 

--- a/scripts/salt_3006.27_requirements.txt
+++ b/scripts/salt_3006.27_requirements.txt
@@ -1,0 +1,15 @@
+setuptools
+msgpack
+pyyaml
+looseversion
+packaging
+distro
+jinja2
+cryptography
+zmq
+cherrypy
+virtualenvwrapper
+markupsafe
+tornado
+PyOpenSSL
+salt==${SALT_VERSION}


### PR DESCRIPTION
## Description

Update salt to 3006.27

- [ ] Runtime image burning (per provider)
  - AWS https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2411/
  - Azure https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2421/
  - GCP https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2422/
  - AWS arm64 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2434/
- [ ] Runtime image validation (per provider)
  - AWS http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5934/
  - Azure http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5936/
  - GCP http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5939/
  - AWS arm64 http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5940/
- [ ] FreeIPA image burning (per provider)
  - AWS https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2426/
- [ ] FreeIPA image validation (per provider)
  - AWS http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5935/
- [ ] Base image burning
  - YARN https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2438/
- [ ] Base image validation
  - YARN http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5942/