### PR TITLE
CB-30406 Replace the hardcoded /dev/nvme1n1 AWS RHEL8/9 states with detection

### DIFF
--- a/saltstack/base/salt/mount/init.sls
+++ b/saltstack/base/salt/mount/init.sls
@@ -16,17 +16,30 @@ mount-nfs-sequentially-service-start:
     - require:
       - file: mount-nfs-sequentially-service-file
 {% elif pillar['OS'] == 'redhat8' or pillar['OS'] == 'redhat9' %}
-format-additional-disk:
+format-and-mount-additional-disk:
   cmd.run:
-    - name: mkfs.xfs /dev/nvme1n1
-
-create-additional-disk-mount-point:
-  file.directory:
-    - name: /mnt/tmp/
-
-mount-additional-disk:
-  cmd.run:
-    - name: mount /dev/nvme1n1 /mnt/tmp/
+    - name: |
+        set -euo pipefail
+        # Pick the unpartitioned, unmounted whole disk (the extra EBS scratch volume).
+        # NVMe device indices are NOT stable on Nitro instances, so never assume
+        # /dev/nvme1n1 - the root volume can enumerate there instead (see CB-30406).
+        disk=""
+        for d in $(lsblk -dno NAME,TYPE | awk '$2=="disk"{print $1}'); do
+          if [ -z "$(lsblk -no MOUNTPOINT "/dev/$d" | tr -d '[:space:]')" ] \
+             && [ "$(lsblk -no NAME "/dev/$d" | grep -c .)" -eq 1 ]; then
+            disk="/dev/$d"; break
+          fi
+        done
+        if [ -z "$disk" ]; then
+          echo "ERROR: no free (unpartitioned, unmounted) additional disk found" >&2
+          lsblk >&2
+          exit 1
+        fi
+        echo "Using additional disk: $disk"
+        mkfs.xfs -f "$disk"
+        mkdir -p /mnt/tmp
+        mount "$disk" /mnt/tmp/
+    - unless: mountpoint -q /mnt/tmp
 {% endif %}
 {% elif salt['environ.get']('CLOUD_PROVIDER') == "GCP" and pillar['OS'] == 'redhat8' %}
 format-additional-disk:


### PR DESCRIPTION
## Description

CB-30406 Replace the hardcoded /dev/nvme1n1 AWS RHEL8/9 states with detection

Replace the hardcoded /dev/nvme1n1 AWS RHEL8/9 states with detection that picks the unpartitioned, unmounted whole disk (the scratch EBS volume) regardless of NVMe enumeration order — so it can never target the root disk again. Guarded by unless: mountpoint -q /mnt/tmp (idempotent) and fails loudly with an lsblk dump if no free disk is found.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
  - AWS https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2440/consoleFull
- [ ] Runtime image validation (per provider)
  - http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/5943/console
- [ ] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation
