### PR TITLE
CB-33242 Add SALTBOOT_HTTPS_ONLY when HTTPS is enabled

### DIFF
--- a/saltstack/base/salt/salt-bootstrap/etc/systemd/system/salt-bootstrap.service
+++ b/saltstack/base/salt/salt-bootstrap/etc/systemd/system/salt-bootstrap.service
@@ -22,6 +22,7 @@ Environment='SALTBOOT_PORT=7070'
 {% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
 Environment='SALTBOOT_HTTPS_PORT=7071'
 Environment='SALTBOOT_HTTPS_ENABLED=true'
+Environment='SALTBOOT_HTTPS_ONLY=true'
 Environment='SALTBOOT_HTTPS_CERT_FILE=/etc/salt-bootstrap/certs/saltboot.pem'
 Environment='SALTBOOT_HTTPS_KEY_FILE=/etc/salt-bootstrap/certs/saltboot-key.pem'
 Environment='SALTBOOT_HTTPS_CACERT_FILE=/etc/salt-bootstrap/certs/ca.pem'


### PR DESCRIPTION
## Summary

Adds `Environment='SALTBOOT_HTTPS_ONLY=true'` to the salt-bootstrap systemd unit template when HTTPS is enabled. This disables the plain HTTP listener on port 7070, so salt-bootstrap only serves encrypted traffic on port 7071.

## Dependency

Requires the salt-bootstrap side: https://github.com/hortonworks/salt-bootstrap/pull/62

## How it works

- When `SALTBOOT_HTTPS_ENABLED=true` is set (images with salt-bootstrap >= 0.14.3), the new `SALTBOOT_HTTPS_ONLY=true` flag is also set in the systemd unit.
- The salt-bootstrap binary checks both flags: `httpsEnabled && httpsOnly` — only then is the HTTP listener skipped.
- Old salt-bootstrap binaries that don't know about `SALTBOOT_HTTPS_ONLY` simply ignore the env var — no harm.
- Inter-node communication is safe in mixed clusters: the distributor's `sendRequestWithFallback()` tries HTTPS first, then falls back to HTTP if the target node doesn't support it.

## Tested

Verified on an OpenStack FreeIPA node (`perdos-os-env-sb1`):
- Before: ports 7070 (HTTP) and 7071 (HTTPS) both listening
- After: only port 7071 (HTTPS) listening, health check responds OK