### PR TITLE
CB-33707 Rearranged cdp-infra-tools repo files for easier version pinning

### DIFF
--- a/saltstack/base/salt/telemetry/init.sls
+++ b/saltstack/base/salt/telemetry/init.sls
@@ -3,57 +3,43 @@
   {% set platform = platform ~ 'arm64' %}
 {% endif %}
 
-# TODO: Use the cdp-infra-tools-internal repo file for Internal releases (assuming there's an UNIREL ticket, etc)
-# TODO: Use the cdp-infra-tools-latest repo file for Base releases
 add_cdp_infra_tools_repo:
   file.managed:
     - name: /etc/yum.repos.d/cdp-infra-tools.repo
-{% if salt['environ.get']('IMAGE_BURNING_TYPE') == 'prewarm' and salt['environ.get']('STACK_VERSION').split('.') | map('int') | list >= '7.3.2'.split('.') | map('int') | list %}
-    - source: salt://telemetry/yum/cdp-infra-tools-latest.repo.j2
-{% elif salt['environ.get']('IMAGE_BURNING_TYPE') == 'base' or salt['environ.get']('IMAGE_BURNING_TYPE') == 'freeipa' %}
-    - source: salt://telemetry/yum/cdp-infra-tools-latest.repo.j2
-{% else %}
     - source: salt://telemetry/yum/cdp-infra-tools.repo.j2
-{% endif %}
     - template: jinja
     - platform: "{{ platform }}"
 
 list_available_packages_from_cdp_infra_tools_repo:
   cmd.run:
-    - name: yum --disablerepo="*" --enablerepo=cdp-infra-tools list available
+    - name: dnf repoquery --show-duplicates --disablerepo="*" --enablerepo="cdp-infra-tools-*" --qf "%{name}-%{version}-%{release}.%{arch} \t\t\t %{repoid}"
 
 install_cdp_infra_tools_packages:
   pkg.installed:
     - pkgs:
 {% if salt['environ.get']('INCLUDE_CDP_TELEMETRY') == "Yes" %}
-      - cdp-telemetry
+  {% if salt['environ.get']('IMAGE_BURNING_TYPE') == 'prewarm' and salt['environ.get']('STACK_VERSION').split('.') | map('int') | list <= '7.3.1'.split('.') | map('int') | list %}
+      - cdp-telemetry: 1.3.10_b1
+  {% else %}
+      - cdp-telemetry: 1.3.14_b2
+  {% endif %}
 {% endif %}
 {% if salt['environ.get']('INCLUDE_FLUENT') == "Yes" %}
   {% if pillar['OS'] != 'redhat9' %}
       - redhat-lsb-core # this will install redhat-lsb-core which is required for fluent (but not on RHEL 9 as it's not available there!)
   {% endif %}
-      - cdp-logging-agent
+  {% if salt['environ.get']('IMAGE_BURNING_TYPE') == 'prewarm' and salt['environ.get']('STACK_VERSION').split('.') | map('int') | list <= '7.3.1'.split('.') | map('int') | list %}
+      - cdp-logging-agent: 1.3.10_b1
+  {% else %}
+      - cdp-logging-agent: 1.3.12_b1
+  {% endif %}
 {% endif %}
 {% if pillar['OS'] == 'redhat9' %}
-      - cdp-request-signer # For other OSes there's an override - see a few lines below
+      - cdp-request-signer: 1.3.14_b2
+{% else %} # Why do we need this override? Do we still need this?
+      - cdp-request-signer: 1.3.7_b2
 {% endif %}
 
 remove_cdp_infra_tools_repo:
   file.absent:
     - name: /etc/yum.repos.d/cdp-infra-tools.repo
-
-# TODO: Why do we need this override? Do we still need this?
-{% if salt['environ.get']('CLOUD_PROVIDER') != "AWS_GOV" %}
-override_cdp_request_signer:
-  cmd.run:
-    - name: |
-{% if pillar['OS'] == 'redhat8' and salt['environ.get']('ARCHITECTURE') == 'arm64' %}
-        dnf -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat8arm64/yum/cdp_request_signer-1.3.7_b2.rpm
-{% elif pillar['OS'] == 'redhat8' %}
-        dnf -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat8/yum/cdp_request_signer-1.3.7_b2.rpm
-{% elif pillar['OS'] == 'centos7' %}
-        yum -y install https://archive.cloudera.com/cdp-infra-tools/1.3.7/redhat7/yum/cdp_request_signer-1.3.7_b2.rpm
-{% else %}
-        echo "No override for RHEL 9."
-{% endif %}
-{% endif %}

--- a/saltstack/base/salt/telemetry/yum/cdp-infra-tools-internal.repo.j2
+++ b/saltstack/base/salt/telemetry/yum/cdp-infra-tools-internal.repo.j2
@@ -1,7 +1,0 @@
-[cdp-infra-tools]
-name=CDP Infra Tools
-baseurl=https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/69373518/cdp-infra-tools/0.x/{{ platform }}/yum/
-enabled=1
-priority=1
-gpgcheck=1
-gpgkey=https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/69373518/cdp-infra-tools/0.x/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins

--- a/saltstack/base/salt/telemetry/yum/cdp-infra-tools-latest.repo.j2
+++ b/saltstack/base/salt/telemetry/yum/cdp-infra-tools-latest.repo.j2
@@ -1,7 +1,0 @@
-[cdp-infra-tools]
-name=CDP Infra Tools
-baseurl=https://archive.cloudera.com/cdp-infra-tools/1.3.12/{{ platform }}/yum/
-enabled=1
-priority=1
-gpgcheck=1
-gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.12/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins

--- a/saltstack/base/salt/telemetry/yum/cdp-infra-tools.repo.j2
+++ b/saltstack/base/salt/telemetry/yum/cdp-infra-tools.repo.j2
@@ -1,7 +1,54 @@
-[cdp-infra-tools]
-name=CDP Infra Tools
+# Legacy - Used in some old builds based on CentOS 7 / RHEL 8
+[cdp-infra-tools-internal]
+name=CDP Infra Tools Internal Builds
+baseurl=https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/69373518/cdp-infra-tools/0.x/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/69373518/cdp-infra-tools/0.x/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+skip_if_unavailable=true
+
+# Automatically points to the latest build
+[cdp-infra-tools-latest]
+name=CDP Infra Tools Latest Build
+baseurl=https://archive.cloudera.com/cdp-infra-tools/latest/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://archive.cloudera.com/cdp-infra-tools/latest/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+
+# Legacy - Used in some old builds based on CentOS 7 / RHEL 8
+[cdp-infra-tools-1.3.7]
+name=CDP Infra Tools v1.3.7
+baseurl=https://archive.cloudera.com/cdp-infra-tools/1.3.7/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.7/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+skip_if_unavailable=true
+
+# Legacy - Used in some old builds based on CentOS 7 / RHEL 8
+[cdp-infra-tools-1.3.10]
+name=CDP Infra Tools v1.3.10
 baseurl=https://archive.cloudera.com/cdp-infra-tools/1.3.10/{{ platform }}/yum/
 enabled=1
 priority=1
 gpgcheck=1
 gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.10/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+skip_if_unavailable=true
+
+[cdp-infra-tools-1.3.12]
+name=CDP Infra Tools v1.3.12
+baseurl=https://archive.cloudera.com/cdp-infra-tools/1.3.12/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.12/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+
+[cdp-infra-tools-1.3.14]
+name=CDP Infra Tools v1.3.14
+baseurl=https://archive.cloudera.com/cdp-infra-tools/1.3.14/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.14/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider)
 - Azure 7.3.2.10000 RHEL9 - https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2489/
- [x] Runtime image validation (per provider)
 - Not necessary.
- [x] FreeIPA image burning (per provider)
 - GCP RHEL9 - https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2487/
- [x] FreeIPA image validation (per provider)
 - Not necessary
- [x] Base image burning
 - AWS ARM64 RHEL8 - https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2494/
 - YARN RHEL9 - https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2495/
- [x] Base image validation
 - Not necessary

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.