### PR TITLE
[WIP] CB-26774 Use scap-security-guide RPM playbooks for CIS remediation

### DIFF
--- a/saltstack/final/salt/cis-controls/redhat8.sls
+++ b/saltstack/final/salt/cis-controls/redhat8.sls
@@ -132,11 +132,29 @@ add_cis_control_sh:
         additional_tags: ""
 {% endif %}
 
+# cis_control.sh remediates using the Ansible playbooks shipped by scap-security-guide
+# (/usr/share/scap-security-guide/ansible/), so the package must be present beforehand.
+install_scap_security_guide_for_cis:
+  pkg.installed:
+    - name: scap-security-guide
+
 execute_cis_control_sh:
   cmd.run:
     - name: /opt/provision-scripts/cis_control.sh
+    - require:
+      - file: add_cis_control_sh
+      - pkg: install_scap_security_guide_for_cis
     - env:
       - IMAGE_BASE_NAME: {{ salt['environ.get']('IMAGE_BASE_NAME') }}
       - CLOUD_PROVIDER: {{ salt['environ.get']('CLOUD_PROVIDER') }}
       - STIG_ENABLED: {{ salt['environ.get']('STIG_ENABLED') }}
       - OS: {{ salt['environ.get']('OS') }}
+
+# The openscap scan (which also installs scap-security-guide and reinstalls it as needed)
+# only runs when OSCAP_SCAN_ENABLED=true, so remove the package here to avoid shipping it
+# in images built without the scan.
+remove_scap_security_guide_after_cis:
+  pkg.removed:
+    - name: scap-security-guide
+    - require:
+      - cmd: execute_cis_control_sh

--- a/saltstack/final/salt/cis-controls/redhat9.sls
+++ b/saltstack/final/salt/cis-controls/redhat9.sls
@@ -136,11 +136,29 @@ add_cis_control_sh:
         additional_tags: ""
 {% endif %}
 
+# cis_control.sh remediates using the Ansible playbooks shipped by scap-security-guide
+# (/usr/share/scap-security-guide/ansible/), so the package must be present beforehand.
+install_scap_security_guide_for_cis:
+  pkg.installed:
+    - name: scap-security-guide
+
 execute_cis_control_sh:
   cmd.run:
     - name: /opt/provision-scripts/cis_control.sh
+    - require:
+      - file: add_cis_control_sh
+      - pkg: install_scap_security_guide_for_cis
     - env:
       - IMAGE_BASE_NAME: {{ salt['environ.get']('IMAGE_BASE_NAME') }}
       - CLOUD_PROVIDER: {{ salt['environ.get']('CLOUD_PROVIDER') }}
       - STIG_ENABLED: {{ salt['environ.get']('STIG_ENABLED') }}
       - OS: {{ salt['environ.get']('OS') }}
+
+# The openscap scan (which also installs scap-security-guide and reinstalls it as needed)
+# only runs when OSCAP_SCAN_ENABLED=true, so remove the package here to avoid shipping it
+# in images built without the scan.
+remove_scap_security_guide_after_cis:
+  pkg.removed:
+    - name: scap-security-guide
+    - require:
+      - cmd: execute_cis_control_sh

--- a/saltstack/final/salt/cis-controls/scripts/cis_control.sh
+++ b/saltstack/final/salt/cis-controls/scripts/cis_control.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 set -ex -o pipefail -o errexit
 
-# Remediating the system to align with the CIS L1 baseline using an SSG Ansible playbook
-# The ansible playbook is available at
-# https://github.com/AutomateCompliance/AnsibleCompliancePlaybooks/blob/main/rhel8-playbook-cis_server_l1.yml
-# https://github.com/AutomateCompliance/AnsibleCompliancePlaybooks/blob/main/rhel8-playbook-stig.yml
+# Remediating the system to align with the CIS L1 baseline using an SSG Ansible playbook.
+# The playbooks are shipped by Red Hat's scap-security-guide RPM (installed in
+# cis-controls/redhat{8,9}.sls) under /usr/share/scap-security-guide/ansible/, e.g.:
+#   /usr/share/scap-security-guide/ansible/rhel8-playbook-cis_server_l1.yml
+#   /usr/share/scap-security-guide/ansible/rhel8-playbook-stig.yml
+# Using the RPM-provided content keeps remediation in lockstep with the SSG datastream
+# used by the openscap scan, instead of cloning the stale AutomateCompliance mirror.
 
 ANSIBLE_PATH=/mnt/tmp/ansible
+SSG_ANSIBLE_DIR=/usr/share/scap-security-guide/ansible
 
 if [ "${STIG_ENABLED}" == "True" ]; then
     # The list of tags of ansible tasks from the above-mentioned playbook that would break functionality, so we are skipping temporarily
@@ -60,8 +64,13 @@ case ${OS} in
     python3 -m pip install ansible "ansible-core==2.13"
     ;;
 esac
-yum install -y git
-git clone https://github.com/AutomateCompliance/AnsibleCompliancePlaybooks.git $ANSIBLE_PATH/ansible-compliance-playbooks
+
+# The SSG Ansible playbooks are provided by the scap-security-guide RPM, which is
+# installed by the calling salt state (cis-controls/redhat{8,9}.sls) before this runs.
+if [ ! -d "$SSG_ANSIBLE_DIR" ]; then
+    echo "scap-security-guide playbooks not found at $SSG_ANSIBLE_DIR" >&2
+    exit 1
+fi
 
 #Generate missing host keys as they are needed by the playbook
 ssh-keygen -A
@@ -71,10 +80,10 @@ mkdir -p /tmp/cis
 chmod 777 /tmp/cis
 
 if [ "${STIG_ENABLED}" == "True" ]; then
-    ansible-playbook -i localhost, -c local $ANSIBLE_PATH/ansible-compliance-playbooks/$PLAYBOOK-stig.yml --skip-tags $SKIP_TAGS | tee /tmp/cis/stig_log.txt
+    ansible-playbook -i localhost, -c local $SSG_ANSIBLE_DIR/$PLAYBOOK-stig.yml --skip-tags $SKIP_TAGS | tee /tmp/cis/stig_log.txt
     chmod 777 /tmp/cis/stig_log.txt
 else
-    ansible-playbook -i localhost, -c local $ANSIBLE_PATH/ansible-compliance-playbooks/$PLAYBOOK-cis_server_l1.yml --skip-tags $SKIP_TAGS --extra-vars "$EXTRA_VARS" | tee /tmp/cis/cis_log.txt
+    ansible-playbook -i localhost, -c local $SSG_ANSIBLE_DIR/$PLAYBOOK-cis_server_l1.yml --skip-tags $SKIP_TAGS --extra-vars "$EXTRA_VARS" | tee /tmp/cis/cis_log.txt
     chmod 777 /tmp/cis/cis_log.txt
 fi
 

--- a/saltstack/final/salt/cis-controls/scripts/cis_control.sh
+++ b/saltstack/final/salt/cis-controls/scripts/cis_control.sh
@@ -48,6 +48,8 @@ if [ "${OS}" == "redhat9" ]; then
     SKIP_TAGS+=",accounts_umask_etc_bashrc"
 fi
 
+SKIP_TAGS+=",firewalld_loopback_traffic_restricted,firewalld_loopback_traffic_trusted"
+
 SKIP_TAGS+="{{ additional_tags }}"
 
 #Install and download what we need for the hardening


### PR DESCRIPTION
## Description

Remediate CIS L1 / STIG from the Ansible playbooks shipped by Red Hat's scap-security-guide RPM (/usr/share/scap-security-guide/ansible/) instead of cloning the stale AutomateCompliance mirror at build time. This keeps remediation content in lockstep with the SSG datastream used by the openscap scan and removes the build-time GitHub dependency.

- cis_control.sh: drop 'yum install git' + git clone; reference $SSG_ANSIBLE_DIR directly with a presence guard.
- redhat{8,9}.sls: install scap-security-guide before running the script and remove it afterwards, so images built without the openscap scan (OSCAP_SCAN_ENABLED=false) don't ship the package.

## How Has This Been Tested?

- [ ] Runtime image burning (per provider)
  - AWS https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2439/
- [ ] Runtime image validation (per provider)
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation