### PR TITLE
CB-34023 Fix gov FreeIPA LUKS reopen: raise TimeoutSec and harden DNS resolution

### DIFF
--- a/saltstack/base/salt/luks/bin/reopen-luks-volume.sh
+++ b/saltstack/base/salt/luks/bin/reopen-luks-volume.sh
@@ -97,17 +97,21 @@ add_kms_entries_to_etc_hosts() {
     # Prepend the Amazon provided DNS server to the list of DNS servers
     DNS_SERVERS=("$AMAZON_PROVIDED_DNS_SERVER" "${DNS_SERVERS[@]}")
 
+{%- raw %}
     log "DNS servers available for resolving KMS endpoint: ${DNS_SERVERS[*]}"
     for dns_server in "${DNS_SERVERS[@]}"; do
-      log "Trying to resolve $KMS_ENDPOINT using DNS server $dns_server"
-      set +e
-      KMS_IP_ADDRESSES=($(temp="$(dig @"$dns_server" "$KMS_ENDPOINT" +noall +short)" && echo "$temp"))
-      set -e
-{%- raw %}
-      if (( "${#KMS_IP_ADDRESSES[@]}" > 0 )); then
-        log "Successfully resolved $KMS_ENDPOINT using DNS server $dns_server"
-        break
-      fi
+      for attempt in 1 2 3; do
+        log "Trying to resolve $KMS_ENDPOINT using DNS server $dns_server (attempt $attempt/3)"
+        set +e
+        KMS_IP_ADDRESSES=($(temp="$(dig @"$dns_server" "$KMS_ENDPOINT" +noall +short)" && echo "$temp"))
+        set -e
+        if (( "${#KMS_IP_ADDRESSES[@]}" > 0 )); then
+          log "Successfully resolved $KMS_ENDPOINT using DNS server $dns_server"
+          break 2
+        fi
+        log "Attempt $attempt failed for DNS server $dns_server"
+        (( attempt < 3 )) && sleep 5
+      done
     done
 
     if (( "${#KMS_IP_ADDRESSES[@]}" <= 0 )); then

--- a/saltstack/base/salt/luks/etc/systemd/system/cdp-reopen-luks-volume.service
+++ b/saltstack/base/salt/luks/etc/systemd/system/cdp-reopen-luks-volume.service
@@ -26,7 +26,7 @@ Type=oneshot
 ExecStart=/bin/bash -c '/etc/cdp-luks/bin/reopen-luks-volume.sh 2>&1 | tee /var/log/cdp-luks/reopen-luks-volume-$(date +"%%F-%%T").log && exit ${PIPESTATUS[0]}'
 RemainAfterExit=yes
 Restart=on-failure
-TimeoutSec=30
+TimeoutSec=300
 
 [Install]
 WantedBy=network-online.target


### PR DESCRIPTION
## Description

Please include a summary of the change and specify which issue it addresses.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2732/
- [ ] Runtime image validation (per provider)
- [x] FreeIPA image burning: https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2731/
- [ ] FreeIPA image validation (per provider)
- [ ] Base image burning
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.