### PR TITLE
CB-34039 Add proxy_ssl_protocols TLSv1.2 TLSv1.3 for upstream HTTPS backends

### DIFF
--- a/saltstack/base/salt/nginx/etc/nginx/ssl.conf
+++ b/saltstack/base/salt/nginx/etc/nginx/ssl.conf
@@ -54,6 +54,7 @@ server {
 {% endif %}
     location /saltboot {
         proxy_pass         https://saltboot;
+        proxy_ssl_protocols TLSv1.2 TLSv1.3;
           proxy_redirect     off;
         proxy_set_header   Host $host;
         proxy_set_header   X-Forwarded-Host $server_name;
@@ -61,6 +62,7 @@ server {
     }
     location ~ /saltapi/(?<section>.*) {
         proxy_pass         https://saltapi/$section$is_args$args;
+        proxy_ssl_protocols TLSv1.2 TLSv1.3;
         proxy_read_timeout 300;
         proxy_redirect     off;
         proxy_set_header   Host $host;


### PR DESCRIPTION
## Problem

Cluster deployment fails with TLS 1.3-only encryption profile (QI95 blocker).

nginx 1.20.1 (RHEL 9 package) defaults `proxy_ssl_protocols` to `TLSv1 TLSv1.1 TLSv1.2` — TLSv1.3 is not included in the default until nginx 1.25.1. When the encryption profile enforces TLS 1.3-only on salt-bootstrap (`SALTBOOT_MIN_TLS_VERSION=1.3`), the nginx → salt-bootstrap upstream TLS handshake fails:

```
salt-bootstrap: tls: client offered only unsupported versions: [303 302 301]
nginx error.log: SSL_do_handshake() failed (SSL: error:0A00042E:SSL routines::tlsv1 alert protocol version:SSL alert number 70) while SSL handshaking to upstream
```

The inbound `ssl_protocols TLSv1.2 TLSv1.3` on the listener only controls the server side. The outbound (proxy client) side uses `proxy_ssl_protocols` which was missing.

## Fix

Add `proxy_ssl_protocols TLSv1.2 TLSv1.3;` to the `/saltboot` and `/saltapi` location blocks.

## Verification

Tested on the affected instance (10.80.215.34):
- Before fix: `curl https://127.0.0.1:9443/saltboot/health` → 502 Bad Gateway
- After fix: `curl https://127.0.0.1:9443/saltboot/health` → 200 OK

Jira: https://cloudera.atlassian.net/browse/CB-34039