### PR TITLE
CB-33241 Enforce TLS restrictions on salt-bootstrap via systemd drop-in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ ifeq ($(SALT_NEWER_PYZMQ),1)
 else
 	PYZMQ_VERSION ?= 19.0
 endif
-SALTBOOT_VERSION ?= "0.14.5"
+SALTBOOT_VERSION ?= "0.14.6"
 ifneq ($(CLOUD_PROVIDER),YARN)
 	ifneq ($(OS),centos7)
 		SALTBOOT_MINOR_VERSION = $(shell echo $(SALTBOOT_VERSION) | cut -d. -f2)

--- a/saltstack/base/salt/nginx/etc/nginx/nginx.conf
+++ b/saltstack/base/salt/nginx/etc/nginx/nginx.conf
@@ -54,7 +54,7 @@ http {
     }
 
     upstream saltboot {
-        server 127.0.0.1:7070;
+        server 127.0.0.1:7071;
     }
 
     upstream saltapi {

--- a/saltstack/base/salt/nginx/etc/nginx/ssl.conf
+++ b/saltstack/base/salt/nginx/etc/nginx/ssl.conf
@@ -53,7 +53,7 @@ server {
     }
 {% endif %}
     location /saltboot {
-        proxy_pass         http://saltboot;
+        proxy_pass         https://saltboot;
           proxy_redirect     off;
         proxy_set_header   Host $host;
         proxy_set_header   X-Forwarded-Host $server_name;

--- a/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
+++ b/saltstack/base/salt/prerequisites/usr/bin/user-data-helper.sh
@@ -92,6 +92,19 @@ signKey: |-
  -----END PUBLIC KEY-----
 EOF
   chmod 600 /etc/salt-bootstrap/security-config.yml
+
+  if [[ "$SALTBOOT_HTTPS_ONLY" == "true" || -n "$SALTBOOT_MIN_TLS_VERSION" || -n "$SALTBOOT_MAX_TLS_VERSION" || -n "$SALTBOOT_CIPHER_SUITES" || "$SALTBOOT_FIPS_ONLY" == "true" ]]; then
+    mkdir -p /etc/systemd/system/salt-bootstrap.service.d
+    {
+      echo "[Service]"
+      [[ "$SALTBOOT_HTTPS_ONLY" == "true" ]] && echo "Environment='SALTBOOT_HTTPS_ONLY=true'"
+      [[ -n "$SALTBOOT_MIN_TLS_VERSION" ]] && echo "Environment='SALTBOOT_MIN_TLS_VERSION=$SALTBOOT_MIN_TLS_VERSION'"
+      [[ -n "$SALTBOOT_MAX_TLS_VERSION" ]] && echo "Environment='SALTBOOT_MAX_TLS_VERSION=$SALTBOOT_MAX_TLS_VERSION'"
+      [[ -n "$SALTBOOT_CIPHER_SUITES" ]] && echo "Environment='SALTBOOT_CIPHER_SUITES=$SALTBOOT_CIPHER_SUITES'"
+      [[ "$SALTBOOT_FIPS_ONLY" == "true" ]] && echo "Environment='GODEBUG=fips140=only'"
+    } > /etc/systemd/system/salt-bootstrap.service.d/tls.conf
+    systemctl daemon-reload
+  fi
 }
 
 create_certificates_certm() {

--- a/saltstack/base/salt/salt-bootstrap/init.sls
+++ b/saltstack/base/salt/salt-bootstrap/init.sls
@@ -43,6 +43,19 @@ add_empty_networkcfg:
 {% endif %}
 
 
+{% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
+generate_saltbootstrap_placeholder_certs:
+  cmd.run:
+    - name: |
+        mkdir -p /etc/salt-bootstrap/certs
+        openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+          -keyout /etc/salt-bootstrap/certs/saltboot-key.pem \
+          -out /etc/salt-bootstrap/certs/saltboot.pem \
+          -days 1 -nodes -subj '/CN=saltboot-bake-placeholder'
+        cp /etc/salt-bootstrap/certs/saltboot.pem /etc/salt-bootstrap/certs/ca.pem
+    - creates: /etc/salt-bootstrap/certs/saltboot.pem
+{% endif %}
+
 salt-bootstrap:
 {% if pillar['subtype'] != 'Docker' %}
   service.running:
@@ -54,3 +67,14 @@ salt-bootstrap:
     - require:
       - install_saltbootstrap
       - create_saltbootstrap_service_files
+{% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
+      - generate_saltbootstrap_placeholder_certs
+{% endif %}
+
+{% if salt['environ.get']('SALTBOOT_HTTPS_ENABLED') == 'true' %}
+remove_placeholder_certs:
+  file.absent:
+    - name: /etc/salt-bootstrap/certs
+    - require:
+      - salt-bootstrap
+{% endif %}


### PR DESCRIPTION
## Summary

Adds boot-time TLS enforcement for salt-bootstrap port 7071, controlled by Cloudbreak via user-data environment variables. A systemd drop-in is written at boot when any TLS restriction or HTTPS-only mode is configured. Also switches nginx to always proxy to the HTTPS port (7071) since salt-bootstrap always has HTTPS enabled.

## Changes

- **Makefile**: salt-bootstrap 0.14.5 → 0.14.6 (adds `SALTBOOT_MIN_TLS_VERSION`, `SALTBOOT_MAX_TLS_VERSION`, `SALTBOOT_CIPHER_SUITES` env var support)
- **user-data-helper.sh**: Creates `/etc/systemd/system/salt-bootstrap.service.d/tls.conf` drop-in when any of the following env vars are set by Cloudbreak:
  - `SALTBOOT_HTTPS_ONLY=true` — disables HTTP listener on port 7070
  - `SALTBOOT_MIN_TLS_VERSION` — e.g. `1.3` to reject TLS 1.2
  - `SALTBOOT_MAX_TLS_VERSION` — e.g. `1.2` to reject TLS 1.3
  - `SALTBOOT_CIPHER_SUITES` — comma-separated cipher names (TLS 1.2 only; Go does not support configuring TLS 1.3 ciphers)
  - `SALTBOOT_FIPS_ONLY=true` → sets `GODEBUG=fips140=only` to block `TLS_CHACHA20_POLY1305_SHA256`
- **init.sls**: Removes placeholder certs after image validation (real certs are generated at boot by `create_cert_for_saltboot_tls`)
- **nginx.conf**: Upstream `saltboot` now points to `127.0.0.1:7071` (HTTPS port) instead of `7070` (HTTP port that is no longer listening in HTTPS-only mode)
- **ssl.conf**: `proxy_pass` for `/saltboot` changed from `http://` to `https://` to match the HTTPS upstream

## Why the nginx change

Salt-bootstrap always has HTTPS enabled (`SALTBOOT_HTTPS_ENABLED=true` in the service file). When `SALTBOOT_HTTPS_ONLY=true` is also set, port 7070 is not listening at all. Cloudbreak health-checks arrive via `9443 → nginx → upstream saltboot`, but with the old config nginx tried `http://127.0.0.1:7070` which was refused. The salt state that would fix the port (`update_saltboot_port_in_nginx_conf`) cannot run because Cloudbreak cannot reach the node to execute it — a chicken-and-egg problem. Fixing the base config eliminates this.

## Related PRs

- cloudbreak (TLS enforcement via encryption profile): https://github.infra.cloudera.com/cloudbreak/cloudbreak/pull/6434
- salt-bootstrap 0.14.6: https://github.com/hortonworks/salt-bootstrap/pull/62 (merged)