### PR TITLE
CB-33707 Use latest cdp-telemetry release for new images (cb and free…

### DIFF
--- a/saltstack/base/salt/telemetry/init.sls
+++ b/saltstack/base/salt/telemetry/init.sls
@@ -18,6 +18,13 @@ add_cdp_infra_tools_repo:
     - template: jinja
     - platform: "{{ platform }}"
 
+add_cdp_infra_tools_pinned_repo:
+  file.managed:
+    - name: /etc/yum.repos.d/cdp-infra-tools-pinned.repo
+    - source: salt://telemetry/yum/cdp-infra-tools-pinned.repo.j2
+    - template: jinja
+    - platform: "{{ platform }}"
+
 list_available_packages_from_cdp_infra_tools_repo:
   cmd.run:
     - name: yum --disablerepo="*" --enablerepo=cdp-infra-tools list available
@@ -41,6 +48,10 @@ install_cdp_infra_tools_packages:
 remove_cdp_infra_tools_repo:
   file.absent:
     - name: /etc/yum.repos.d/cdp-infra-tools.repo
+
+remove_cdp_infra_tools_pinned_repo:
+  file.absent:
+    - name: /etc/yum.repos.d/cdp-infra-tools-pinned.repo
 
 # TODO: Why do we need this override? Do we still need this?
 {% if salt['environ.get']('CLOUD_PROVIDER') != "AWS_GOV" %}

--- a/saltstack/base/salt/telemetry/yum/cdp-infra-tools-latest.repo.j2
+++ b/saltstack/base/salt/telemetry/yum/cdp-infra-tools-latest.repo.j2
@@ -1,7 +1,7 @@
 [cdp-infra-tools]
 name=CDP Infra Tools
-baseurl=https://archive.cloudera.com/cdp-infra-tools/1.3.12/{{ platform }}/yum/
+baseurl=https://archive.cloudera.com/cdp-infra-tools/latest/{{ platform }}/yum/
 enabled=1
 priority=1
 gpgcheck=1
-gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.12/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+gpgkey=https://archive.cloudera.com/cdp-infra-tools/latest/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins

--- a/saltstack/base/salt/telemetry/yum/cdp-infra-tools-pinned.repo.j2
+++ b/saltstack/base/salt/telemetry/yum/cdp-infra-tools-pinned.repo.j2
@@ -1,0 +1,7 @@
+[cdp-infra-tools-pinned]
+name=CDP Infra Tools Pinned
+baseurl=https://archive.cloudera.com/cdp-infra-tools/1.3.12/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.12/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins


### PR DESCRIPTION
…ipa)

- Update cdp-infra-tools-latest.repo.j2 to use latest URL instead of 1.3.12
- Add cdp-infra-tools-pinned.repo.j2 pointing to 1.3.12 for cdp-logging-agent
- Add/remove pinned repo states in init.sls so both repos are active during install

## Description

Use latest cdp-telemetry release for new images (cb and freeipa)

## How Has This Been Tested?

Not tested.

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.