### PR TITLE
CB-33469 Updated RHEL 9 source images to 9.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(error "AZURE_IMAGE_VHD and Marketplace image properties (AZURE_IMAGE_PUBLISHER
 		else ifeq ($(OS),redhat9)
 			AZURE_IMAGE_PUBLISHER ?= RedHat
 			AZURE_IMAGE_OFFER ?= rhel-byos
-			AZURE_IMAGE_SKU ?= rhel-lvm95
+			AZURE_IMAGE_SKU ?= rhel-lvm98
 		else ifeq ($(OS),centos7)
 			AZURE_IMAGE_PUBLISHER ?= OpenLogic
 			AZURE_IMAGE_OFFER ?= CentOS
@@ -101,6 +101,8 @@ $(error Unexpected OS type $(OS) for Azure)
 			PLAN_NAME ?= rhel-lvm95
 		else ifeq ($(OS_VERSION),9.6)
 			PLAN_NAME ?= rhel-lvm96
+		else ifeq ($(OS_VERSION),9.8)
+			PLAN_NAME ?= rhel-lvm98
 		endif
 	endif
 endif
@@ -109,10 +111,10 @@ endif
 ifeq ($(CLOUD_PROVIDER),AWS)
 	ifeq ($(OS),redhat9)
 		ifeq ($(ARCHITECTURE),arm64)
-			AWS_SOURCE_AMI ?= ami-06f1805217126b0d0
+			AWS_SOURCE_AMI ?= ami-06e87d669dc318713
 			AWS_INSTANCE_TYPE ?= r7gd.2xlarge
 		else
-			AWS_SOURCE_AMI ?= ami-08a3a46b7bf22015a
+			AWS_SOURCE_AMI ?= ami-08c9d8f6174932e4a
 			AWS_INSTANCE_TYPE ?= t3.2xlarge
 		endif
 	else ifeq ($(OS),redhat8)
@@ -174,7 +176,7 @@ ifeq ($(CLOUD_PROVIDER),GCP)
 		endif
 	endif
 	ifeq ($(OS),redhat9)
-		GCP_SOURCE_IMAGE ?= rhel-9-byos-v20250709
+		GCP_SOURCE_IMAGE ?= rhel-9-byos-v20260811
 	endif
 endif
 

--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -1,11 +1,4 @@
-# CB-30236: We need this distro upgrade, because we only have a 9.5 base image for Azure
-{% if salt['environ.get']('CLOUD_PROVIDER') == 'Azure' and pillar['OS'] == 'redhat9' %}
-distro-upgrade:
-  cmd.run:
-    - name: |
-        dnf clean all
-        dnf upgrade -y --releasever=9.6
-{% elif salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' and pillar['OS'] == 'redhat8' %}
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' and pillar['OS'] == 'redhat8' %}
 update-packages:
   cmd.run:
     - name: dnf update -y --releasever=8.8 --nobest

--- a/saltstack/base/salt/prerequisites/packages.sls
+++ b/saltstack/base/salt/prerequisites/packages.sls
@@ -1,4 +1,11 @@
-{% if salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' and pillar['OS'] == 'redhat8' %}
+# CB-30236: We need this distro upgrade, because we only have a 9.5 base image for Azure
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'Azure' and salt['environ.get']('RHEL_VERSION') == '9.6' %}
+distro-upgrade:
+  cmd.run:
+    - name: |
+        dnf clean all
+        dnf upgrade -y --releasever=9.6
+{% elif salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' and pillar['OS'] == 'redhat8' %}
 update-packages:
   cmd.run:
     - name: dnf update -y --releasever=8.8 --nobest

--- a/saltstack/base/salt/prerequisites/user_uid.sls
+++ b/saltstack/base/salt/prerequisites/user_uid.sls
@@ -1,7 +1,7 @@
 show_passwd:
   cmd.run:
     - name: |
-        echo printing passwd
+        echo Contents of /etc/passwd before remapping...
         cat /etc/passwd
 
 {% set ids = {
@@ -9,13 +9,36 @@ show_passwd:
   'cloudera_scm_group': '988',
 } %}
 
-{% if (salt['environ.get']('CLOUD_PROVIDER') == 'AWS' or salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' or salt['environ.get']('CLOUD_PROVIDER') == 'GCP') and pillar['OS'] == 'redhat9' %}
-# pesign has the needed uid/gid for cloudera-scm so it has to be modified
-change_pesign_uid:
+# OpenStack user remapping
+##########################
+
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'Openstack' and pillar['OS'] == 'redhat9' %}
+# flatpak has the needed uid for cloudera-scm so it has to be modified
+change_flatpak_uid:
   cmd.run:
     - name: |
-        usermod -u 10001 pesign
-        find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h pesign {} \;
+        usermod -u 10001 flatpak
+        find / -ignore_readdir_race -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h flatpak {} \;
+    - onlyif: id flatpak && [ "$(id -u flatpak)" -eq 992 ]
+
+# AWS/AWSGov/GCP user remapping
+###############################
+
+{% elif (salt['environ.get']('CLOUD_PROVIDER') == 'AWS' or salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' or salt['environ.get']('CLOUD_PROVIDER') == 'GCP') and pillar['OS'] == 'redhat9' %}
+remap_gid:
+  cmd.run:
+    - name: |
+        REMAPPED_GRP=$(getent group {{ ids.cloudera_scm_group }} | cut -d: -f1); groupmod -g 10001 $REMAPPED_GRP; find / -not -path "/proc/*" -group {{ ids.cloudera_scm_group }} -exec chgrp -h $REMAPPED_GRP {} \;
+    - onlyif: getent group {{ ids.cloudera_scm_group }}
+
+remap_uid:
+  cmd.run:
+    - name: |
+        REMAPPED_USER=$(cat /etc/passwd | grep {{ ids.cloudera_scm_user }}:{{ ids.cloudera_scm_user }} | cut -d: -f1); usermod -u 10001 $REMAPPED_USER; find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h $REMAPPED_USER {} \;
+    - onlyif: id {{ ids.cloudera_scm_user }}
+
+# YCLOUD user remapping
+#######################
 
 {% elif pillar['subtype'] == 'Docker' and pillar['OS'] == 'redhat9' %}
 # saslauth has the needed uid/gid for cloudera-scm so it has to be modified, YCLOUD only
@@ -24,6 +47,9 @@ change_saslauth_uid:
     - name: |
         usermod -u 10002 saslauth
         find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h saslauth {} \;
+
+# Azure user remapping
+######################
 
 {% elif salt['environ.get']('CLOUD_PROVIDER') == 'Azure' %}
 
@@ -61,24 +87,21 @@ remove_libstoragemgmt_user:
     - name: libstoragemgmt
 
 {% endif %}
-
 {% endif %}
+
+show_passwd_after_remapping:
+  cmd.run:
+    - name: |
+        echo Contents of /etc/passwd after remapping...
+        cat /etc/passwd
+
+# Cloudera SCM user / group creation
+####################################
 
 create_cloudera_scm_group:
   group.present:
     - name: cloudera-scm
     - gid: {{ ids.cloudera_scm_group }} 
-
-{% if salt['environ.get']('CLOUD_PROVIDER') == 'Openstack' and pillar['OS'] == 'redhat9' %}
-# flatpak has the needed uid for cloudera-scm so it has to be modified
-change_flatpak_uid:
-  cmd.run:
-    - name: |
-        usermod -u 10001 flatpak
-        find / -ignore_readdir_race -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h flatpak {} \;
-    - onlyif: id flatpak && [ "$(id -u flatpak)" -eq 992 ]
-
-{% endif %}
 
 create_cloudera_scm_user:
   user.present:

--- a/saltstack/base/salt/prerequisites/user_uid.sls
+++ b/saltstack/base/salt/prerequisites/user_uid.sls
@@ -1,81 +1,9 @@
-show_passwd:
-  cmd.run:
-    - name: |
-        echo Contents of /etc/passwd before remapping...
-        cat /etc/passwd
-
 {% set ids = {
   'cloudera_scm_user': '992',
   'cloudera_scm_group': '988',
 } %}
 
-# OpenStack user remapping
-##########################
-
-{% if salt['environ.get']('CLOUD_PROVIDER') == 'Openstack' and pillar['OS'] == 'redhat9' %}
-# flatpak has the needed uid for cloudera-scm so it has to be modified
-change_flatpak_uid:
-  cmd.run:
-    - name: |
-        usermod -u 10001 flatpak
-        find / -ignore_readdir_race -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h flatpak {} \;
-    - onlyif: id flatpak && [ "$(id -u flatpak)" -eq 992 ]
-
-# AWS/AWSGov/GCP user remapping
-###############################
-
-{% elif (salt['environ.get']('CLOUD_PROVIDER') == 'AWS' or salt['environ.get']('CLOUD_PROVIDER') == 'AWS_GOV' or salt['environ.get']('CLOUD_PROVIDER') == 'GCP') and pillar['OS'] == 'redhat9' %}
-remap_gid:
-  cmd.run:
-    - name: |
-        REMAPPED_GRP=$(getent group {{ ids.cloudera_scm_group }} | cut -d: -f1); groupmod -g 10001 $REMAPPED_GRP; find / -not -path "/proc/*" -group {{ ids.cloudera_scm_group }} -exec chgrp -h $REMAPPED_GRP {} \;
-    - onlyif: getent group {{ ids.cloudera_scm_group }}
-
-remap_uid:
-  cmd.run:
-    - name: |
-        REMAPPED_USER=$(cat /etc/passwd | grep {{ ids.cloudera_scm_user }}:{{ ids.cloudera_scm_user }} | cut -d: -f1); usermod -u 10001 $REMAPPED_USER; find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h $REMAPPED_USER {} \;
-    - onlyif: id {{ ids.cloudera_scm_user }}
-
-# YCLOUD user remapping
-#######################
-
-{% elif pillar['subtype'] == 'Docker' and pillar['OS'] == 'redhat9' %}
-# saslauth has the needed uid/gid for cloudera-scm so it has to be modified, YCLOUD only
-change_saslauth_uid:
-  cmd.run:
-    - name: |
-        usermod -u 10002 saslauth
-        find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h saslauth {} \;
-
-# Azure user remapping
-######################
-
-{% elif salt['environ.get']('CLOUD_PROVIDER') == 'Azure' %}
-
-{% if pillar['OS'] == 'redhat8' %}
-# sssd has the needed uid/gid for cloudera-scm so it has to be modified
-change_sssd_ids:
-  cmd.run:
-    - name: |
-        usermod -u 10001 sssd
-        groupmod -g 10001 sssd
-        find / -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h sssd {} \;
-        find / -not -path "/proc/*" -group {{ ids.cloudera_scm_group }}  -exec chgrp -h sssd {} \;
-
-{% elif pillar['OS'] == 'redhat9' %}
-
-{% set ids = {
-  'cloudera_scm_user': '991',
-  'cloudera_scm_group': '987',
-} %}
-
-# pipewire has the needed gid for cloudera-scm so it has to be modified
-change_pipewire_ids:
-  cmd.run:
-    - name: |
-        groupmod -g 10001 pipewire
-        find / -not -path "/proc/*" -group {{ ids.cloudera_scm_group }} -exec chgrp -h pipewire {} \; ; exit 0
+{% if salt['environ.get']('CLOUD_PROVIDER') == 'Azure' and pillar['OS'] == 'redhat9' %}
 
 # libstoragemgmt has the needed uid for cloudera-scm so it has to be removed
 remove_libstoragemgmt:
@@ -86,17 +14,50 @@ remove_libstoragemgmt_user:
   user.absent:
     - name: libstoragemgmt
 
-{% endif %}
-{% endif %}
+{% set ids = {
+  'cloudera_scm_user': '991',
+  'cloudera_scm_group': '987',
+} %}
+
+{% endif  %}
+
+show_passwd:
+  cmd.run:
+    - name: |
+        echo Contents of /etc/passwd before remapping...; cat /etc/passwd
+
+list_original:
+  cmd.run:
+    - name: |
+        touch /tmp/remap-original-resources.txt
+        find / -ignore_readdir_race -not -path "/proc/*" -group {{ ids.cloudera_scm_group }} -exec printf "%s\n" {} \; >>/tmp/remap-original-resources.txt
+        find / -ignore_readdir_race -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec printf "%s\n" {} \; >>/tmp/remap-original-resources.txt
+        echo Original resources with GID/UID: {{ ids.cloudera_scm_group }}/{{ ids.cloudera_scm_user }}; cat /tmp/remap-original-resources.txt | sort | uniq
+
+remap_gid:
+  cmd.run:
+    - name: |
+        REMAPPED_GRP=$(getent group {{ ids.cloudera_scm_group }} | cut -d: -f1); groupmod -g 10001 $REMAPPED_GRP; find / -ignore_readdir_race -not -path "/proc/*" -group {{ ids.cloudera_scm_group }} -exec chgrp -h $REMAPPED_GRP {} \;
+    - onlyif: getent group {{ ids.cloudera_scm_group }}
+
+remap_uid:
+  cmd.run:
+    - name: |
+        REMAPPED_USER=$(getent passwd {{ ids.cloudera_scm_user }} | cut -d: -f1); usermod -u 10001 $REMAPPED_USER; find / -ignore_readdir_race -not -path "/proc/*" -user {{ ids.cloudera_scm_user }} -exec chown -h $REMAPPED_USER {} \;
+    - onlyif: getent passwd {{ ids.cloudera_scm_user }}
 
 show_passwd_after_remapping:
   cmd.run:
     - name: |
-        echo Contents of /etc/passwd after remapping...
-        cat /etc/passwd
+        echo Contents of /etc/passwd after remapping...; cat /etc/passwd
 
-# Cloudera SCM user / group creation
-####################################
+list_updated:
+  cmd.run:
+    - name: |
+        touch /tmp/remap-remapped-resources.txt
+        find / -ignore_readdir_race -not -path "/proc/*" -group 10001 -exec printf "%s\n" {} \; >>/tmp/remap-remapped-resources.txt
+        find / -ignore_readdir_race -not -path "/proc/*" -user 10001 -exec printf "%s\n" {} \; >>/tmp/remap-remapped-resources.txt
+        echo Updated resources with new UID/GID:; cat /tmp/remap-remapped-resources.txt | sort | uniq
 
 create_cloudera_scm_group:
   group.present:

--- a/scripts/repo-setup.sh
+++ b/scripts/repo-setup.sh
@@ -12,6 +12,11 @@ function update_yum_repos() {
     RHEL_VERSION=$(cat /etc/redhat-release | grep -oP "[0-9\.]*")
     RHEL_VERSION=${RHEL_VERSION/.0/}
 
+    # CB-30236: We need this override, because we only have a 9.5 base image for Azure
+    if [[ "${CLOUD_PROVIDER}" == "Azure" && "${RHEL_VERSION}" == "9.5" ]]; then
+      RHEL_VERSION="9.6"
+    fi
+
     # For AWS Gov sadly we have an ancient RHEL 8.4 base image, so this needs an override
     if [[ "${CLOUD_PROVIDER}" == "AWS_GOV" && "${RHEL_VERSION}" == "8.4" ]]; then
       RHEL_VERSION="8.10"

--- a/scripts/repo-setup.sh
+++ b/scripts/repo-setup.sh
@@ -12,11 +12,6 @@ function update_yum_repos() {
     RHEL_VERSION=$(cat /etc/redhat-release | grep -oP "[0-9\.]*")
     RHEL_VERSION=${RHEL_VERSION/.0/}
 
-    # CB-30236: We need this override, because we only have a 9.5 base image for Azure
-    if [[ "${CLOUD_PROVIDER}" == "Azure" && "${RHEL_VERSION}" == "9.5" ]]; then
-      RHEL_VERSION="9.6"
-    fi
-
     # For AWS Gov sadly we have an ancient RHEL 8.4 base image, so this needs an override
     if [[ "${CLOUD_PROVIDER}" == "AWS_GOV" && "${RHEL_VERSION}" == "8.4" ]]; then
       RHEL_VERSION="8.10"
@@ -34,6 +29,11 @@ function update_yum_repos() {
       dnf config-manager --disable ubi-9.6-baseos-cldr
       dnf config-manager --disable ubi-9.6-appstream-cldr
       dnf config-manager --disable ubi-9.6-supplementary-cldr
+      dnf upgrade --refresh -y
+    elif [ "${RHEL_VERSION}" == "9.8" ]; then
+      dnf config-manager --disable ubi-9.8-baseos-cldr
+      dnf config-manager --disable ubi-9.8-appstream-cldr
+      dnf config-manager --disable ubi-9.8-supplementary-cldr
       dnf upgrade --refresh -y
     fi
   else


### PR DESCRIPTION
## Description

Enables using RHEL 9.8 with Runtime > 7.3.3.

**TODO**: Runtime version check is missing, right now this simply overwrites RHEL 9 source images, so DO NOT MERGE YET. Version check clarification is needed.

## How Has This Been Tested?

Describe the tests that were run, and provide Jenkins links for each completed task below:

- [x] Runtime image burning (per provider)
  - GCP RHEL 9 7.3.2 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3051/ (dies because of unrelated reasons!)
  - AWS ARM64 RHEL 8 7.3.1 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3047/
  - AWS x86 RHEL 9 7.3.2 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3045/
  - Azure RHEL 9 7.3.2 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3044/
- [x] Runtime image validation (per provider)
  - GCP n/a see above
  - AWS ARM64 RHEL 8 7.3.1 http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/6185/
  - AWS x86 RHEL 9 7.3.2 http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/6186/
  - Azure RHEL 9 7.3.2 http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/6187/
- [x] FreeIPA image burning (per provider)
  - AWS ARM64 RHEL 9 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3043/
- [x] FreeIPA image validation (per provider)
  - AWS ARM64 RHEL 9 http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-imagevalidator-v2/6184/
- [x] Base image burning
 - OpenStack RHEL 9 https://build.eng.cloudera.com/job/cloudbreak-multi-packer-image-builder-salt-v3/3042/
- [ ] Base image validation

> **Note:**  
> If any of the above tasks are not applicable to your change, include a one-line justification below each unchecked item.