### PR TITLE
CB-34206 Update jumpgate-agent version to 3.16.1

### DIFF
--- a/docker/redhat8/Dockerfile
+++ b/docker/redhat8/Dockerfile
@@ -106,7 +106,7 @@ ENV INCLUDE_FLUENT="Yes"
 ENV INCLUDE_CDP_TELEMETRY="Yes"
 ENV FREEIPA_PLUGIN_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/49070467/thunderhead/1.x/redhat8/yum/cdp-hashed-pwd-1.0-20240109061814git4230396.el8.x86_64.rpm"
 ENV FREEIPA_LDAP_AGENT_RPM_URL="https://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/49050621/thunderhead/1.x/redhat8/yum/freeipa-ldap-agent-1.0.0-b12325.x86_64.rpm"
-ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.16.0/jumpgate-agent.rpm"
+ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.16.1/jumpgate-agent.rpm"
 
 #we build logic on the existance of this directory, please DO NOT REMOVE
 RUN mkdir /yarn-private

--- a/docker/redhat9.6/Dockerfile
+++ b/docker/redhat9.6/Dockerfile
@@ -108,7 +108,7 @@ ENV INCLUDE_FLUENT="Yes"
 ENV INCLUDE_CDP_TELEMETRY="Yes"
 ENV FREEIPA_PLUGIN_RPM_URL="https://archive.cloudera.com/cdp-freeipa-artifacts/cdp-hashed-pwd-1.1-b847.el7.x86_64.rpm"
 ENV FREEIPA_LDAP_AGENT_RPM_URL="https://archive.cloudera.com/cdp-freeipa-artifacts/freeipa-ldap-agent-1.1.0.3-b525.x86_64.rpm"
-ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.16.0/jumpgate-agent.rpm"
+ENV JUMPGATE_AGENT_RPM_URL="https://archive.cloudera.com/ccm/3.16.1/jumpgate-agent.rpm"
 #we build logic on the existance of this directory, please DO NOT REMOVE
 RUN mkdir /yarn-private
 

--- a/scripts/packer.sh
+++ b/scripts/packer.sh
@@ -56,7 +56,7 @@ packer_in_container() {
 
   # Jumpgate Agent
   if ! [[ $JUMPGATE_AGENT_RPM_URL =~ ^http.*rpm$ ]]; then
-    JUMPGATE_AGENT_VERSION=3.16.0
+    JUMPGATE_AGENT_VERSION=3.16.1
     case "$ARCHITECTURE" in
       "arm64") ARCHPART=".aarch64" ;;
       *) ARCHPART="" ;;

--- a/scripts/update-jumpgate-agent.sh
+++ b/scripts/update-jumpgate-agent.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-# Example: JUMPGATE_AGENT_URL=https://archive.cloudera.com/ccm/3.16.0/jumpgate-agent.x86_64.rpm
+# Example: JUMPGATE_AGENT_URL=https://archive.cloudera.com/ccm/3.16.1/jumpgate-agent.x86_64.rpm
 : "${JUMPGATE_AGENT_URL:?}"
 
 if [[ -z $JUMPGATE_AGENT_URL ]]; then


### PR DESCRIPTION
This version contains the fix for the agent not being able to start on FIPS is enabled.

https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/2930/

Validator still fails but at least now the FreeIPA is successfully created: http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/6114/