### PR TITLE
CB-32514: Generate the expected openstack image entry in imagecatalog-cli

### DIFF
--- a/packer.json
+++ b/packer.json
@@ -1128,7 +1128,8 @@
         "azure_image_publisher={{user `azure_image_publisher`}}",
         "azure_image_offer={{user `azure_image_offer`}}",
         "azure_image_sku={{user `azure_image_sku`}}",
-        "azure_image_version={{user `azure_image_version`}}"
+        "azure_image_version={{user `azure_image_version`}}",
+        "openstack_region={{user `openstack_region`}}"
       ]
     }
   ]

--- a/scripts/pp_json.sh
+++ b/scripts/pp_json.sh
@@ -84,6 +84,7 @@ cat  > ${image_name}_$metadata_filename_postfix.json <<EOF
 "mpack_urls": $(if [[ -z "$mpack_urls" ]]; then echo []; else mpackjson=$(IFS=, read -ra mpacks <<< "$mpack_urls"; for mpack in "${mpacks[@]}"; do echo "\"${mpack}\","; done); echo "[${mpackjson:0:${#mpackjson}-1}]"; fi),
 "aws_ami_regions": "${aws_ami_regions}",
 "azure_storage_accounts": "${azure_storage_accounts}",
+"openstack_region": "${openstack_region}",
 "gcp_storage_bundle": "${gcp_storage_bundle}",
 "hdp_repository_version": "${stack_repository_version}",
 "cdh_repository_version": "${stack_repository_version#*-}",


### PR DESCRIPTION
## Description

We need to generate the proper image entry format for openstack in image catalog cli, so the roper region name information should be serialized to the image metadata used by the image catalog cli. 

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [ ] Runtime image burning (per provider)
- [ ] Runtime image validation (per provider)
- [x] FreeIPA image burning (per provider)
- [ ] FreeIPA image validation (per provider)
- [x] Base image burning
- [ ] Base image validation

https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2574
https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2575
