### PR TITLE
CB-34129 Updated cdp-infra-tools to 1.3.16 where applicable

### DIFF
--- a/saltstack/base/salt/telemetry/init.sls
+++ b/saltstack/base/salt/telemetry/init.sls
@@ -21,7 +21,7 @@ install_cdp_infra_tools_packages:
   {% if salt['environ.get']('IMAGE_BURNING_TYPE') == 'prewarm' and salt['environ.get']('STACK_VERSION').split('.') | map('int') | list <= '7.3.1'.split('.') | map('int') | list %}
       - cdp-telemetry: 1.3.10_b1
   {% else %}
-      - cdp-telemetry: 1.3.15_b2
+      - cdp-telemetry: 1.3.16_b2
   {% endif %}
 {% endif %}
 {% if salt['environ.get']('INCLUDE_FLUENT') == "Yes" %}
@@ -35,7 +35,7 @@ install_cdp_infra_tools_packages:
   {% endif %}
 {% endif %}
 {% if pillar['OS'] == 'redhat9' %}
-      - cdp-request-signer: 1.3.15_b2
+      - cdp-request-signer: 1.3.16_b2
 {% else %} # Why do we need this override? Do we still need this?
       - cdp-request-signer: 1.3.7_b2
 {% endif %}

--- a/saltstack/base/salt/telemetry/yum/cdp-infra-tools.repo.j2
+++ b/saltstack/base/salt/telemetry/yum/cdp-infra-tools.repo.j2
@@ -60,3 +60,11 @@ enabled=1
 priority=1
 gpgcheck=1
 gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.15/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+
+[cdp-infra-tools-1.3.16]
+name=CDP Infra Tools v1.3.16
+baseurl=https://archive.cloudera.com/cdp-infra-tools/1.3.16/{{ platform }}/yum/
+enabled=1
+priority=1
+gpgcheck=1
+gpgkey=https://archive.cloudera.com/cdp-infra-tools/1.3.16/{{ platform }}/yum/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins


### PR DESCRIPTION
## What

Adopt **cdp-infra-tools 1.3.16** in image builds:

- `saltstack/base/salt/telemetry/init.sls`: bump `cdp-telemetry` and (redhat9) `cdp-request-signer` from `1.3.15_b2` to `1.3.16_b2`.
- `saltstack/base/salt/telemetry/yum/cdp-infra-tools.repo.j2`: add the `[cdp-infra-tools-1.3.16]` repo stanza.

Mirrors the previous bump (CB-34070, "Updated cdp-infra-tools to 1.3.15 where applicable").

## Why

1.3.16 ships the CB-34129 fix: cdp-telemetry stops bundling a too-new libgcc that broke `cdp-doctor` on RHEL 9. Master currently pins the regressed **1.3.15**, so this also moves `cdp-request-signer` off that build. The non-RHEL9 `cdp-request-signer: 1.3.7_b2` override is intentionally left untouched, as in prior bumps.

Upstream release: RELENG-37083 (branch) / RELENG-37123 (prod release of 1.3.16-b2).

## Verification

1.3.16 is published on archive.cloudera.com. Both `cdp-telemetry` and `cdp-request-signer` resolve to `1.3.16_b2` for redhat8, redhat9, redhat8arm64 and redhat9arm64, and the `latest` link now redirects to 1.3.16. Safe to merge/build.
