### PR TITLE
Install jumpgate agent version 3.16 on both x86 and arm images

### DIFF
--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -57,9 +57,9 @@ packer_in_container() {
   # Jumpgate Agent
   if ! [[ $JUMPGATE_AGENT_RPM_URL =~ ^http.*rpm$ ]]; then
     if [[ "$ARCHITECTURE" == "arm64" ]]; then
-      export JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.13.0/jumpgate-agent.aarch64.rpm"
+      export JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.16.0/jumpgate-agent.aarch64.rpm"
     else
-      export JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.14.0/jumpgate-agent.rpm"
+      export JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.16.0/jumpgate-agent.rpm"
     fi
   fi
 


### PR DESCRIPTION
## Description

Install jumpgate agent ARM 3.16 on both x86 and arm images

## How Has This Been Tested?

- ~~[ ] Runtime image burning (per provider)~~
- ~~[ ] Runtime image validation (per provider)~~
- [ ] FreeIPA image burning (per provider)
  - x86 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2640/
  - arm64 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2641/
- [ ] FreeIPA image validation (per provider)
- ~~[ ] Base image burning~~
- ~~[ ] Base image validation~~
